### PR TITLE
Feat(TSK-22): 홈 화면에서 타임라인 영역 퍼블리싱

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -1,9 +1,10 @@
 @font-face {
   font-family: 'Pretendard';
   src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff')
+    url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff') format('woff')
     url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff') format('woff')
     url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff') format('woff');
-  font-weight: 400 600 700;
+  font-weight: 400 500 600 700;
   font-style: normal;
 }
 
@@ -11,6 +12,7 @@
   --Base-White: #fff;
   --gradient-01: linear-gradient(190deg, #384149 17.29%, #000 86.35%);
   --Red-600: #d14444;
+  --Blue-300: #087bff;
   --Blue-900: #242c33;
   --Gray-10: #a7abad;
 }

--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import stylex from '@stylexjs/stylex';
+
+/**
+ * 홈 화면의 타임라인을 나타내는 컴포넌트
+ */
+const TimeLine = () => {
+  return (
+    <div {...stylex.props(Styles.container)}>
+      <div {...stylex.props(Styles.timeAndMeetingDivider)} />
+      <div {...stylex.props(Styles.timeAndMeetingContent)}>
+        <div {...stylex.props(Styles.timeContent)}>
+          <span {...stylex.props(Styles.timeText)}>09:00</span>
+          <div {...stylex.props(Styles.timeDot)} />
+        </div>
+        <div {...stylex.props(Styles.meetingContent)}>
+          <div {...stylex.props(Styles.detailContent)}>
+            <p {...stylex.props(Styles.titleText)}>룸렛 회의</p>
+            <div {...stylex.props(Styles.categoryTag)}>기획</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TimeLine;
+
+const Styles = stylex.create({
+  container: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '24px',
+    backgroundColor: '#FAFAFA',
+    paddingTop: '30px',
+    position: 'relative',
+    borderTop: '1px solid #F2F2F2',
+  },
+  timeAndMeetingDivider: {
+    position: 'absolute',
+    top: 0,
+    left: '67px',
+    height: '100%',
+    borderRight: '1px solid #E2E2E2',
+  },
+  timeAndMeetingContent: {
+    padding: '0 16px',
+    display: 'flex',
+    gap: '12px',
+    alignItems: 'flex-start',
+  },
+  timeContent: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  timeText: {
+    paddingRight: '9px',
+    fontSize: '1.4rem',
+    fontWeight: '400',
+    lineHeight: '1.8rem',
+    color: '#999999',
+    textAlign: 'right',
+  },
+  timeDot: {
+    zIndex: 1,
+    width: '8px',
+    height: '8px',
+    display: 'inline-block',
+    backgroundColor: '#444444',
+    borderRadius: '50%',
+  },
+  meetingContent: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '14px',
+  },
+  detailContent: {
+    padding: '16px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    backgroundColor: 'var(--Base-White)',
+    borderLeft: '2px solid var(--Blue-300)',
+    borderRadius: '0 16px 16px 0',
+  },
+  titleText: {
+    fontSize: '1.4rem',
+    fontWeight: 700,
+    lineHeight: '2rem',
+    color: '#61686D',
+  },
+  categoryTag: {
+    padding: '4px 8px',
+    backgroundColor: 'var(--Blue-300)',
+    borderRadius: '20px',
+    fontSize: '1.2rem',
+    fontWeight: 500,
+    lineHeight: '100%',
+    color: 'var(--Base-White)',
+  },
+});

--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -8,15 +8,17 @@ const TimeLine = () => {
   return (
     <div {...stylex.props(Styles.container)}>
       <div {...stylex.props(Styles.timeAndMeetingDivider)} />
-      <div {...stylex.props(Styles.timeAndMeetingContent)}>
-        <div {...stylex.props(Styles.timeContent)}>
-          <span {...stylex.props(Styles.timeText)}>09:00</span>
-          <div {...stylex.props(Styles.timeDot)} />
-        </div>
-        <div {...stylex.props(Styles.meetingContent)}>
-          <div {...stylex.props(Styles.detailContent)}>
-            <p {...stylex.props(Styles.titleText)}>룸렛 회의</p>
-            <div {...stylex.props(Styles.categoryTag)}>기획</div>
+      <div {...stylex.props(Styles.scrollContainer)}>
+        <div {...stylex.props(Styles.timeAndMeetingContent)}>
+          <div {...stylex.props(Styles.timeContent)}>
+            <span {...stylex.props(Styles.timeText)}>09:00</span>
+            <div {...stylex.props(Styles.timeDot)} />
+          </div>
+          <div {...stylex.props(Styles.meetingContent)}>
+            <div {...stylex.props(Styles.detailContent)}>
+              <p {...stylex.props(Styles.titleText)}>룸렛 회의</p>
+              <div {...stylex.props(Styles.categoryTag)}>기획</div>
+            </div>
           </div>
         </div>
       </div>
@@ -37,6 +39,16 @@ const Styles = stylex.create({
     paddingTop: '30px',
     position: 'relative',
     borderTop: '1px solid #F2F2F2',
+  },
+  scrollContainer: {
+    width: '100%',
+    height: 'calc(100vh - 374px)',
+    paddingTop: '30px',
+    paddingBottom: '70px',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    overflowY: 'auto',
   },
   timeAndMeetingDivider: {
     position: 'absolute',

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -19,5 +19,6 @@ const Styles = stylex.create({
     height: '100%',
     margin: '0 auto',
     maxWidth: '767px',
+    overflowY: 'hidden',
   },
 });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import stylex from '@stylexjs/stylex';
 import GnbNavLayout from '@src/layouts/GnbNavLayout';
 import UserGreeting from '@src/features/home/components/UserGreeting';
 import MeetingStatus from '@src/features/home/components/MeetingStatus';
+import TimeLine from '@src/features/home/components/TimeLine';
 
 const Home = () => {
   console.log('');
@@ -19,6 +20,10 @@ const Home = () => {
         <MeetingStatus />
       </section>
       {/* 타임 라인 섹션 */}
+      <section {...stylex.props(Styles.timeLineSection)}>
+        <h2 {...stylex.props(Styles.sectionTitle, Styles.timeLineSectionTitle)}>타임라인</h2>
+        <TimeLine />
+      </section>
     </GnbNavLayout>
   );
 };
@@ -37,11 +42,17 @@ const Styles = stylex.create({
     padding: '0 16px',
     marginBottom: '24px',
   },
+  timeLineSection: {
+    height: '100%',
+  },
   sectionTitle: {
     marginBottom: '16px',
     fontSize: '1.6rem',
     fontWeight: '600',
     lineHeight: '2.4rem',
     color: '#616161',
+  },
+  timeLineSectionTitle: {
+    padding: '0 16px',
   },
 });


### PR DESCRIPTION
# 작업 내용 
- 홈 화면에서 타임라인 영역 구현
   - 타임 라인 영역만 스크롤이 되게 구현하고, 이로 인해 MainLayout의 container에 `overflowY: 'hidden'`를 추가하여 전체 영역에 스크롤이 생기지 않게 함.