### PR TITLE
Feat(TSK-22): GNB 레이아웃 퍼블리싱

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -9,6 +9,8 @@
 :root {
   --Base-White: #fff;
   --gradient-01: linear-gradient(190deg, #384149 17.29%, #000 86.35%);
+  --Blue-900: #242c33;
+  --Gray-10: #a7abad;
 }
 
 html {

--- a/src/assets/reset.css
+++ b/src/assets/reset.css
@@ -87,3 +87,9 @@ textarea:not([rows]) {
 :target {
   scroll-margin-block: 5ex;
 }
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}

--- a/src/components/icons/CalendarOutlined.tsx
+++ b/src/components/icons/CalendarOutlined.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+const CalendarOutlined = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg width={width} height={height} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M3 10h18M8 6V2m8 4V2M9.4 22h5.2c2.24 0 3.36 0 4.216-.436a4 4 0 001.748-1.748C21 18.96 21 17.84 21 15.6v-5.2c0-2.24 0-3.36-.436-4.216a4 4 0 00-1.748-1.748C17.96 4 16.84 4 14.6 4H9.4c-2.24 0-3.36 0-4.216.436a4 4 0 00-1.748 1.748C3 7.04 3 8.16 3 10.4v5.2c0 2.24 0 3.36.436 4.216a4 4 0 001.748 1.748C6.04 22 7.16 22 9.4 22z"
+        stroke="#A7ABAD"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};
+
+export default CalendarOutlined;

--- a/src/components/icons/CalendarTwoTone.tsx
+++ b/src/components/icons/CalendarTwoTone.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import type { IconProps } from './types';
+
+const CalendarTwoTone: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg width={width} height={height} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M3 10.4c0-2.24 0-3.36.436-4.216a4 4 0 011.748-1.748C6.04 4 7.16 4 9.4 4h5.2c2.24 0 3.36 0 4.216.436a4 4 0 011.748 1.748C21 7.04 21 8.16 21 10.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 01-1.748 1.748C17.96 22 16.84 22 14.6 22H9.4c-2.24 0-3.36 0-4.216-.436a4 4 0 01-1.748-1.748C3 18.96 3 17.84 3 15.6v-5.2z"
+        fill="#C7CDDF"
+      />
+      <path
+        d="M3 10h18M8 6V2m8 4V2M9.4 22h5.2c2.24 0 3.36 0 4.216-.436a4 4 0 001.748-1.748C21 18.96 21 17.84 21 15.6v-5.2c0-2.24 0-3.36-.436-4.216a4 4 0 00-1.748-1.748C17.96 4 16.84 4 14.6 4H9.4c-2.24 0-3.36 0-4.216.436a4 4 0 00-1.748 1.748C3 7.04 3 8.16 3 10.4v5.2c0 2.24 0 3.36.436 4.216a4 4 0 001.748 1.748C6.04 22 7.16 22 9.4 22z"
+        stroke="#242C33"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};
+
+export default CalendarTwoTone;

--- a/src/components/icons/HomeOutlined.tsx
+++ b/src/components/icons/HomeOutlined.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from 'react';
+import type { IconProps } from './types';
+
+const HomeOutlined: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg width={width} height={height} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <g
+        clipPath="url(#prefix__clip0_1420_2649)"
+        stroke="#A7ABAD"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M19.841 8.294l-6-4.663a3 3 0 00-3.683 0l-6 4.663A2.996 2.996 0 003 10.659v8.093A2.247 2.247 0 005.25 21h13.5A2.251 2.251 0 0021 18.752V10.66c0-.925-.427-1.799-1.159-2.366zM16 15c-2.21 1.333-5.792 1.333-8 0" />
+      </g>
+      <defs>
+        <clipPath id="prefix__clip0_1420_2649">
+          <path fill="#fff" d="M0 0h24v24H0z" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+
+export default HomeOutlined;

