### PR TITLE
Feat(TSK-13): 온보딩 화면 퍼블리싱 및 redux toolkit 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .next
+
+# etc
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@stylexjs/stylex": "^0.4.1",
         "next": "^14.0.4",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-slick": "^0.29.0"
       },
       "devDependencies": {
         "@stylexjs/babel-plugin": "^0.4.1",
@@ -3469,6 +3470,11 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3832,6 +3838,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -5373,6 +5384,14 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
+    },
     "node_modules/json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -5464,8 +5483,7 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6043,6 +6061,22 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-slick": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
+      "integrity": "sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -6150,6 +6184,11 @@
       "bin": {
         "jsesc": "bin/jsesc"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -6391,6 +6430,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next": "^14.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-slick": "^0.29.0"
+        "react-slick": "^0.29.0",
+        "slick-carousel": "^1.8.1"
       },
       "devDependencies": {
         "@stylexjs/babel-plugin": "^0.4.1",
@@ -5332,6 +5333,12 @@
         "set-function-name": "^2.0.1"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6403,6 +6410,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
       }
     },
     "node_modules/snake-case": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.1.0",
         "@stylexjs/nextjs-plugin": "^0.4.1",
         "@stylexjs/stylex": "^0.4.1",
         "next": "^14.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^9.1.0",
         "react-slick": "^0.29.0",
         "slick-carousel": "^1.8.1"
       },
@@ -2389,6 +2391,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.1.0.tgz",
+      "integrity": "sha512-nfJ/b4ZhzUevQ1ZPKjlDL6CMYxO4o7ZL7OSsvSOxzT/EN11LsBDgTqP7aedHtBrFSVoK7oTP1SbMWUwGb30NLg==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@stylexjs/babel-plugin": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@stylexjs/babel-plugin/-/babel-plugin-0.4.1.tgz",
@@ -2735,13 +2760,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.48",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
       "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2761,13 +2786,18 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.19.0",
