### PR TITLE
Feat(4TS-29): react-query 설치 및 초대하기 관련 API 연결, Confirm 모달 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@reduxjs/toolkit": "^2.1.0",
         "@stylexjs/nextjs-plugin": "^0.4.1",
         "@stylexjs/stylex": "^0.4.1",
+        "@tanstack/react-query": "^5.59.15",
         "antd": "^5.16.4",
         "axios": "^1.7.2",
         "dayjs": "^1.11.10",
@@ -2926,6 +2927,30 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.59.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.59.13.tgz",
+      "integrity": "sha512-Oou0bBu/P8+oYjXsJQ11j+gcpLAMpqW42UlokQYEz4dE7+hOtVO9rVuolJKgEccqzvyFzqX4/zZWY+R/v1wVsQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.59.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.59.15.tgz",
+      "integrity": "sha512-QbVlAkTI78wB4Mqgf2RDmgC0AOiJqer2c5k9STOOSXGv1S6ZkY37r/6UpE8DbQ2Du0ohsdoXgFNEyv+4eDoPEw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.59.13"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@reduxjs/toolkit": "^2.1.0",
     "@stylexjs/nextjs-plugin": "^0.4.1",
     "@stylexjs/stylex": "^0.4.1",
+    "@tanstack/react-query": "^5.59.15",
     "antd": "^5.16.4",
     "axios": "^1.7.2",
     "dayjs": "^1.11.10",

--- a/src/components/ui/Modal/confirm/index.tsx
+++ b/src/components/ui/Modal/confirm/index.tsx
@@ -3,27 +3,76 @@ import stylex from '@stylexjs/stylex';
 import Modal from '..';
 import { colors, Typography } from '../../../../../public/styles/vars.stylex';
 import { ModalProps } from '../types';
+import { createRoot } from 'react-dom/client';
 