--- a/src/components/icons/HomeTwoTone.tsx
+++ b/src/components/icons/HomeTwoTone.tsx
@@ -1,0 +1,31 @@
+import React, { FC } from 'react';
+import type { IconProps } from './types';
+
+const HomeTwoTone: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg width={width} height={height} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <g
+        clipPath="url(#prefix__clip0_1420_3318)"
+        stroke="#242C33"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path
+          d="M19.841 8.294l-6-4.663a3 3 0 00-3.683 0l-6 4.663A2.996 2.996 0 003 10.659v8.093A2.247 2.247 0 005.25 21h13.5A2.251 2.251 0 0021 18.752V10.66c0-.925-.427-1.799-1.159-2.366z"
+          fill="#C7CDDF"
+        />
+        <path d="M16 15c-2.21 1.333-5.792 1.333-8 0" />
+      </g>
+      <defs>
+        <clipPath id="prefix__clip0_1420_3318">
+          <path fill="#fff" d="M0 0h24v24H0z" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+
+export default HomeTwoTone;

--- a/src/components/icons/ListOutlined.tsx
+++ b/src/components/icons/ListOutlined.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+import type { IconProps } from './types';
+
+const ListOutlined: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg width={width} height={height} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        clipRule="evenodd"
+        d="M8.244 2h7.361c.077 0 .153.005.228.015a5.733 5.733 0 015.334 5.7v8.572A5.733 5.733 0 0115.423 22H8.244A5.733 5.733 0 012.5 16.285v-8.57A5.733 5.733 0 018.244 2z"
+        stroke="#A7ABAD"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M21.167 8.714a1 1 0 000-2v2zm-5.334-1h-1a1 1 0 001 1v-1zm1-5.7a1 1 0 10-2 0h2zM10.5 17.666a1 1 0 100-2v2zm-4-2a1 1 0 100 2v-2zm9.333-2a1 1 0 100-2v2zm-9.333-2a1 1 0 100 2v-2zm14.667-4.952h-5.334v2h5.334v-2zm-4.334 1v-5.7h-2v5.7h2zM10.5 15.666h-4v2h4v-2zm5.333-4H6.5v2h9.333v-2z"
+        fill="#A7ABAD"
+      />
+    </svg>
+  );
+};
+
+export default ListOutlined;

--- a/src/components/icons/ListTwoTone.tsx
+++ b/src/components/icons/ListTwoTone.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from 'react';
+import type { IconProps } from './types';
+
+const ListTwoTone: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg width={width} height={height} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8.244 2h7.361c.077 0 .153.005.228.015a5.733 5.733 0 015.334 5.7v8.572A5.733 5.733 0 0115.423 22H8.244A5.733 5.733 0 012.5 16.285v-8.57A5.733 5.733 0 018.244 2z"
+        fill="#C7CDDF"
+        stroke="#242C33"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M21.167 7.714h-5.334v-5.7M10.5 16.666h-4 4zm5.333-4H6.5h9.333z"
+        fill="#C7CDDF"
+      />
+      <path
+        d="M21.167 8.714a1 1 0 000-2v2zm-5.334-1h-1a1 1 0 001 1v-1zm1-5.7a1 1 0 10-2 0h2zM10.5 17.666a1 1 0 100-2v2zm-4-2a1 1 0 100 2v-2zm9.333-2a1 1 0 100-2v2zm-9.333-2a1 1 0 100 2v-2zm14.667-4.952h-5.334v2h5.334v-2zm-4.334 1v-5.7h-2v5.7h2zM10.5 15.666h-4v2h4v-2zm5.333-4H6.5v2h9.333v-2z"
+        fill="#242C33"
+      />
+    </svg>
+  );
+};
+
+export default ListTwoTone;

--- a/src/components/icons/MypageOutlined.tsx
+++ b/src/components/icons/MypageOutlined.tsx
@@ -1,0 +1,30 @@
+import React, { FC } from 'react';
+import type { IconProps } from './types';
+
+const MypageOutlined = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg width={width} height={height} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M12.25 21.75a9.5 9.5 0 100-19 9.5 9.5 0 000 19z"
+        stroke="#A7ABAD"
+        strokeWidth={2}
+        strokeMiterlimit={10}
+      />
+      <path
+        d="M7.26 13.64a1.21 1.21 0 100-2.42 1.21 1.21 0 000 2.42zM17.24 13.64a1.21 1.21 0 100-2.42 1.21 1.21 0 000 2.42z"
+        fill="#A7ABAD"
+      />
+      <path
+        d="M13.61 14.84h-2.24a.46.46 0 01-.44-.59l1.5-5.06"
+        stroke="#A7ABAD"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default MypageOutlined;

--- a/src/components/icons/types/index.ts
+++ b/src/components/icons/types/index.ts
@@ -1,0 +1,6 @@
+type IconProps = {
+  width: number;
+  height: number;
+};
+
+export type { IconProps };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,1 @@
+export { default as s3ImgUrlConfig } from './s3ImgUrlConfig';

