### PR TITLE
Feat(3TS-29): 마이페이지 알림 설정 페이지 및 알림 리스트 확인 페이지 구현

### DIFF
--- a/src/components/icons/CloseOutlined.tsx
+++ b/src/components/icons/CloseOutlined.tsx
@@ -1,0 +1,13 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const CloseOutlined: FC<IconProps> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" {...props}>
+    <path
+      fill="#61686D"
+      d="m12.666 4.272-.94-.94L8 7.059 4.273 3.332l-.94.94L7.06 7.999l-3.727 3.726.94.94L8 8.94l3.726 3.726.94-.94L8.94 8z"
+      opacity={0.3}
+    />
+  </svg>
+);
+export default CloseOutlined;

--- a/src/components/ui/Toggle/index.tsx
+++ b/src/components/ui/Toggle/index.tsx
@@ -1,0 +1,14 @@
+import React, { FC, useState } from 'react';
+import styles from './styles/styles.module.css';
+
+type ToggleProps = {
+  onChange: (e: React.ChangeEvent) => void;
+};
+
+const Toggle: FC<ToggleProps> = (props) => {
+  const { onChange } = props;
+
+  return <input className={styles['common-toggle']} type="checkbox" onChange={onChange} />;
+};
+
+export default Toggle;

--- a/src/components/ui/Toggle/styles/styles.module.css
+++ b/src/components/ui/Toggle/styles/styles.module.css
@@ -1,0 +1,34 @@
+.common-toggle {
+  margin: 0;
+  appearance: none;
+  position: relative;
+  width: 46px;
+  height: 26px;
+  border-radius: 13px;
+  background-color: #e2e2e2;
+  transition: background 0.3s;
+  outline: none;
+  cursor: pointer;
+}
+
+.common-toggle::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 30%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  height: 20px;
+  width: 20px;
+  background-color: #fff;
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.15);
+  transition: left 0.3s;
+}
+
+.common-toggle:checked {
+  background-color: #b5312c;
+}
+
+.common-toggle:checked::after {
+  left: 70%;
+}