-type ConfirmModalProps = {
+let root = null;
+const confirmModalId = 'confirm-modal';
+
+interface ConfirmModalProps {
   content: string;
   onOk: (e: React.MouseEvent) => void;
   onCancel: (e: React.MouseEvent) => void;
   okBtnName?: string;
   cancelBtnName?: string;
-};
+}
 
 const ConfirmModal: FC<ModalProps & ConfirmModalProps> = (props) => {
   const { content, onOk, onCancel, okBtnName, cancelBtnName } = props;
+
+  /**
+   * 모달 닫기
+   */
+  const close = () => {
+    const targetConfirmModalElement = document.getElementById(confirmModalId);
+
+    if (targetConfirmModalElement) {
+      root.unmount(targetConfirmModalElement);
+    }
+  };
+
+  /**
+   * 취소 버튼을 눌렀을 때
+   */
+  const handleClickCancel = (e) => {
+    // onCancel가 존재하면, onCandle 함수 실행
+    if (onCancel) {
+      onCancel(e);
+    }
+
+    // 모달 닫기
+    close();
+  };
+
+  /**
+   * 확인 버튼을 눌렀을 때
+   */
+  const handleClickOk = (e) => {
+    // onOk가 존재하면, onOk 함수 실행
+    if (onOk) {
+      onOk(e);
+    }
+
+    // 모달 닫기
+    close();
+  };
 
   return (
     <Modal isOpen>
       <div {...stylex.props(Styles.container)}>
         <p {...stylex.props(Typography.SubTextLargeRegular, Styles.content)}>{content}</p>
         <div {...stylex.props(Styles.btnContainer)}>
-          <button type="button" onClick={onCancel} {...stylex.props(Styles.cancelBtn, Typography.SubTextLargeSemiBold)}>
+          <button
+            type="button"
+            onClick={handleClickCancel}
+            {...stylex.props(Styles.cancelBtn, Typography.SubTextLargeSemiBold)}
+          >
             {cancelBtnName || '취소'}
           </button>
-          <button type="button" onClick={onOk} {...stylex.props(Styles.okBtn, Typography.SubTextLargeSemiBold)}>
+          <button
+            type="button"
+            onClick={handleClickOk}
+            {...stylex.props(Styles.okBtn, Typography.SubTextLargeSemiBold)}
+          >
             {okBtnName || '확인'}
           </button>
         </div>
@@ -32,7 +81,17 @@ const ConfirmModal: FC<ModalProps & ConfirmModalProps> = (props) => {
   );
 };
 
-export default ConfirmModal;
+const confirm = (props) => {
+  // body 태그에 div 태그를 추가하여 모달 띄우기
+  const divElement = document.createElement('div');
+  divElement.id = confirmModalId;
+  document.body.appendChild(divElement);
+  root = createRoot(divElement);
+
+  root.render(<ConfirmModal {...props} />);
+};
+
+export { confirm };
 
 const Styles = stylex.create({
   container: {

--- a/src/features/invite/queries/useGetInviteInfoQuery.tsx
+++ b/src/features/invite/queries/useGetInviteInfoQuery.tsx
@@ -33,7 +33,7 @@ const getInviteInfoApi = async (InviteId: string): Promise<InviteInfo> => {
  *   - `isLoading`: 데이터 로딩 여부
  *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
  */
-const useInviteInfoQuery = () => {
+const useGetInviteInfoQuery = () => {
   const router = useRouter();
   const InviteId = router.query.InviteId as string;
 
@@ -46,4 +46,4 @@ const useInviteInfoQuery = () => {
   return result;
 };
 
-export default useInviteInfoQuery;
+export default useGetInviteInfoQuery;

--- a/src/features/invite/queries/useInviteInfoQuery.tsx
+++ b/src/features/invite/queries/useInviteInfoQuery.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { useRouter } from 'next/router';
+
+interface InviteInfo {
+  myInfo: {
+    MemberId: number;
+    displayName: string;
+    profileImgUrl: string;
+    position: string;
+    isAdmin: boolean;
+    email: string;
+    teamInfo: {
+      TeamId: number;
+      teamName: string;
+    };
+  };
+}
+
+const getInviteInfoApi = async (InviteId: string): Promise<InviteInfo> => {
+  const response = await axios.get(`/v1/workspace/invite/${InviteId}`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 초대 정보를 가져오는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 초대 정보 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useInviteInfoQuery = () => {
+  const router = useRouter();
+  const InviteId = router.query.InviteId as string;
+  const result = useQuery({
+    queryKey: ['inviteInfo', InviteId],
+    queryFn: () => getInviteInfoApi(InviteId),
+  });
+
+  return result;
+};
+
+export default useInviteInfoQuery;

--- a/src/features/invite/queries/useInviteInfoQuery.tsx
+++ b/src/features/invite/queries/useInviteInfoQuery.tsx
@@ -3,16 +3,17 @@ import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 
 interface InviteInfo {
-  myInfo: {
-    MemberId: number;
-    displayName: string;
-    profileImgUrl: string;
-    position: string;
-    isAdmin: boolean;
-    email: string;
-    teamInfo: {
-      TeamId: number;
-      teamName: string;
+  code: number;
+  success: boolean;
+  inviteInfo: {
+    InviteId: string;
+    workspace: {
+      WorkspaceId: number;
+      workspaceName: string;
+    };
+    invitedMember: {
+      displayName: string;
+      profileImgUrl: string;
     };
   };
 }
@@ -35,9 +36,11 @@ const getInviteInfoApi = async (InviteId: string): Promise<InviteInfo> => {
 const useInviteInfoQuery = () => {
   const router = useRouter();
   const InviteId = router.query.InviteId as string;
+
   const result = useQuery({
     queryKey: ['inviteInfo', InviteId],
     queryFn: () => getInviteInfoApi(InviteId),
+    enabled: Boolean(InviteId), // InviteId가 정의되어 있지 않은 경우, 첫 렌더링시 요청이 이뤄지지 않게 함.
   });
 
   return result;

--- a/src/features/invite/queries/useInviteInfoQuery.tsx
+++ b/src/features/invite/queries/useInviteInfoQuery.tsx
@@ -1,5 +1,5 @@
+import clientInstance from '@src/utils/api/clientInstance';
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 import { useRouter } from 'next/router';
 
 interface InviteInfo {
@@ -18,7 +18,7 @@ interface InviteInfo {
 }
 
 const getInviteInfoApi = async (InviteId: string): Promise<InviteInfo> => {
-  const response = await axios.get(`/v1/workspace/invite/${InviteId}`);
+  const response = await clientInstance.get(`/v1/workspace/invite/${InviteId}`);
 
   return response.data;
 };

--- a/src/features/invite/queries/usePostWorkspaceJoinQuery.tsx
+++ b/src/features/invite/queries/usePostWorkspaceJoinQuery.tsx
@@ -1,5 +1,6 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
 import clientInstance from '@src/utils/api/clientInstance';
-import { useMutation } from '@tanstack/react-query';
 
 interface WorkspaceInfo {
   code: number;
@@ -35,8 +36,12 @@ const postWorkspaceJoinApi = async (data: JoinInfo): Promise<WorkspaceInfo> => {
  *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
  */
 const usePostWorkspaceJoinQuery = () => {
-  const mutation = useMutation({
+  const mutation = useCustomMutation({
     mutationFn: (data: JoinInfo) => postWorkspaceJoinApi(data),
+    onError: (error, variables, context) => {
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
   });
 
   return mutation;

--- a/src/features/invite/queries/usePostWorkspaceJoinQuery.tsx
+++ b/src/features/invite/queries/usePostWorkspaceJoinQuery.tsx
@@ -1,0 +1,45 @@
+import clientInstance from '@src/utils/api/clientInstance';
+import { useMutation } from '@tanstack/react-query';
+
+interface WorkspaceInfo {
+  code: number;
+  success: boolean;
+  workspaceInfo: {
+    WorkspaceId: number;
+    workspaceName: string;
+  };
+}
+
+interface JoinInfo {
+  WorkspaceId: number;
+  joinInfo: { displayName: string; InviteId: string };
+}
+
+const postWorkspaceJoinApi = async (data: JoinInfo): Promise<WorkspaceInfo> => {
+  const { WorkspaceId, joinInfo } = data;
+
+  const response = await clientInstance.post(`/v1/workspace/@${WorkspaceId}/join`, joinInfo);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 참여 데이터를 전송하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 워크페이스에 참여하기 위한 데이터
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const usePostWorkspaceJoinQuery = () => {
+  const mutation = useMutation({
+    mutationFn: (data: JoinInfo) => postWorkspaceJoinApi(data),
+  });
+
+  return mutation;
+};
+
+export default usePostWorkspaceJoinQuery;

--- a/src/hooks/react-query/useCustomMutation.tsx
+++ b/src/hooks/react-query/useCustomMutation.tsx
@@ -1,0 +1,17 @@
+import { QueryClient, useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { CustomAxiosError } from '@src/types/axios/error';
+
+/**
+ * 룸렛에서 axios로 api를 호출할 때 사용되는 CustomAxiosError로 Error 타입을 재지정한 커스텀 훅
+ * @param options react-query에서 사용하던 options와 동일
+ * @param queryClient react-query에서 사용하던 queryClient와 동일
+ * @returns
+ */
+function useCustomMutation<TData = unknown, TError = CustomAxiosError, TVariables = void, TContext = unknown>(
+  options: UseMutationOptions<TData, TError, TVariables, TContext>,
+  queryClient?: QueryClient
+): UseMutationResult<TData, TError, TVariables> {
+  return useMutation<TData, TError, TVariables>(options, queryClient);
+}
+
+export default useCustomMutation;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,8 @@ import 'dayjs/locale/ko';
 // 타임존 설정
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+// react-query
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // redux
 import { Provider } from 'react-redux';
 import { store } from '../store';
@@ -25,9 +27,14 @@ export default function App({ Component, pageProps }: AppProps) {
   // 로케일 설정
   dayjs.locale('ko');
 
+  // client 생성
+  const queryClient = new QueryClient();
+
   return (
-    <Provider store={store}>
-      <Component {...pageProps} />
-    </Provider>
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>
+        <Component {...pageProps} />
+      </Provider>
+    </QueryClientProvider>
   );
 }

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -6,11 +6,11 @@ import { colors, Typography } from '../../public/styles/vars.stylex';
 import Input from '@src/components/ui/Input';
 import useInput from '@src/hooks/useInput';
 import Button from '@src/components/ui/Button';
-import useInviteInfoQuery from '@src/features/invite/queries/useInviteInfoQuery';
+import useGetInviteInfoQuery from '@src/features/invite/queries/useGetInviteInfoQuery';
 
 const Invite = () => {
   const [nickname, handleChangeNickname] = useInput('');
-  const { data } = useInviteInfoQuery();
+  const { data } = useGetInviteInfoQuery();
   const letterImgUrl = 'https://roomlet.s3.ap-northeast-2.amazonaws.com/public/images/invite/invite-letter.png';
 
   return (

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -8,11 +8,13 @@ import useInput from '@src/hooks/useInput';
 import Button from '@src/components/ui/Button';
 import useGetInviteInfoQuery from '@src/features/invite/queries/useGetInviteInfoQuery';
 import usePostWorkspaceJoinQuery from '@src/features/invite/queries/usePostWorkspaceJoinQuery';
+import { useRouter } from 'next/router';
 
 const Invite = () => {
   const [displayName, handleChangeDisplayName] = useInput('');
   const { data } = useGetInviteInfoQuery();
   const mutation = usePostWorkspaceJoinQuery();
+  const router = useRouter();
   const letterImgUrl = 'https://roomlet.s3.ap-northeast-2.amazonaws.com/public/images/invite/invite-letter.png';
 
   const handleClickJoin = () => {
@@ -20,6 +22,10 @@ const Invite = () => {
       WorkspaceId: data.inviteInfo.workspace.WorkspaceId,
       joinInfo: { displayName, InviteId: data.inviteInfo.InviteId },
     });
+  };
+
+  const handleClickDenyJoin = () => {
+    router.push('/');
   };
 
   return (
@@ -54,7 +60,11 @@ const Invite = () => {
           <Button type="button" onClick={handleClickJoin}>
             참가하기
           </Button>
-          <button type="button" {...stylex.props(Styles.dontParticipateButton, Typography.M3BodyLarge)}>
+          <button
+            type="button"
+            onClick={handleClickDenyJoin}
+            {...stylex.props(Styles.dontParticipateButton, Typography.M3BodyLarge)}
+          >
             참가하지 않기
           </button>
         </div>

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -27,10 +27,10 @@ const Invite = () => {
             <div {...stylex.props(Typography.M3BodyLarge)}>
               <img src={letterImgUrl} alt="편지 이미지" {...stylex.props(Styles.letterImg)} />
               <div {...stylex.props(Styles.contentWrapper, Typography.M3BodyLarge)}>
-                [{data.myInfo.displayName}]님이 초대했어요.
+                [{data?.myInfo?.displayName}]님이 초대했어요.
                 <br />
                 <br />
-                룸렛에서 [{data.myInfo.teamInfo.teamName}] 회의를 <br />
+                룸렛에서 [{data?.myInfo?.teamInfo?.teamName}] 회의를 <br />
                 함께 준비해보세요.
               </div>
             </div>

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -7,11 +7,20 @@ import Input from '@src/components/ui/Input';
 import useInput from '@src/hooks/useInput';
 import Button from '@src/components/ui/Button';
 import useGetInviteInfoQuery from '@src/features/invite/queries/useGetInviteInfoQuery';
+import usePostWorkspaceJoinQuery from '@src/features/invite/queries/usePostWorkspaceJoinQuery';
 
 const Invite = () => {
-  const [nickname, handleChangeNickname] = useInput('');
+  const [displayName, handleChangeDisplayName] = useInput('');
   const { data } = useGetInviteInfoQuery();
+  const mutation = usePostWorkspaceJoinQuery();
   const letterImgUrl = 'https://roomlet.s3.ap-northeast-2.amazonaws.com/public/images/invite/invite-letter.png';
+
+  const handleClickJoin = () => {
+    mutation.mutate({
+      WorkspaceId: data.inviteInfo.workspace.WorkspaceId,
+      joinInfo: { displayName, InviteId: data.inviteInfo.InviteId },
+    });
+  };
 
   return (
     <MainLayout isScroll>
@@ -39,10 +48,12 @@ const Invite = () => {
 
         <div className="" {...stylex.props(Styles.formContainer)}>
           {/* 닉네임 */}
-          <Input onChange={handleChangeNickname} value={nickname} placeholder="사용하실 닉네임을 입력해주세요." />
+          <Input onChange={handleChangeDisplayName} value={displayName} placeholder="사용하실 닉네임을 입력해주세요." />
 
           {/* 참가하기 및 참가하지 않기 버튼 */}
-          <Button type="button">참가하기</Button>
+          <Button type="button" onClick={handleClickJoin}>
+            참가하기
+          </Button>
           <button type="button" {...stylex.props(Styles.dontParticipateButton, Typography.M3BodyLarge)}>
             참가하지 않기
           </button>

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -27,10 +27,10 @@ const Invite = () => {
             <div {...stylex.props(Typography.M3BodyLarge)}>
               <img src={letterImgUrl} alt="편지 이미지" {...stylex.props(Styles.letterImg)} />
               <div {...stylex.props(Styles.contentWrapper, Typography.M3BodyLarge)}>
-                [{data?.myInfo?.displayName}]님이 초대했어요.
+                [{data?.inviteInfo?.invitedMember.displayName}]님이 초대했어요.
                 <br />
                 <br />
-                룸렛에서 [{data?.myInfo?.teamInfo?.teamName}] 회의를 <br />
+                룸렛에서 [{data?.inviteInfo?.workspace?.workspaceName}] 회의를 <br />
                 함께 준비해보세요.
               </div>
             </div>

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -6,9 +6,11 @@ import { colors, Typography } from '../../public/styles/vars.stylex';
 import Input from '@src/components/ui/Input';
 import useInput from '@src/hooks/useInput';
 import Button from '@src/components/ui/Button';
+import useInviteInfoQuery from '@src/features/invite/queries/useInviteInfoQuery';
 
 const Invite = () => {
   const [nickname, handleChangeNickname] = useInput('');
+  const { data } = useInviteInfoQuery();
   const letterImgUrl = 'https://roomlet.s3.ap-northeast-2.amazonaws.com/public/images/invite/invite-letter.png';
 
   return (
@@ -25,10 +27,10 @@ const Invite = () => {
             <div {...stylex.props(Typography.M3BodyLarge)}>
               <img src={letterImgUrl} alt="편지 이미지" {...stylex.props(Styles.letterImg)} />
               <div {...stylex.props(Styles.contentWrapper, Typography.M3BodyLarge)}>
-                ~님이 초대했어요.
+                [{data.myInfo.displayName}]님이 초대했어요.
                 <br />
                 <br />
-                룸렛에서 [워크스페이스] 회의를 <br />
+                룸렛에서 [{data.myInfo.teamInfo.teamName}] 회의를 <br />
                 함께 준비해보세요.
               </div>
             </div>

--- a/src/types/axios/error.d.ts
+++ b/src/types/axios/error.d.ts
@@ -1,0 +1,17 @@
+import { AxiosError } from 'axios';
+
+/**
+ * 에러 발생시, 백엔드에서 표현하는 response로 나타낼 수 있게 커스텀한 AxiosError 타입
+ */
+interface CustomAxiosError extends AxiosError {
+  response: {
+    data: {
+      success: boolean;
+      code: number;
+      message: {
+        errCode: string;
+        errMsg: string;
+      };
+    };
+  };
+}


### PR DESCRIPTION
# 작업 내용
- react-query 설치
   - 원래 redux-saga를 사용해왔었는데 클라이언트 상태 관리와 서버 서버 상태 관리를 함께 redux로 관리하니 유지보수 어려움이 있었고, 단지 서버 상태 관리를 위해 리덕스를 사용하는 일도 잦다보니 redux를 제대로 활용하고 있다는 느낌을 받지 못했음.
   - 이러한 이유로 평소에 react-query를 사용하면 좋다는 얘기들을 보았는데 크게 와닫지 않다가 [우아한 테크 세미나 - 프론트엔드 상태관리 실전편](https://www.youtube.com/watch?v=nkXIpGjVxWU) 영상을 우연히 보게 되었고, 이번 프로젝트에 react-query를 도입해보기로 함.
   - swr를 사용해본 경험이 있어서 react-query를 사용하는 데 어려움은 없었고, 이전에 보일러플레이트 코드를 작성하던 과정들이 없다보니 확실히 생산성 면에서 압도적으로 좋다는 느낌을 받음.
   - react-query에서 api 연결시 다 커스텀 훅으로 연결해서 사용하기로 함.
      - hook 명명 규칙은 `use + http 메서드 + 기능 + query`으로 함.
   - react-query에서 제공하는 mutation에서 Error 타입이 axios에 맞게 되어있지 않아서 AxiosError로 타입을 재정의하는 훅을 만들었고, 서버에서 전달하는 에러 표현에 맞게 다시 커스텀하여 CustomAxiosError 타입으로 정의함.
- 초대하기 관련 api 연결
   - 워크스페이스 초대 코드 생성 api
   - 워크스페이스 참여 api
- confirm 모달 개선
   - confirm 모달을 렌더링할 때 불러올 수 있게 해서 함수안에서 따로 모달을 불러오게 할 수 없었음. 특정 조건문을 통과했을 때 confirm 모달을 나타나게 하려면 번거로운 과정을 거쳐야했음.
   - 함수 안이나 특정 조건문에 만족할 떄, confirm 모달을 자바스크립트 confirm 처럼 사용할 수 있도록 함.