--- a/src/config/s3ImgUrlConfig.ts
+++ b/src/config/s3ImgUrlConfig.ts
@@ -1,0 +1,6 @@
+// 어떤 컴포넌트에서든 공통으로 사용할 s3 이미지 url 관리
+const s3ImgUrlConfig = {
+  defaultProfile: 'https://roomlet-front.s3.ap-northeast-2.amazonaws.com/public/images/profile/default.png',
+};
+
+export default s3ImgUrlConfig;

--- a/src/layouts/GnbNavLayout.tsx
+++ b/src/layouts/GnbNavLayout.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { useRouter } from 'next/router';
 import stylex from '@stylexjs/stylex';
 import MainLayout from './MainLayout';
 import HomeTwoTone from '@src/components/icons/HomeTwoTone';
@@ -22,8 +23,8 @@ type MenuListType = {
 }[];
 
 const GnbNavLayout: FC<GnbNavLayoutProps> = (props) => {
+  const router = useRouter();
   const { children } = props;
-  const isActive = false; // [ ] isActive에 대한 코드 작성하기
   const menuList: MenuListType = [
     {
       id: 1,
@@ -37,21 +38,21 @@ const GnbNavLayout: FC<GnbNavLayoutProps> = (props) => {
       name: '캘린더',
       onIcon: <CalendarTwoTone width={24} height={24} />,
       offIcon: <CalendarOutlined width={24} height={24} />,
-      href: '/',
+      href: '/calender',
     },
     {
       id: 1,
       name: '예약리스트',
       onIcon: <ListTwoTone width={24} height={24} />,
       offIcon: <ListOutlined width={24} height={24} />,
-      href: '/',
+      href: '/reservations',
     },
     {
       id: 1,
       name: '마이페이지',
       onIcon: '',
       offIcon: <MypageOutlined width={24} height={24} />,
-      href: '/',
+      href: '/mypage',
     },
   ];
 
@@ -60,12 +61,16 @@ const GnbNavLayout: FC<GnbNavLayoutProps> = (props) => {
       <main {...stylex.props(Styles.wrapper)}>{children}</main>
       <div {...stylex.props(Styles.gnbNavContent)}>
         <ul {...stylex.props(Styles.gnbNavList)}>
-          {menuList.map((item) => (
-            <li key={item.id} {...stylex.props(Styles.gnbNavItem)}>
-              {isActive ? item.onIcon : item.offIcon}
-              <span>{item.name}</span>
-            </li>
-          ))}
+          {menuList.map((item) => {
+            const isActive = router.asPath === item.href || router.asPath.indexOf(item.href) > -1;
+
+            return (
+              <li key={item.id} {...stylex.props(Styles.gnbNavItem, isActive && Styles.gnbNavItemActive)}>
+                {isActive ? item.onIcon : item.offIcon}
+                <span>{item.name}</span>
+              </li>
+            );
+          })}
         </ul>
       </div>
     </MainLayout>
@@ -103,6 +108,11 @@ const Styles = stylex.create({
     fontSize: '12px',
     fontWeight: '500',
     lineHeight: '1',
+    color: `var(--Gray-10)`,
     flexShrink: 0,
+  },
+  gnbNavItemActive: {
+    fontWeight: '500',
+    color: `var(--Blue-900)`,
   },
 });

--- a/src/layouts/GnbNavLayout.tsx
+++ b/src/layouts/GnbNavLayout.tsx
@@ -1,0 +1,108 @@
+import React, { FC } from 'react';
+import stylex from '@stylexjs/stylex';
+import MainLayout from './MainLayout';
+import HomeTwoTone from '@src/components/icons/HomeTwoTone';
+import CalendarTwoTone from '@src/components/icons/CalendarTwoTone';
+import CalendarOutlined from '@src/components/icons/CalendarOutlined';
+import HomeOutlined from '@src/components/icons/HomeOutlined';
+import ListOutlined from '@src/components/icons/ListOutlined';
+import ListTwoTone from '@src/components/icons/ListTwoTone';
+import MypageOutlined from '@src/components/icons/MypageOutlined';
+
+type GnbNavLayoutProps = {
+  children: React.ReactElement | React.ReactElement[] | string;
+};
+
+type MenuListType = {
+  id: number;
+  name: string;
+  onIcon: React.ReactElement | React.ReactElement[] | string;
+  offIcon: React.ReactElement | React.ReactElement[] | string;
+  href: string;
+}[];
+
+const GnbNavLayout: FC<GnbNavLayoutProps> = (props) => {
+  const { children } = props;
+  const isActive = false; // [ ] isActive에 대한 코드 작성하기
+  const menuList: MenuListType = [
+    {
+      id: 1,
+      name: '홈',
+      onIcon: <HomeTwoTone width={24} height={24} />,
+      offIcon: <HomeOutlined width={24} height={24} />,
+      href: '/',
+    },
+    {
+      id: 1,
+      name: '캘린더',
+      onIcon: <CalendarTwoTone width={24} height={24} />,
+      offIcon: <CalendarOutlined width={24} height={24} />,
+      href: '/',
+    },
+    {
+      id: 1,
+      name: '예약리스트',
+      onIcon: <ListTwoTone width={24} height={24} />,
+      offIcon: <ListOutlined width={24} height={24} />,
+      href: '/',
+    },
+    {
+      id: 1,
+      name: '마이페이지',
+      onIcon: '',
+      offIcon: <MypageOutlined width={24} height={24} />,
+      href: '/',
+    },
+  ];
+
+  return (
+    <MainLayout>
+      <main {...stylex.props(Styles.wrapper)}>{children}</main>
+      <div {...stylex.props(Styles.gnbNavContent)}>
+        <ul {...stylex.props(Styles.gnbNavList)}>
+          {menuList.map((item) => (
+            <li key={item.id} {...stylex.props(Styles.gnbNavItem)}>
+              {isActive ? item.onIcon : item.offIcon}
+              <span>{item.name}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </MainLayout>
+  );
+};
+
+export default GnbNavLayout;
+
+const Styles = stylex.create({
+  wrapper: {
+    paddingBottom: '90px',
+  },
+  gnbNavContent: {
+    width: '100%',
+    maxWidth: '767px',
+    padding: '16px 0',
+    position: 'fixed',
+    bottom: 0,
+    borderTop: '1px solid #E2E2E2',
+    borderRadius: '16px 16px 0 0',
+    background: 'var(--Base-White)',
+  },
+  gnbNavList: {
+    display: 'flex',
+    gap: '8px',
+    justifyContent: 'space-between',
+  },
+  gnbNavItem: {
+    padding: '0 11px',
+    display: 'flex',
+    gap: '8px',
+    flex: 1,
+    flexDirection: 'column',
+    alignItems: 'center',
+    fontSize: '12px',
+    fontWeight: '500',
+    lineHeight: '1',
+    flexShrink: 0,
+  },
+});

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import stylex from '@stylexjs/stylex';
+import GnbNavLayout from '@src/layouts/GnbNavLayout';
 
 const styles = stylex.create({
   base: {
@@ -15,7 +16,11 @@ const styles = stylex.create({
 const Home = () => {
   console.log('');
 
-  return <div {...stylex.props(styles.base)}>Hello, Next.js</div>;
+  return (
+    <GnbNavLayout>
+      <div {...stylex.props(styles.base)}>Hello, Next.js</div>
+    </GnbNavLayout>
+  );
 };
 
 export default Home;


### PR DESCRIPTION
# 작업 내용
- 홈 화면을 구성하기 전에 하단 네비게이션바 형태의 GNB 퍼블리싱
- GNB를 구성하는 SVG 아이콘 컴포넌트 생성
   - SVG 아이콘 컴포넌트 내에서 Props를 통해 색상을 유동적으로 변경할 수 있게 하는 작업들이 사실은 자동 svg 생성 스크립트를 만들어서 사용하지 않는 한, 경험상 수작업으로 일일히 바꿔주면 생산성을 굉장히 떨어뜨리게 하는 작업이라고 생각해왔음.
   - 그래서 이번에는 UI 라이브러리들을 참고하여 TwoTone, Outlined, Filled, Rounded로 아이콘들을 각각 생성해서 사용하기로 했음.
      참고: https://mui.com/material-ui/material-icons/
   - SVG를 JSX 형식으로 변경하는데 직접 svg 코드를 긁어와서 사용하는 것은 비효율적이라고 생각해서, 피그마의 **SVG to JSX**플러그인을 사용해서 바로 변환하여 사용할 수 있게 함.