### PR TITLE
Feat(3TS-7): 예약하기에서 미니 캘린더에서 날짜 선택 오류 해결 및 DateWheelPicker가 나타나게 구현 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react": "^18.2.0",
         "react-calendar": "^5.0.0",
         "react-dom": "^18.2.0",
-        "react-mobile-picker": "^1.0.0",
+        "react-mobile-picker": "^1.0.1",
         "react-redux": "^9.1.0",
         "react-slick": "^0.29.0",
         "react-switch": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "^18.2.0",
     "react-calendar": "^5.0.0",
     "react-dom": "^18.2.0",
-    "react-mobile-picker": "^1.0.0",
+    "react-mobile-picker": "^1.0.1",
     "react-redux": "^9.1.0",
     "react-slick": "^0.29.0",
     "react-switch": "^7.0.0",

--- a/src/components/ui/Modal/index.tsx
+++ b/src/components/ui/Modal/index.tsx
@@ -36,5 +36,6 @@ const Styles = stylex.create({
     alignItems: 'center',
     background: 'rgba(0, 0, 0, 0.5)',
     color: BackgroundColor.gradientBlackBg,
+    zIndex: 9999,
   },
 });

--- a/src/features/booking/assets/custom-react-calendar.css
+++ b/src/features/booking/assets/custom-react-calendar.css
@@ -68,6 +68,43 @@
   font-weight: 700;
 }
 
