### PR TITLE
Update(TSK-24): 캘린더에서 옆으로 넘기는 효과를 scroll snap에서 swiper로 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react-redux": "^9.1.0",
         "react-slick": "^0.29.0",
         "react-switch": "^7.0.0",
-        "slick-carousel": "^1.8.1"
+        "slick-carousel": "^1.8.1",
+        "swiper": "^11.1.14"
       },
       "devDependencies": {
         "@stylexjs/babel-plugin": "^0.4.1",
@@ -7810,6 +7811,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.1.14",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.14.tgz",
+      "integrity": "sha512-VbQLQXC04io6AoAjIUWuZwW4MSYozkcP9KjLdrsG/00Q/yiwvhz9RQyt0nHXV10hi9NVnDNy1/wv7Dzq1lkOCQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-redux": "^9.1.0",
     "react-slick": "^0.29.0",
     "react-switch": "^7.0.0",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "swiper": "^11.1.14"
   },
   "devDependencies": {
     "@stylexjs/babel-plugin": "^0.4.1",

--- a/src/features/calendar/components/MeetingSchedule/index.tsx
+++ b/src/features/calendar/components/MeetingSchedule/index.tsx
@@ -46,7 +46,7 @@ export default MeetingSchedule;
 const Styles = stylex.create({
   container: {
     width: '100%',
-    height: 'calc(100vh - 549px)',
+    height: 'calc(100vh - 532px)',
     padding: '16px',
     borderTop: '1px solid #E2E2E2',
     overflowY: 'auto',

--- a/src/features/calendar/components/MonthlyCalendar/index.tsx
+++ b/src/features/calendar/components/MonthlyCalendar/index.tsx
@@ -1,9 +1,16 @@
 import dayjs from 'dayjs';
 import React, { useEffect, useState } from 'react';
 import stylex from '@stylexjs/stylex';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+// Import Swiper styles
+import 'swiper/css';
 
 const MonthlyCalendar = () => {
-  const [monthList, setMonthList] = useState<string[]>(['2024-02']);
+  const currentMonth = dayjs().format('YYYY-MM');
+  const prevMonth = dayjs().subtract(1, 'M').format('YYYY-MM');
+  const nextMonth = dayjs().add(1, 'M').format('YYYY-MM');
+  const [monthList, setMonthList] = useState<string[]>([prevMonth, currentMonth, nextMonth]);
   const [selectDate, setSelectDate] = useState<number>(dayjs().date());
   const dayOfTheWeek = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
   const getCurrentMonth = (ym) => dayjs(ym).month();
@@ -37,14 +44,37 @@ const MonthlyCalendar = () => {
     setSelectDate(date);
   };
 
-  useEffect(() => {
-    setMonthList(['2024-01', ...monthList, '2024-03']);
-  }, []);
+  const handleSlideChange = (swiper) => {
+    const monthFormat = 'YYYY-MM';
+
+    // 첫번째 요소를 만났을 때, 미리 이전 2달치 로드
+    if (swiper.activeIndex === 0) {
+      const firstMonthIndex = monthList[0];
+      setMonthList([
+        dayjs(firstMonthIndex).subtract(2, 'M').format(monthFormat),
+        dayjs(firstMonthIndex).subtract(1, 'M').format(monthFormat),
+        ...monthList,
+      ]);
+      swiper.slideTo(2, 0);
+    }
+
+    if (swiper.activeIndex === monthList.length - 1) {
+      // 마지막 요소를 만났을 때, 미리 뒤의 2달치 로드
+      const lastMonthIndex = monthList[monthList.length - 1];
+
+      setMonthList([
+        ...monthList,
+        dayjs(lastMonthIndex).add(1, 'M').format(monthFormat),
+        dayjs(lastMonthIndex).add(2, 'M').format(monthFormat),
+      ]);
+      swiper.slideTo(monthList.length, 0);
+    }
+  };
 
   return (
-    <div {...stylex.props(Styles.scrollWrapper)}>
+    <Swiper spaceBetween={50} slidesPerView={1} initialSlide={1} onSlideChange={handleSlideChange}>
       {monthList.map((ym) => (
-        <div {...stylex.props(Styles.scrollContent)}>
+        <SwiperSlide {...stylex.props(Styles.scrollContent)}>
           <div {...stylex.props(Styles.monthlyContent)}>
             <h1 {...stylex.props(Styles.currentMonthText)}>{dayjs(ym).format('YYYY.MM')}</h1>
             <table {...stylex.props(Styles.calenderContent)}>
@@ -131,9 +161,9 @@ const MonthlyCalendar = () => {
               </tbody>
             </table>
           </div>
-        </div>
+        </SwiperSlide>
       ))}
-    </div>
+    </Swiper>
   );
 };
 
@@ -143,13 +173,8 @@ const Styles = stylex.create({
   scrollWrapper: {
     display: 'flex',
     overflow: 'auto',
-    scrollSnapType: 'x mandatory',
-    '::-webkit-scrollbar': {
-      // 스크롤바 보이지 않게 설정
-      backgroundColor: 'rgba(0,0,0,0)',
-    },
   },
-  scrollContent: { width: '100%', height: 'auto', display: 'flex', flexShrink: 0, scrollSnapAlign: 'start' },
+  scrollContent: { width: '100%', height: 'auto', display: 'flex', flexShrink: 0 },
   monthlyContent: { width: '100%', height: '100%' },
   currentMonthText: {
     padding: '16px 20px',


### PR DESCRIPTION
# 작업 내용
- css에서 제공하는 scroll snap에서 swiper로 변경
   - scroll snap을 사용하면 y축 영역 스크롤이 무한대로 되는 문제가 발생했음. 원인을 찾지 못했고, scroll snap이 아직 불안정하다는 레딧과 stackoverflow, velog 등의 글을 여럿 보았음. 그래서 swiper 라이브러리를 사용하여 달력을 옆으로 넘기게 함.