--- a/src/features/alarm/components/AlarmCategoryList/index.tsx
+++ b/src/features/alarm/components/AlarmCategoryList/index.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import stylex from '@stylexjs/stylex';
+import { Typography, colors } from '../../../../../public/styles/vars.stylex';
+
+const AlarmCategoryList = () => {
+  const [selectCategory, setSelectCategory] = useState<string>('all');
+  const categoryList = [
+    { id: 1, name: '전체', value: 'all' },
+    { id: 2, name: '테스트', value: 'test' },
+  ];
+
+  const handleClick = (e) => {
+    const value = e.target.getAttribute('value');
+    setSelectCategory(value);
+  };
+
+  return (
+    <div {...stylex.props(AlarmCategoryStyles.Wrapper)}>
+      <ul {...stylex.props(AlarmCategoryStyles.List)} onClick={handleClick}>
+        {categoryList.map((item, idx) => (
+          <li
+            key={item.id}
+            value={item.value}
+            {...stylex.props(
+              AlarmCategoryStyles.Item,
+              Typography.SubTextLargeRegular,
+              idx === categoryList.length - 1 && AlarmCategoryStyles.LastItem,
+              item.value === selectCategory && AlarmCategoryStyles.Active
+            )}
+          >
+            {item.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AlarmCategoryList;
+
+const AlarmCategoryStyles = stylex.create({
+  Wrapper: {
+    padding: '16px',
+    overflowX: 'auto',
+  },
+  List: {
+    listStyle: 'none',
+    textWrap: 'nowrap',
+  },
+  Item: {
+    marginRight: '8px',
+    padding: '7px 16px',
+    display: 'inline-block',
+    borderRadius: '20px',
+    boxShadow: `inset 0 0 0 1px ${colors.gray30}`,
+    color: '#000',
+    flexShrink: 0,
+  },
+  LastItem: {
+    marginRight: '16px',
+  },
+  Active: {
+    boxShadow: `inset 0 0 0 1px ${colors.red500}`,
+    color: colors.red500,
+    background: '#FDF0F0',
+  },
+});

--- a/src/features/alarm/components/AlarmList/index.tsx
+++ b/src/features/alarm/components/AlarmList/index.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import stylex, { props } from '@stylexjs/stylex';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { Typography, colors } from '../../../../../public/styles/vars.stylex';
+import CloseOutlined from '@src/components/icons/CloseOutlined';
+
+// fromNow를 사용하기 위해 플러그인 사용
+dayjs.extend(relativeTime);
+
+/**
+ * 알람 리스트 컴포넌트
+ */
+const AlarmList = () => {
+  const data = [
+    {
+      id: 1,
+      isRead: false,
+      category: 'reservation',
+      content: `'레나'님의 회의가 예약되었어요.`,
+      createdAt: '2024-05-24',
+    },
+    {
+      id: 2,
+      isRead: true,
+      category: 'reservation',
+      content: `'레나'님의 회의가 예약되었어요.`,
+      createdAt: '2024-05-24',
+    },
+  ];
+
+  const alarmCategoryInfo = {
+    reservation: { imgKey: 'public/images/alarm/checked 1.png', korean: '예약' },
+    invite: { imgKey: 'public/images/alarm/plus 1.png', korean: '초대' },
+    change: { imgKey: 'public/images/alarm/shuffle 1.png', korean: '변경' },
+    notice: { imgKey: 'public/images/alarm/volume-up 1.png', korean: '공지' },
+    remind: { imgKey: 'public/images/alarm/bell 1.png', korean: '리마인드' },
+  };
+
+  return (
+    <ul>
+      {data.map((item) => (
+        <li key={item.id} {...stylex.props(AlarmStyles.Item, !item.isRead && AlarmStyles.NotRead)}>
+          {/* 알람 정보 */}
+          <div {...stylex.props(AlarmStyles.InfoContainer)}>
+            {/* 읽었는지 안 읽었는지 체크하는 dot */}
+            <div {...stylex.props(AlarmStyles.DotWrapper)}>
+              {item.isRead ? '' : <span {...stylex.props(AlarmStyles.Dot)} />}
+            </div>
+
+            {/* 카테고리 이미지 */}
+            <div {...stylex.props(AlarmStyles.ImgWrapper)}>
+              <img
+                src={`${process.env.NEXT_PUBLIC_S3_URL}/${alarmCategoryInfo[item.category].imgKey}`}
+                alt={alarmCategoryInfo[item.category].korean}
+                width={24}
+              />
+            </div>
+
+            {/* 카테고리와 알람내용, 날짜 */}
+            <div>
+              <p {...stylex.props(Typography.SubTextLargeMedium, AlarmStyles.CategoryText)}>
+                {alarmCategoryInfo[item.category].korean}
+              </p>
+              <p {...stylex.props(Typography.TextSmallMedium, AlarmStyles.ContentText)}>{item.content}</p>
+              <p {...stylex.props(Typography.CaptionRegularRegular, AlarmStyles.DateText)}>
+                {dayjs(item.createdAt).fromNow()}
+              </p>
+            </div>
+          </div>
+
+          {/* 알람 삭제 */}
+          <button type="button">
+            <CloseOutlined width={16} height={16} />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default AlarmList;
+
+const AlarmStyles = stylex.create({
+  Item: {
+    width: '100%',
+    padding: '16px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  NotRead: {
+    background: '#FFF3F3',
+  },
+  InfoContainer: {
+    display: 'flex',
+  },
+  DotWrapper: {
+    width: '4px',
+  },
+  Dot: {
+    width: '4px',
+    height: '4px',
+    display: 'inline-block',
+    background: colors.red300,
+    borderRadius: '50%',
+    verticalAlign: 'top',
+  },
+  ImgWrapper: {
+    marginRight: '11px',
+  },
+  CategoryText: {
+    marginBottom: '4px',
+    color: colors.black300,
+  },
+  ContentText: {
+    marginBottom: '4px',
+    color: colors.black300,
+  },
+  DateText: {
+    color: colors.gray60,
+  },
+});

--- a/src/features/mypage/compontents/MyPageAlarmToggle/index.tsx
+++ b/src/features/mypage/compontents/MyPageAlarmToggle/index.tsx
@@ -1,0 +1,49 @@
+import React, { FC, useState } from 'react';
+import stylex from '@stylexjs/stylex';
+import Toggle from '@src/components/ui/Toggle';
+import { Typography, colors } from '../.././../../../public/styles/vars.stylex';
+
+type MyPageAlarmToggleProps = {
+  key: string | number;
+  label: string;
+  caption: string;
+  apiUrl: string;
+};
+
+const MyPageAlarmToggle: FC<MyPageAlarmToggleProps> = (props) => {
+  const { label, caption, apiUrl } = props;
+  const [isInviteMeeting, setIsInviteMeeting] = useState<boolean>(false);
+
+  const handleChangeAlarm = (e) => {
+    setIsInviteMeeting(e.target.checked);
+  };
+
+  return (
+    <div {...stylex.props(Styles.Container)}>
+      <div>
+        <p {...stylex.props(Typography.TextSmallMedium, Styles.Label)}>{label}</p>
+        <p {...stylex.props(Typography.CaptionLargeRegular, Styles.Caption)}>{caption}</p>
+      </div>
+      <Toggle onChange={handleChangeAlarm} />
+    </div>
+  );
+};
+
+export default MyPageAlarmToggle;
+
+const Styles = stylex.create({
+  Container: {
+    width: '100%',
+    padding: '16px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  Label: {
+    color: colors.black400,
+    marginBottom: '4px',
+  },
+  Caption: {
+    color: colors.gray60,
+  },
+});

--- a/src/pages/alarm.tsx
+++ b/src/pages/alarm.tsx
@@ -1,0 +1,30 @@
+import Header from '@src/components/ui/Header';
+import AlarmCategoryList from '@src/features/alarm/components/AlarmCategoryList';
+import AlarmList from '@src/features/alarm/components/AlarmList';
+import MainLayout from '@src/layouts/MainLayout';
+import React, { useState } from 'react';
+
+const Alarm = () => {
+  const [isReadAll, setIsReadAll] = useState<boolean>(false);
+
+  const readAllBtnProps = {
+    name: '모두 읽기',
+    isActive: true,
+    onClick: () => console.log(''),
+  };
+
+  // 컨텍스트로 알림 카테고리 관리하기
+  return (
+    <MainLayout>
+      <Header title="알림" prevUrl="/" rightBtnInfo={readAllBtnProps} />
+
+      {/* 알림 카테고리 */}
+      <AlarmCategoryList />
+
+      {/* 알림 리스트 */}
+      <AlarmList />
+    </MainLayout>
+  );
+};
+
+export default Alarm;

--- a/src/pages/mypage/alarm.tsx
+++ b/src/pages/mypage/alarm.tsx
@@ -1,0 +1,42 @@
+import Header from '@src/components/ui/Header';
+import Toggle from '@src/components/ui/Toggle';
+import MyPageAlarmToggle from '@src/features/mypage/compontents/MyPageAlarmToggle';
+import MainLayout from '@src/layouts/MainLayout';
+import React, { useState } from 'react';
+
+const MyPageAlarmSetting = () => {
+  const toggleList = [
+    {
+      id: 1,
+      label: '회의 초대',
+      caption: '새로운 회의에 초대되면 알려드려요.',
+      apiUrl: '',
+    },
+    {
+      id: 2,
+      label: '회의 변경',
+      caption: '참여중인 회의에 변경사항이 있을 때 알려드려요.',
+      apiUrl: '',
+    },
+    {
+      id: 3,
+      label: '회의 리마인드',
+      caption: '회의 시간이 다가오면 30분 전에 다시 한 번 알려드려요.',
+      apiUrl: '',
+    },
+  ];
+
+  return (
+    <MainLayout>
+      <Header title="알림 수신 설정" prevUrl="/mypage" />
+
+      <section>
+        {toggleList.map((item) => (
+          <MyPageAlarmToggle key={item.id} label={item.label} caption={item.caption} apiUrl={item.apiUrl} />
+        ))}
+      </section>
+    </MainLayout>
+  );
+};
+
+export default MyPageAlarmSetting;

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -21,7 +21,7 @@ const MyPageHome = () => {
       href: `/${commonUrl}/workspace`,
     },
     { id: 2, name: '멤버초대', icon: <AddUserOutlined width={24} height={24} />, href: '' },
-    { id: 4, name: '알림설정', icon: <BellOutlined width={24} height={24} />, href: '' },
+    { id: 4, name: '알림 설정', icon: <BellOutlined width={24} height={24} />, href: `/${commonUrl}/alarm` },
     { id: 5, name: '워크스페이스 나가기', icon: <ExitOutlined width={24} height={24} />, href: '' },
   ];
 

--- a/src/pages/mypage/profile.tsx
+++ b/src/pages/mypage/profile.tsx
@@ -15,7 +15,7 @@ import MyPageImgUpload from '@src/features/mypage/compontents/MyPageImgUpload';
 import MyPageInput from '@src/features/mypage/compontents/MyPageInput';
 import useInput from '@src/hooks/useInput';
 
-const Reservations = () => {
+const MyPageProfile = () => {
   const [nickname, handleChangeNickname] = useInput<string>('');
   const [isEditComplete, setIsEditComplete] = useState<boolean>(false);
 
@@ -50,7 +50,7 @@ const Reservations = () => {
   );
 };
 
-export default Reservations;
+export default MyPageProfile;
 
 const Styles = stylex.create({
   SettingContainer: {


### PR DESCRIPTION
# 작업 내용
- 공통으로 사용할 토글 컴포넌트 구현
- 알람 설정 페이지 구현
   - 알람 설정 타이틀, 설명, 토글이 표현된 컴포넌트 구현
- 알람 리스트 페이지 구현
   - 알람 카테고리 컴포넌트 구현
   - 알람 리스트 컴포넌트 구현
      - 각 알람의 카테고리를 표현하는 이미지는 s3에서 관리하고, 이미지 키를 코드로 관리함.