+/* 달력 사이드 여백 */
+.mini-calendar .react-calendar__month-view {
+  padding: 12px;
+}
+
+/* 요일 간격 */
+.mini-calendar .react-calendar__month-view__weekdays {
+  gap: 24px;
+  margin-top: 14px;
+  margin-bottom: 24px;
+}
+
+/* 일자별 간격 */
+.mini-calendar .react-calendar__month-view__days {
+  gap: 24px;
+}
+
+/* 360px 미만 화면 */
+@media screen and (max-width: 359px) {
+  /* 달력 사이드 여백 */
+  .mini-calendar .react-calendar__month-view {
+    padding: 12px;
+  }
+
+  /* 요일 간격 */
+  .mini-calendar .react-calendar__month-view__weekdays {
+    gap: 17px;
+    margin-top: 14px;
+    margin-bottom: 16px;
+  }
+
+  /* 일자별 간격 */
+  .mini-calendar .react-calendar__month-view__days {
+    gap: 17px;
+  }
+}
+
 /* 토,일 */
 .mini-calendar .react-calendar__month-view__weekdays__weekday.react-calendar__month-view__weekdays__weekday--weekend {
   flex: none !important;
@@ -75,7 +112,6 @@
   margin-inline-end: 0px;
   width: 22px;
   height: 22px;
-  margin: 12px 16px;
   margin-right: 0;
   max-width: 100%;
   text-align: center;
@@ -95,7 +131,6 @@
   margin-inline-end: 0px;
   width: 22px;
   height: 22px;
-  margin: 12px 16px;
   margin-right: 0;
   max-width: 100%;
   text-align: center;
@@ -148,7 +183,8 @@
   width: 22px;
   height: 22px;
   max-width: 100%;
-  margin: 12px 16px;
+  /* margin: 16px 20px; */
+  gap: 20px;
   /* padding: 10px 6.6667px; */
   background: none;
   text-align: center;

--- a/src/features/booking/components/BookingDatePicker/MiniCalendar/index.tsx
+++ b/src/features/booking/components/BookingDatePicker/MiniCalendar/index.tsx
@@ -149,7 +149,7 @@ export default MiniCalendar;
 
 const Styles = stylex.create({
   Wrapper: {
-    width: '286px', // 설정한 너비에 맞게 일주일에 표현되는 일 수가 달라짐
+    width: { default: '328px', '@media (max-width: 359px)': '286px' }, // 설정한 너비에 맞게 일주일에 표현되는 일 수가 달라짐
     position: 'absolute',
     top: '56px',
     left: 0,

--- a/src/features/booking/components/BookingDatePicker/MiniCalendar/index.tsx
+++ b/src/features/booking/components/BookingDatePicker/MiniCalendar/index.tsx
@@ -17,20 +17,14 @@ type MiniCalendarProps = {
 
 type ValuePiece = Date | null;
 
-type Value = ValuePiece | [ValuePiece, ValuePiece];
-
 const MiniCalendar: FC<MiniCalendarProps> = (props) => {
   const { onClose } = props;
   const { selectBookingDate } = useSelector((state: RootState) => state.booking);
   const [year, setYear] = useState<number>(dayjs().year());
-  const [month, setMonth] = useState<number>(dayjs().month());
+  const [month, setMonth] = useState<number>(dayjs().month() + 1);
   const [day, setDay] = useState<number>(dayjs().date());
+  const miniCalenderRef = useRef<HTMLDivElement>(null);
   const dispatch = useDispatch();
-  const dateSelections = {
-    year: Array(300).map((_, idx) => 1800 + idx),
-    month: Array(11).map((_, idx) => 1 + idx),
-    day: Array(30).map((_, idx) => 1 + idx),
-  };
 
   const handleFormatDay = (locale, date) => dayjs(date).format('D');
 
@@ -82,8 +76,8 @@ const MiniCalendar: FC<MiniCalendarProps> = (props) => {
   useEffect(() => {
     if (!selectBookingDate) {
       setYear(dayjs().year());
-      setMonth(dayjs().month());
-      setDay(dayjs().day());
+      setMonth(dayjs().month() + 1);
+      setDay(dayjs().date());
     } else {
       const selectDateArr = dayjs(selectBookingDate).format('YYYY-M-D').split('-');
 
@@ -98,7 +92,7 @@ const MiniCalendar: FC<MiniCalendarProps> = (props) => {
   }, []);
 
   return (
-    <div {...stylex.props(Styles.Wrapper)}>
+    <div {...stylex.props(Styles.Wrapper)} ref={miniCalenderRef}>
       <div {...stylex.props(Styles.MoveDateContainer)}>
         <button type="button" {...stylex.props(Styles.DatePickerBtn, Typography.SubtitleSmallBold)}>
           {year}년 {month}월
@@ -113,6 +107,7 @@ const MiniCalendar: FC<MiniCalendarProps> = (props) => {
           </button>
         </div>
       </div>
+
       <Calendar
         onChange={handleChangeDate}
         value={new Date(year, month - 1, day)} // month는 0~11까지라서 -1을 해줌.

--- a/src/features/booking/components/BookingDatePicker/MiniCalendar/index.tsx
+++ b/src/features/booking/components/BookingDatePicker/MiniCalendar/index.tsx
@@ -10,6 +10,7 @@ import TriangleFilled from '@src/components/icons/TriangleFilled';
 import { useDispatch, useSelector } from 'react-redux';
 import { saveSelectBookingDate } from '@src/features/booking/slices/booking';
 import { RootState } from '@src/store';
+import DateWheelPicker from '@src/features/calendar/components/DateWheelPicker';
 
 type MiniCalendarProps = {
   onClose: (status: boolean) => void;
@@ -20,11 +21,16 @@ type ValuePiece = Date | null;
 const MiniCalendar: FC<MiniCalendarProps> = (props) => {
   const { onClose } = props;
   const { selectBookingDate } = useSelector((state: RootState) => state.booking);
+  const [isDateWheelPickerOpen, setIsDateWheelPickerOpen] = useState<boolean>(false);
   const [year, setYear] = useState<number>(dayjs().year());
   const [month, setMonth] = useState<number>(dayjs().month() + 1);
   const [day, setDay] = useState<number>(dayjs().date());
   const miniCalenderRef = useRef<HTMLDivElement>(null);
   const dispatch = useDispatch();
+
+  const handleClickDateWheelPicker = () => {
+    setIsDateWheelPickerOpen(!isDateWheelPickerOpen);
+  };
 
   const handleFormatDay = (locale, date) => dayjs(date).format('D');
 
@@ -64,6 +70,12 @@ const MiniCalendar: FC<MiniCalendarProps> = (props) => {
     setDay(+selectDay);
   };
 
+  const handleSelectDateWheelPicker = (date) => {
+    setYear(+date.year);
+    setMonth(+date.month);
+    setDay(+date.day);
+  };
+
   const handleClickCancel = () => {
     onClose(false);
   };
@@ -92,51 +104,65 @@ const MiniCalendar: FC<MiniCalendarProps> = (props) => {
   }, []);
 
   return (
-    <div {...stylex.props(Styles.Wrapper)} ref={miniCalenderRef}>
-      <div {...stylex.props(Styles.MoveDateContainer)}>
-        <button type="button" {...stylex.props(Styles.DatePickerBtn, Typography.SubtitleSmallBold)}>
-          {year}년 {month}월
-          <TriangleFilled width={24} height={24} />
-        </button>
-        <div {...stylex.props(Styles.MonthMoveBtnContainer)}>
-          <button type="button" onClick={handleClickPrevMonth}>
-            <ArrowHeadOutlinedV2 width={24} height={24} rotate={180} />
+    <>
+      <div {...stylex.props(Styles.Wrapper)} ref={miniCalenderRef}>
+        <div {...stylex.props(Styles.MoveDateContainer)}>
+          <button
+            type="button"
+            {...stylex.props(Styles.DatePickerBtn, Typography.SubtitleSmallBold)}
+            onClick={handleClickDateWheelPicker}
+          >
+            {year}년 {month}월
+            <TriangleFilled width={24} height={24} />
           </button>
-          <button type="button" onClick={handleClickNextMonth}>
-            <ArrowHeadOutlinedV2 width={24} height={24} />
+          <div {...stylex.props(Styles.MonthMoveBtnContainer)}>
+            <button type="button" onClick={handleClickPrevMonth}>
+              <ArrowHeadOutlinedV2 width={24} height={24} rotate={180} />
+            </button>
+            <button type="button" onClick={handleClickNextMonth}>
+              <ArrowHeadOutlinedV2 width={24} height={24} />
+            </button>
+          </div>
+        </div>
+
+        <Calendar
+          onChange={handleChangeDate}
+          value={new Date(year, month - 1, day)} // month는 0~11까지라서 -1을 해줌.
+          showNavigation={false}
+          formatDay={handleFormatDay}
+          formatShortWeekday={handleFormatShortWeekday} // 요일을 표현하는 방식 커스텀
+          locale="en-GB"
+          activeStartDate={new Date(year, month - 1, day)} // month는 0~11까지라서 -1을 해줌.
+          calendarType="gregory" // 일주일의 시작이 sun으로 시작되게 수정
+          tileClassName="mini-calendar-title"
+          className="mini-calendar"
+        />
+        <div {...stylex.props(Styles.CancelAndSaveBtnContainer)}>
+          <button
+            type="button"
+            onClick={handleClickCancel}
+            {...stylex.props(BtnStyles.CommonBtn, BtnStyles.Cancel, Typography.SubTextLargeMedium)}
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={handleClickSave}
+            {...stylex.props(BtnStyles.CommonBtn, BtnStyles.Save, Typography.SubTextLargeMedium)}
+          >
+            저장
           </button>
         </div>
       </div>
 
-      <Calendar
-        onChange={handleChangeDate}
-        value={new Date(year, month - 1, day)} // month는 0~11까지라서 -1을 해줌.
-        showNavigation={false}
-        formatDay={handleFormatDay}
-        formatShortWeekday={handleFormatShortWeekday} // 요일을 표현하는 방식 커스텀
-        locale="en-GB"
-        activeStartDate={new Date(year, month - 1, day)} // month는 0~11까지라서 -1을 해줌.
-        calendarType="gregory" // 일주일의 시작이 sun으로 시작되게 수정
-        tileClassName="mini-calendar-title"
-        className="mini-calendar"
+      {/* wheel로 날짜를 선택하는 컴포넌트  */}
+      <DateWheelPicker
+        isOpen={isDateWheelPickerOpen}
+        onClose={handleClickDateWheelPicker}
+        defaultValue={{ year: `${year}`, month: `${month}`, day: `${day}` }}
+        onSelect={handleSelectDateWheelPicker}
       />
-      <div {...stylex.props(Styles.CancelAndSaveBtnContainer)}>
-        <button
-          type="button"
-          onClick={handleClickCancel}
-          {...stylex.props(BtnStyles.CommonBtn, BtnStyles.Cancel, Typography.SubTextLargeMedium)}
-        >
-          취소
-        </button>
-        <button
-          type="button"
-          onClick={handleClickSave}
-          {...stylex.props(BtnStyles.CommonBtn, BtnStyles.Save, Typography.SubTextLargeMedium)}
-        >
-          저장
-        </button>
-      </div>
-    </div>
+    </>
   );
 };
 

--- a/src/features/booking/components/BookingDatePicker/index.tsx
+++ b/src/features/booking/components/BookingDatePicker/index.tsx
@@ -62,7 +62,7 @@ const Styles = stylex.create({
   Wrapper: {
     width: '150px',
     position: 'relative',
-    zIndex: 1,
+    zIndex: 2,
   },
   dateText: {
     color: colors.gray60,

--- a/src/features/booking/components/BookingDatePicker/index.tsx
+++ b/src/features/booking/components/BookingDatePicker/index.tsx
@@ -25,19 +25,6 @@ const BookingDatePicker = () => {
     setIsCalendarOpen(true);
   };
 
-  const handleClickOutside = ({ target }) => {
-    if (!calendarRef.current.contains(target)) {
-      setIsCalendarOpen(false);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener('click', handleClickOutside);
-    return () => {
-      window.removeEventListener('click', handleClickOutside);
-    };
-  }, []);
-
   const handleCloseCalendar = (status: boolean) => {
     setIsCalendarOpen(status);
   };

--- a/src/features/calendar/components/DateWheelPicker/index.tsx
+++ b/src/features/calendar/components/DateWheelPicker/index.tsx
@@ -109,6 +109,8 @@ const Styles = stylex.create({
   container: {
     width: '208px',
     background: colors.white500,
+    borderRadius: '4px',
+    border: `1px solid ${colors.gray40}`,
   },
   selectDateWrapper: {
     color: colors.red500,

--- a/src/features/calendar/components/DateWheelPicker/index.tsx
+++ b/src/features/calendar/components/DateWheelPicker/index.tsx
@@ -1,0 +1,146 @@
+import Modal from '@src/components/ui/Modal';
+import React, { FC, useState } from 'react';
+import stylex from '@stylexjs/stylex';
+import dayjs from 'dayjs';
+import Picker from 'react-mobile-picker';
+import { colors, Typography } from '../../../../../public/styles/vars.stylex';
+
+type PickerType = { year: string; month: string; day: string };
+
+interface DateWheelPickerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (date: PickerType) => void;
+  defaultValue: PickerType;
+}
+
+const selections = {
+  year: Array(50)
+    .fill(2024)
+    .map((value, index) => String(value + index)),
+  month: Array(12)
+    .fill(0)
+    .map((_, index) => String(index + 1)),
+  day: Array(31)
+    .fill(0)
+    .map((_, index) => String(index + 1)),
+};
+
+/**
+ * Wheel 형태로 날짜를 선택하는 Picker
+ */
+const DateWheelPicker: FC<DateWheelPickerProps> = (props) => {
+  const { isOpen, onClose, onSelect, defaultValue } = props;
+  console.log({ defaultValue }, dayjs(`${defaultValue.year}.${defaultValue.month}.${defaultValue.day}}`));
+  const todayDate = dayjs(`${defaultValue.year}-${defaultValue.month}-${defaultValue.day}`).format(
+    'YYYY년 M월 D일 ddd요일'
+  );
+  const [pickerValue, setPickerValue] = useState({
+    year: `${defaultValue.year}`,
+    month: `${defaultValue.month}`,
+    day: `${defaultValue.day}`,
+  });
+
+  const handleChangePicker = (data) => {
+    setPickerValue(data);
+  };
+
+  const handleClickCancel = () => {
+    onClose();
+  };
+
+  const handleClickOk = () => {
+    onSelect(pickerValue);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen}>
+      <div {...stylex.props(Styles.container)}>
+        <div {...stylex.props(Typography.TextSmallMedium, Styles.selectDateWrapper)}>{todayDate}</div>
+        <div {...stylex.props(Styles.pickerContainer)}>
+          {/* 날짜 선택 Picker */}
+          {Object.keys(selections).map((name) => (
+            <Picker value={pickerValue} onChange={handleChangePicker} height={120} style={{ width: '55px' }}>
+              <Picker.Column key={name} name={name}>
+                {selections[name].map((option) => (
+                  <Picker.Item key={option} value={option}>
+                    {({ selected }) => (
+                      // 선택된 아이템인지 체크하여 스타일 적용
+                      <div
+                        {...stylex.props(
+                          Typography.TextSmallMedium,
+                          selected ? Styles.selectedPickerItemWrapper : Styles.primaryPickerItemWrapper
+                        )}
+                      >
+                        {option}
+                      </div>
+                    )}
+                  </Picker.Item>
+                ))}
+              </Picker.Column>
+            </Picker>
+          ))}
+        </div>
+        <div {...stylex.props(Styles.btnContainer)}>
+          <button
+            type="button"
+            onClick={handleClickCancel}
+            {...stylex.props(Styles.primaryBtn, Typography.TextSmallRegular, Styles.cancelBtn)}
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={handleClickOk}
+            {...stylex.props(Styles.primaryBtn, Typography.TextSmallRegular)}
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default DateWheelPicker;
+
+const Styles = stylex.create({
+  container: {
+    width: '208px',
+    background: colors.white500,
+  },
+  selectDateWrapper: {
+    color: colors.red500,
+    borderBottom: `1px solid ${colors.red500}`,
+    padding: '8px 16px',
+    textAlign: 'center',
+  },
+  pickerContainer: {
+    width: '100%',
+    padding: '0 32px',
+    gap: '8px',
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  selectedPickerItemWrapper: {
+    color: colors.black400,
+  },
+  primaryPickerItemWrapper: {
+    color: colors.gray40,
+  },
+  btnContainer: {
+    display: 'flex',
+    borderTop: `1px solid ${colors.gray40}`,
+    borderRadius: '0 0 4px 4px',
+  },
+  primaryBtn: {
+    width: '100%',
+    padding: '12px 4px',
+    borderRadius: '4px',
+  },
+  cancelBtn: {
+    borderRight: `1px solid ${colors.gray40}`,
+    borderRadius: '4px',
+  },
+});

--- a/src/pages/booking.tsx
+++ b/src/pages/booking.tsx
@@ -13,7 +13,7 @@ import Radio from '@src/components/ui/Radio';
 import BookingAutoCompleteSelect from '@src/features/booking/components/BookingAutoCompleteSelect';
 import MainLayout from '@src/layouts/MainLayout';
 import BookingTextarea from '@src/features/booking/components/BookingTextarea';
-import useTextArea from '@src/hooks/useTextarea';
+import useTextArea from '@src/hooks/useTextArea';
 
 const Booking = () => {
   const [meetingTitle, handleMeetingTitle] = useInput<string>('');


### PR DESCRIPTION
# 작업 내용
- 아이폰 SE에서도 미니 캘린더를 사용할 수 있도록 미니 캘린더 사이즈 조절
   - 요일과 일자 간격 조절함.
- react-mobile-picker를 사용하여 미니 캘린더에서 년월 부분 클릭했을 때, 직접만든 DateWheelPicker가 나타나게 구현
- 미니 캘린더가 오픈된 직후 날짜를 바로 선택했을 떄, 한 달전 날짜로 표시되는 문제 해결
   - month 및 date 계산 오류가 있었음. month는 0-11 기준으로 12개월이 표현되는데, 해당값 그대로 '월'이 표현되고 있어서 한 달전 날짜로 보여졌고, 일자는 date 대신에 요일인 day 값으로 날짜가 계산되고 있었음.