@@ -3661,7 +3691,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4910,6 +4940,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6068,6 +6107,32 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-redux": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+      "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "react-native": ">=0.69",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-slick": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
@@ -6082,6 +6147,19 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6191,6 +6269,11 @@
       "bin": {
         "jsesc": "bin/jsesc"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -6885,6 +6968,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/utility-types": {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@reduxjs/toolkit": "^2.1.0",
     "@stylexjs/nextjs-plugin": "^0.4.1",
     "@stylexjs/stylex": "^0.4.1",
     "next": "^14.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^9.1.0",
     "react-slick": "^0.29.0",
     "slick-carousel": "^1.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "@stylexjs/stylex": "^0.4.1",
     "next": "^14.0.4",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-slick": "^0.29.0"
   },
   "devDependencies": {
     "@stylexjs/babel-plugin": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "next": "^14.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-slick": "^0.29.0"
+    "react-slick": "^0.29.0",
+    "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
     "@stylexjs/babel-plugin": "^0.4.1",

--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -1,5 +1,14 @@
+@font-face {
+  font-family: 'Pretendard';
+  src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff')
+    url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff') format('woff');
+  font-weight: 400 700;
+  font-style: normal;
+}
+
 :root {
   ---Base-White: #fff;
+  --gradient-01: linear-gradient(190deg, #384149 17.29%, #000 86.35%);
 }
 
 html {
@@ -13,11 +22,4 @@ body {
 
 button {
   cursor: pointer;
-}
-
-@font-face {
-  font-family: 'Pretendard';
-  src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-  font-weight: 400 700;
-  font-style: normal;
 }

--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -7,7 +7,7 @@
 }
 
 :root {
-  ---Base-White: #fff;
+  --Base-White: #fff;
   --gradient-01: linear-gradient(190deg, #384149 17.29%, #000 86.35%);
 }
 

--- a/src/assets/reset.css
+++ b/src/assets/reset.css
@@ -23,6 +23,7 @@ figure,
 blockquote,
 dl,
 dd {
+  margin-block-start: 0;
   margin-block-end: 0;
 }
 
@@ -34,7 +35,6 @@ ol[role='list'] {
 
 /* 핵심 body의 기본값을 설정합니다. */
 body {
-  min-height: 100vh;
   line-height: 1.5;
 }
 

--- a/src/features/authentication/assets/onboarding-slider.css
+++ b/src/features/authentication/assets/onboarding-slider.css
@@ -1,0 +1,28 @@
+/* 슬라이드의 dot 스타일 변경 코드 */
+.onboading .slick-dots {
+  top: 24px;
+}
+
+.onboading .slick-dots li {
+  position: relative;
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+  width: 10px;
+  width: 10px;
+  cursor: pointer;
+}
+
+.onboading .slick-dots li button:before {
+  padding: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  color: #6a7681;
+  opacity: 1;
+}
+
+.onboading .slick-dots li.slick-active button:before {
+  opacity: 1;
+  color: var(--Base-White);
+}

--- a/src/features/onboarding/components/OnboardingSlider/index.tsx
+++ b/src/features/onboarding/components/OnboardingSlider/index.tsx
@@ -1,0 +1,209 @@
+import React, { useRef, useState } from 'react';
+import MainLayout from '@src/layouts/MainLayout';
+import stylex from '@stylexjs/stylex';
+import { useRouter } from 'next/router';
+import Slider from 'react-slick';
+
+const OnboardingSlider = () => {
+  const router = useRouter();
+  const [dotIndex, setDotIndex] = useState<number>(0);
+  const sliderRef = useRef(null);
+  const settings = {
+    dots: false,
+    arrows: false,
+    fade: true,
+    infinite: false,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    beforeChange: (current, next) => {
+      setDotIndex(next);
+    },
+  };
+
+  const onboardingList = [
+    {
+      id: 1,
+      imgUrl: 'https://roomlet-front.s3.ap-northeast-2.amazonaws.com/public/images/onboarding/CALENDAR.png',
+      name: 'onboarding_01',
+      title: '실시간 회의실 예약',
+      description: (
+        <>
+          몇 번의 클릭 만으로
+          <br />
+          회의실을 예약하고 취소할 수 있습니다.
+          <br />
+          회의실 예약에 필요한 모든 정보를 제공합니다.
+        </>
+      ),
+    },
+    {
+      id: 2,
+      imgUrl: 'https://roomlet-front.s3.ap-northeast-2.amazonaws.com/publzic/images/onboarding/PICTURES.png',
+      name: 'onboarding_02',
+      title: '스케쥴 관리 간소화',
+      description: (
+        <>
+          중복 예약과 일정 충돌을 피하며,
+          <br />
+          프로젝트의 기한을 준수할 수 있게 도와줍니다.
+          <br />
+          더이상 복잡한 스케쥴 조율에 시간을 낭비하지 마세요!
+        </>
+      ),
+    },
+    {
+      id: 3,
+      imgUrl: 'https://roomlet-front.s3.ap-northeast-2.amazonaws.com/public/images/onboarding/CLOCK.png',
+      name: 'onboarding_03',
+      title: '효율적인 회의 관리',
+      description: (
+        <>
+          회의 진행부터 회고까지 한번에 관리할 수 있습니다.
+          <br />
+          룸렛을 이용해 회의시간을 줄이고,
+          <br />
+          {'더 효율적으로 업무에 집중해보세요! >_<//'}
+        </>
+      ),
+    },
+  ];
+
+  const handleChangeDotIndex = (idx) => {
+    setDotIndex(idx);
+  };
+
+  const handleClickSkip = () => {
+    sliderRef.current.slickGoTo(2);
+  };
+
+  const handleClickRunMeeting = () => {
+    router.push('/login');
+  };
+
+  return (
+    <div className="onboading" {...stylex.props(SliderStyles.container)}>
+      <ul {...stylex.props(SliderStyles.dotList)}>
+        {onboardingList.map((_, idx) => (
+          <li>
+            <button type="button" {...stylex.props(SliderStyles.dotButton(idx === dotIndex))} />
+          </li>
+        ))}
+      </ul>
+      <Slider {...settings} ref={sliderRef}>
+        {onboardingList.map((item, idx) => (
+          <div key={item.id}>
+            <div {...stylex.props(SliderStyles.slideContent)}>
+              <div {...stylex.props(SliderStyles.imgContent)}>
+                <img {...stylex.props(SliderStyles.img)} src={item.imgUrl} alt={item.name} />
+              </div>
+              <div {...stylex.props(SliderStyles.textContent)}>
+                <p {...stylex.props(SliderStyles.title)}>{item.title}</p>
+                <p {...stylex.props(SliderStyles.description)}>{item.description}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </Slider>
+      <div {...stylex.props(SliderStyles.buttonContent)}>
+        <button
+          {...stylex.props(SliderStyles.button)}
+          onClick={dotIndex < onboardingList.length - 1 ? handleClickSkip : handleClickRunMeeting}
+          type="button"
+        >
+          {dotIndex < onboardingList.length - 1 ? 'Skip' : '회의 진행하기'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default OnboardingSlider;
+
+const SliderStyles = stylex.create({
+  container: {
+    position: 'relative',
+  },
+  dotList: {
+    margin: 0,
+    padding: 0,
+    position: 'absolute',
+    top: '24px',
+    left: '50%',
+    transform: 'translate(-50%, 0%)',
+    display: 'flex',
+    gap: '4px',
+    listStyle: 'none',
+    zIndex: 3,
+  },
+  dotButton: (isActivate) => ({
+    width: isActivate ? '26px' : '6px',
+    height: '6px',
+    padding: 0,
+    borderRadius: isActivate ? '20px' : '50%',
+    background: isActivate ? 'var(---Base-White)' : '#6A7681',
+    border: 'none',
+  }),
+  slideContent: {
+    width: '100%',
+    height: '100vh',
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'justify-content',
+    background: 'var(--gradient-01)',
+  },
+  imgContent: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  img: {
+    maxWidth: '304px',
+    maxHeight: '304px',
+    width: '100%',
+    height: '100%',
+  },
+  textContent: {
+    width: '100%',
+    padding: '46px 35px 140px',
+    background: 'var( ---Base-White)',
+    borderRadius: '16px 16px  0 0',
+  },
+  title: {
+    marginBottom: '24px',
+    fontSize: '3.2rem',
+    fontWeight: 700,
+    lineHeight: '4rem',
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: '1.4rem',
+    lineHeight: '2rem',
+    fontWeight: 400,
+    textAlign: 'center',
+  },
+  buttonContent: {
+    position: 'absolute',
+    left: '50%',
+    transform: 'translate(-50%, 0%)',
+    bottom: '48px',
+    display: 'flex',
+    justifyContent: 'center',
+    zIndex: 2,
+  },
+  button: {
+    marginTop: '54px',
+    padding: '12px 44px',
+    background: '#4A4A4A',
+    color: 'var(---Base-White)',
+    fontSize: '1.4rem',
+    lineHeight: '2rem',
+    fontWeight: 500,
+    textAlign: 'center',
+    border: 'none',
+    borderRadius: '20px',
+  },
+});

--- a/src/features/onboarding/components/OnboardingSlider/index.tsx
+++ b/src/features/onboarding/components/OnboardingSlider/index.tsx
@@ -39,7 +39,7 @@ const OnboardingSlider = () => {
     },
     {
       id: 2,
-      imgUrl: 'https://roomlet-front.s3.ap-northeast-2.amazonaws.com/publzic/images/onboarding/PICTURES.png',
+      imgUrl: 'https://roomlet-front.s3.ap-northeast-2.amazonaws.com/public/images/onboarding/PICTURES.png',
       name: 'onboarding_02',
       title: '스케쥴 관리 간소화',
       description: (

--- a/src/features/onboarding/components/OnboardingSlider/index.tsx
+++ b/src/features/onboarding/components/OnboardingSlider/index.tsx
@@ -1,13 +1,15 @@
 import React, { useRef, useState } from 'react';
-import MainLayout from '@src/layouts/MainLayout';
 import stylex from '@stylexjs/stylex';
 import { useRouter } from 'next/router';
 import Slider from 'react-slick';
+import { useDispatch } from 'react-redux';
+import { changeHiddenStatus } from '../../slices/onboarding';
 
 const OnboardingSlider = () => {
   const router = useRouter();
   const [dotIndex, setDotIndex] = useState<number>(0);
   const sliderRef = useRef(null);
+  const dispatch = useDispatch();
   const settings = {
     dots: false,
     arrows: false,
@@ -78,6 +80,7 @@ const OnboardingSlider = () => {
   };
 
   const handleClickRunMeeting = () => {
+    dispatch(changeHiddenStatus());
     router.push('/login');
   };
 

--- a/src/features/onboarding/components/OnboardingSlider/index.tsx
+++ b/src/features/onboarding/components/OnboardingSlider/index.tsx
@@ -141,7 +141,7 @@ const SliderStyles = stylex.create({
     height: '6px',
     padding: 0,
     borderRadius: isActivate ? '20px' : '50%',
-    background: isActivate ? 'var(---Base-White)' : '#6A7681',
+    background: isActivate ? 'var(--Base-White)' : '#6A7681',
     border: 'none',
   }),
   slideContent: {
@@ -169,7 +169,7 @@ const SliderStyles = stylex.create({
   textContent: {
     width: '100%',
     padding: '46px 35px 140px',
-    background: 'var( ---Base-White)',
+    background: 'var( --Base-White)',
     borderRadius: '16px 16px  0 0',
   },
   title: {
@@ -198,7 +198,7 @@ const SliderStyles = stylex.create({
     marginTop: '54px',
     padding: '12px 44px',
     background: '#4A4A4A',
-    color: 'var(---Base-White)',
+    color: 'var(--Base-White)',
     fontSize: '1.4rem',
     lineHeight: '2rem',
     fontWeight: 500,

--- a/src/features/onboarding/slices/onboarding.ts
+++ b/src/features/onboarding/slices/onboarding.ts
@@ -1,11 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 export interface OnboardingState {
-  isHidden: boolean;
+  isOnboardingHidden: boolean;
 }
 
 const initialState: OnboardingState = {
-  isHidden: false,
+  isOnboardingHidden: false,
 };
 
 export const onboardingSlice = createSlice({
@@ -13,7 +13,7 @@ export const onboardingSlice = createSlice({
   initialState,
   reducers: {
     changeHiddenStatus: (state) => {
-      state.isHidden = !state.isHidden;
+      state.isOnboardingHidden = !state.isOnboardingHidden;
     },
   },
 });

--- a/src/features/onboarding/slices/onboarding.ts
+++ b/src/features/onboarding/slices/onboarding.ts
@@ -1,0 +1,24 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export interface OnboardingState {
+  isHidden: boolean;
+}
+
+const initialState: OnboardingState = {
+  isHidden: false,
+};
+
+export const onboardingSlice = createSlice({
+  name: 'onboarding',
+  initialState,
+  reducers: {
+    changeHiddenStatus: (state) => {
+      state.isHidden = !state.isHidden;
+    },
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const { changeHiddenStatus } = onboardingSlice.actions;
+
+export default onboardingSlice.reducer;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -17,7 +17,6 @@ const Styles = stylex.create({
   container: {
     width: '100%',
     margin: '0 auto',
-    padding: '16px',
     maxWidth: '767px',
   },
 });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,9 @@
 import type { AppProps } from 'next/app';
 import '@assets/global.css';
 import '@assets/reset.css';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+import '../features/authentication/assets/onboarding-slider.css';
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,6 @@
 import type { AppProps } from 'next/app';
+import { Provider } from 'react-redux';
+import { store } from '../store';
 import '@assets/global.css';
 import '@assets/reset.css';
 import 'slick-carousel/slick/slick.css';
@@ -6,5 +8,9 @@ import 'slick-carousel/slick/slick-theme.css';
 import '../features/authentication/assets/onboarding-slider.css';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <Provider store={store}>
+      <Component {...pageProps} />
+    </Provider>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  base: {
+    fontSize: 16,
+    lineHeight: 1.5,
+    color: 'red',
+  },
+  highlighted: {
+    color: 'rebeccapurple',
+  },
+});
+
+const Home = () => {
+  console.log('');
+
+  return <div {...stylex.props(styles.base)}>Hello, Next.js</div>;
+};
+
+export default Home;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import stylex from '@stylexjs/stylex';
-import RoomletLogo from '@asset/logo_roomlet.svg';
-import RoomletTextLogo from '@asset/logo_text_roomlet.svg';
+import RoomletLogo from '@assets/logo_roomlet.svg';
+import RoomletTextLogo from '@assets/logo_text_roomlet.svg';
 import GoogleLogo from '@features/authentication/assets/google_logo.svg';
 import MainLayout from '@src/layouts/MainLayout';
 
@@ -54,6 +54,7 @@ const LogoStyles = stylex.create({
 const SnsLoginStyles = stylex.create({
   content: {
     width: '100%',
+    padding: '0 16px',
     marginBottom: '24px',
   },
   button: {
@@ -74,6 +75,7 @@ const SnsLoginStyles = stylex.create({
 
 const TermsStyles = stylex.create({
   text: {
+    padding: '0 16px',
     color: '#A6A6A6',
     textAlign: 'center',
     fontSize: '1.2rem',

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,38 +1,51 @@
 import React from 'react';
 import stylex from '@stylexjs/stylex';
+import { useSelector } from 'react-redux';
+import { RootState } from '@src/store';
 import RoomletLogo from '@assets/logo_roomlet.svg';
 import RoomletTextLogo from '@assets/logo_text_roomlet.svg';
 import GoogleLogo from '@features/authentication/assets/google_logo.svg';
 import MainLayout from '@src/layouts/MainLayout';
+import OnboardingSlider from '@src/features/onboarding/components/OnboardingSlider';
 
 const Login = () => {
   const snsLoginList = [{ id: 1, logo: <GoogleLogo />, name: 'Google' }];
+  const { isOnboardingHidden } = useSelector((state: RootState) => state.onboarding);
 
   return (
     <MainLayout>
-      <div {...stylex.props(LogoStyles.content)}>
-        <RoomletLogo />
-        <RoomletTextLogo />
-      </div>
-      <div {...stylex.props(SnsLoginStyles.content)}>
-        {snsLoginList.map((item) => (
-          <button type="button" key={item.id} {...stylex.props(SnsLoginStyles.button)}>
-            <span>{item.logo}</span>
-            <span>{item.name}&nbsp;계정으로 시작하기</span>
-          </button>
-        ))}
-      </div>
-      <p {...stylex.props(TermsStyles.text)}>
-        시작하기를 누르는 것으로 계정 연동에 대한{' '}
-        <a {...stylex.props(TermsStyles.link)} href="/">
-          이용약관
-        </a>
-        과{' '}
-        <a {...stylex.props(TermsStyles.link)} href="/">
-          개인정보 처리방침
-        </a>
-        에 동의하고 서비스를 이용합니다.
-      </p>
+      {/* 로그인 페이지를 새로 고침할 때마다 온보딩 화면이 보임 */}
+      {isOnboardingHidden ? (
+        <>
+          {/* 온보딩이 히든 상태이면 SNS 로그인 화면이 보임 */}
+          <div {...stylex.props(LogoStyles.content)}>
+            <RoomletLogo />
+            <RoomletTextLogo />
+          </div>
+          <div {...stylex.props(SnsLoginStyles.content)}>
+            {snsLoginList.map((item) => (
+              <button type="button" key={item.id} {...stylex.props(SnsLoginStyles.button)}>
+                <span>{item.logo}</span>
+                <span>{item.name}&nbsp;계정으로 시작하기</span>
+              </button>
+            ))}
+          </div>
+          <p {...stylex.props(TermsStyles.text)}>
+            시작하기를 누르는 것으로 계정 연동에 대한{' '}
+            <a {...stylex.props(TermsStyles.link)} href="/">
+              이용약관
+            </a>
+            과{' '}
+            <a {...stylex.props(TermsStyles.link)} href="/">
+              개인정보 처리방침
+            </a>
+            에 동의하고 서비스를 이용합니다.
+          </p>
+        </>
+      ) : (
+        // 온보딩 보기
+        <OnboardingSlider />
+      )}
     </MainLayout>
   );
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import onboardingReducer from '@features/onboarding/slices/onboarding';
+
+export const store = configureStore({
+  reducer: {
+    onboarding: onboardingReducer,
+  },
+});
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>;
+// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
# 작업 목록
- react-slick을 사용하여 온보딩 화면 구현
   - 손으로 옆으로 swipe했을 때 fade처리 되면서 다음 장으로 넘어가야했는데 이 기능을 react-slick을 사용하여 구현함.
- 로그인 페이지에 온보딩 화면 구현
- 온보딩 화면에서 '회의 참여하기'버튼을 눌렀을 때 온보딩 화면이 보여지지 않고 로그인 화면이 보여져야 했는데, 이 때 버튼을 클릭했을 때 변화하는 state관리는 redux-toolkit을 설치하여 온보딩 히든 여부를 관리하는 state를 관리할 수 있게 함.
   - redux toolkit을 사용한 이유는 redux를 실무에서 사용해본 적이 있는데 사용성에는 큰 어려움이 없었으나 매 액션마다 ...state를 고려하며 추가해주는 작업도 번거로웠고, 보일러 플레이트 형식의 코드가 전체적인 개발 업무 생산성을 떨어뜨린다는 생각을 지울 수가 없었음. 그런데 redux toolkit에서는 그러한 단점들을 보완했다고 하여 직접 경험해보기 위해 사용하게 됨.