### PR TITLE
Feat(3TS-7): 예약하기의 참석자 선택 컴포넌트에 멤버 리스트 로드 API 연결 및 선택된 멤버를 표현하는 코드 일부 수정

### DIFF
--- a/src/features/booking/components/BookingAutoCompleteSelect/SearchInput/index.tsx
+++ b/src/features/booking/components/BookingAutoCompleteSelect/SearchInput/index.tsx
@@ -4,19 +4,24 @@ import { Shadows, Typography, colors } from '../../../../../../public/styles/var
 import SearchOutlined from '@src/components/icons/SearchOutlined';
 import CheckmarkOutlined from '@src/components/icons/CheckmarkOutlined';
 import { AutoCompleteItemInfo } from '@src/features/booking/types';
+import useGetMemberListQuery from '@src/features/booking/queries/useGetMemberListQuery';
+import useDebounce from '@src/hooks/useDebounce';
+import ProfileImg from '@src/components/ui/ProfileImg';
 
 type SearchInputProps = {
   onSelect: (valArr: any[]) => void;
   placeholder: string;
   columnItem: AutoCompleteItemInfo;
-  data: any;
+  defaultValue: any[];
 };
 
 const SearchInput: FC<SearchInputProps> = (props) => {
-  const { onSelect, placeholder, columnItem, data } = props;
+  const { onSelect, placeholder, columnItem, defaultValue } = props;
   const [keyword, setKeyword] = useState<string>('');
-  const [selectedKeywordList, setSelectedKeywordList] = useState<any[]>([]);
+  const debounceKeyword = useDebounce(keyword);
+  const [selectedKeywordList, setSelectedKeywordList] = useState<any[]>(defaultValue);
   const [unselectedKeywordList, setUnselectedKeywordList] = useState<any[]>([]);
+  const { data } = useGetMemberListQuery(debounceKeyword);
 
   const handleChangeKeyword = (e) => {
     setKeyword(e.target.value);
@@ -49,8 +54,17 @@ const SearchInput: FC<SearchInputProps> = (props) => {
   };
 
   useEffect(() => {
-    setUnselectedKeywordList(data);
-  }, []);
+    if (selectedKeywordList.length === 0) {
+      // 선택한 리스트 값이 없을 때, 선택하지 않은 값 리스트에 전체 멤버 리스트 삽입
+      setUnselectedKeywordList(data?.memberList);
+    } else {
+      // 선택한 리스트 값이 있을 때, 전체 멤버 리스트에서 선택한 멤버 리스트를 제외한 값을 삽입
+      const selectedIdList = selectedKeywordList.map((item) => item.MemberId);
+      const filterUnselectedMemberList = data?.memberList.filter((item) => !selectedIdList.includes(item.MemberId));
+
+      setUnselectedKeywordList(filterUnselectedMemberList);
+    }
+  }, [data?.memberCount]);
 
   return (
     <div {...stylex.props(Styles.container)}>
@@ -65,29 +79,43 @@ const SearchInput: FC<SearchInputProps> = (props) => {
           placeholder={placeholder}
         />
       </div>
+
       {/* 선택 완료된 항목 */}
       {selectedKeywordList.length > 0 && (
         <div {...stylex.props(Styles.itemListContainer, Styles.checkedItemListWrapper)}>
           {selectedKeywordList.map((item) => (
-            <button type="button" {...stylex.props(Styles.itemBtn)} onClick={(e) => handleClickUncheckedItem(e, item)}>
+            <button
+              type="button"
+              key={item.MemberId}
+              {...stylex.props(Styles.itemBtn)}
+              onClick={(e) => handleClickUncheckedItem(e, item)}
+            >
               <div {...stylex.props(Styles.checkedBox)}>
                 <CheckmarkOutlined width={12} height={8} />
               </div>
-              <span {...stylex.props(Typography.TagLargeMedium)}>{item[columnItem.name.dataName]}</span>
+              <div {...stylex.props(Styles.userInfoContainer)}>
+                <ProfileImg size={20} src={item.profileImgUrl} />
+                <span {...stylex.props(Typography.TagLargeMedium)}>{item[columnItem.name.dataName]}</span>
+              </div>
             </button>
           ))}
         </div>
       )}
+
       {/* 미선택 항목 */}
       <div {...stylex.props(Styles.itemListContainer)}>
-        {unselectedKeywordList.map((item) => (
+        {unselectedKeywordList?.map((item) => (
           <button
             type="button"
+            key={item.MemberId}
             {...stylex.props(Styles.itemBtn, Typography.TagLargeMedium)}
             onClick={(e) => handleClickCheckedItem(e, item)}
           >
             <div {...stylex.props(Styles.uncheckedBox)} />
-            <span {...stylex.props(Typography.TagLargeMedium)}>{item[columnItem.name.dataName]}</span>
+            <div {...stylex.props(Styles.userInfoContainer)}>
+              <ProfileImg size={20} src={item.profileImgUrl} />
+              <span {...stylex.props(Typography.TagLargeMedium)}>{item[columnItem.name.dataName]}</span>
+            </div>
           </button>
         ))}
       </div>
@@ -128,10 +156,16 @@ const Styles = stylex.create({
     border: 'none',
     outline: 'none',
   },
+  userInfoContainer: {
+    display: 'flex',
+    gap: '4px',
+    alignItems: 'center',
+  },
   itemListContainer: {
     paddingTop: '12px',
     display: 'flex',
     gap: '16px',
+    flexDirection: 'column',
   },
   itemBtn: {
     display: 'flex',

--- a/src/features/booking/components/BookingAutoCompleteSelect/index.tsx
+++ b/src/features/booking/components/BookingAutoCompleteSelect/index.tsx
@@ -7,17 +7,15 @@ import { Typography, colors } from '../../../../../public/styles/vars.stylex';
 
 type BookingAutoCompleteSelectProps = {
   defaultValueImgUrl?: string;
-  apiUrl: string;
   onSelect: (value: any) => void;
   replaceSelectedItemsWithImage?: boolean; // 선택된 항목들을 이미지로만 보여줄지 말지 결정하는 함수(ex. 프로필 이미지로만 보여줄지 결정)
   placeholder: string;
   columnItem: AutoCompleteItemInfo;
-  data: any;
 };
 
 const BookingAutoCompleteSelect: FC<BookingAutoCompleteSelectProps> = (props) => {
-  const { defaultValueImgUrl, apiUrl, onSelect, replaceSelectedItemsWithImage, placeholder, columnItem, data } = props;
-  const [selectedItem, setSelectedItem] = useState<any[]>([]);
+  const { defaultValueImgUrl, onSelect, replaceSelectedItemsWithImage, placeholder, columnItem } = props;
+  const [selectedItemList, setSelectedItemList] = useState<any[]>([]);
   const [isOpenAutoCompleteSelect, setIsOpenAutoCompleteSelect] = useState<boolean>(false);
   const autoCompleteRef = useRef<HTMLDivElement>(null);
 
@@ -25,8 +23,9 @@ const BookingAutoCompleteSelect: FC<BookingAutoCompleteSelectProps> = (props) =>
     setIsOpenAutoCompleteSelect(true);
   };
 
-  const handleSelectedKeywordList = (value: any[]) => {
-    setSelectedItem(value);
+  const handleSelectedKeywordList = (list: any[]) => {
+    setSelectedItemList(list);
+    onSelect(list);
   };
 
   const handleClickOutside = ({ target }) => {
@@ -44,19 +43,23 @@ const BookingAutoCompleteSelect: FC<BookingAutoCompleteSelectProps> = (props) =>
 
   return (
     <div {...stylex.props(Styles.autoCompleteSelect)} ref={autoCompleteRef}>
-      {selectedItem.length ? (
+      {/* 선택된 참가자 목록을 밖에서 보여주는 영역 */}
+      {selectedItemList.length ? (
         <>
           {replaceSelectedItemsWithImage ? (
-            <div>
-              {selectedItem.map((item) => (
-                <button type="button">
-                  <ProfileImg src={item.href} size={32} />
+            <div {...stylex.props(Styles.selectedItemContainer)}>
+              {selectedItemList.map((item) => (
+                <button type="button" onClick={handleClickItem}>
+                  <div {...stylex.props(Styles.userInfoContainer)}>
+                    <ProfileImg src={item.profileImgUrl} size={20} />
+                    <span {...stylex.props(Typography.TagLargeMedium)}>{item.displayName}</span>
+                  </div>
                 </button>
               ))}
             </div>
           ) : (
             <div {...stylex.props(Styles.selectedItemContainer)}>
-              {selectedItem.map((item) => (
+              {selectedItemList.map((item) => (
                 <button type="button" onClick={handleClickItem}>
                   <span {...stylex.props(Styles.selectedItemName, Typography.TextSmallRegular)}>{item.teamName}</span>
                 </button>
@@ -73,12 +76,14 @@ const BookingAutoCompleteSelect: FC<BookingAutoCompleteSelectProps> = (props) =>
           )}
         </button>
       )}
+
+      {/* 참석자 검색 및 선택 */}
       {isOpenAutoCompleteSelect && (
         <SearchInput
           onSelect={handleSelectedKeywordList}
           placeholder={placeholder}
           columnItem={columnItem}
-          data={selectedItem}
+          defaultValue={selectedItemList}
         />
       )}
     </div>
@@ -94,7 +99,7 @@ const Styles = stylex.create({
   },
   selectedItemContainer: {
     display: 'flex',
-    gap: '16px',
+    gap: '6px',
   },
   selectedItemName: {
     color: colors.black500,
@@ -108,5 +113,10 @@ const Styles = stylex.create({
     background: colors.gray60,
     borderRadius: '50%',
     color: colors.white500,
+  },
+  userInfoContainer: {
+    display: 'flex',
+    gap: '4px',
+    alignItems: 'center',
   },
 });

--- a/src/features/booking/queries/useGetMemberListQuery.tsx
+++ b/src/features/booking/queries/useGetMemberListQuery.tsx
@@ -1,0 +1,52 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+interface MemberListInfo {
+  success: boolean;
+  code: number;
+  memberList: {
+    MemberId: number;
+    displayName: string;
+    profileImgUrl: string;
+    position: string;
+    isAdmin: boolean;
+    email: string;
+    teamInfo: {
+      TeamId: number;
+      teamName: string;
+    };
+  }[];
+  memberCount: number;
+}
+
+const getMemberListApi = async (WorkspaceId: number, skeywd: string = ''): Promise<MemberListInfo> => {
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/member`, { params: { skeywd } });
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 멤버를 불러오는 커스텀 훅
+ * @param skeywd 검색어
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 멤버 리스트 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useGetMemberListQuery = (skeywd: string) => {
+  const { data } = useGetWorkspaceListQuery();
+  const WorkspaceId = data?.workspaceList[0].WorkspaceId;
+
+  const result = useQuery({
+    queryKey: ['memberList', skeywd],
+    queryFn: () => getMemberListApi(WorkspaceId, skeywd),
+    enabled: Boolean(WorkspaceId), // WorkspaceId가 정의되어 있지 않은 경우, 첫 렌더링시 요청이 이뤄지지 않게 함.
+  });
+
+  return result;
+};
+
+export default useGetMemberListQuery;

--- a/src/hooks/useDebounce.tsx
+++ b/src/hooks/useDebounce.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * debounce를 적용시킨 value를 반환하는 커스텀 훅
+ * @param value debounce를 적용시킬 값
+ * @param delay 지연 시간 설정(기본값 500ms)
+ * @returns
+ */
+function useDebounce(value: string, delay: number = 500) {
+  const [debounceValue, setDebounceValue] = useState<string>(value);
+  const korEngNumRegex = /^[ㄱ-ㅎ가-힣a-zA-Z0-9\s]*$/; // 한글, 영어, 숫자 체크 정규식
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      // 입력한 글자가 한글, 영어, 숫자가 아닌 경우에 값 저장 안함
+      if (!korEngNumRegex.test(value)) {
+        return null;
+      }
+
+      setDebounceValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debounceValue;
+}
+
+export default useDebounce;

--- a/src/pages/booking.tsx
+++ b/src/pages/booking.tsx
@@ -134,15 +134,6 @@ const Booking = () => {
             )}
           </div>
         </BookingFormItem>
-        <BookingFormItem label="팀" required>
-          <BookingAutoCompleteSelect
-            placeholder="참석팀 검색"
-            columnItem={columnItem}
-            data={dummyList}
-            apiUrl={`/v1/workspace/@{wid}/team`}
-            onSelect={handleSelectTeam}
-          />
-        </BookingFormItem>
         <BookingFormItem label="참석자" required>
           <BookingAutoCompleteSelect
             placeholder="참석자 검색"


### PR DESCRIPTION
# 작업 내용
- 회의 예약 폼에서 팀 선택 항목 제거
- React-query를 사용하여 참여한 워크스페이스 멤버를 불러오는 커스텀 훅 구현
   - 멤버 검색을 할 때 입력하는 즉시 바로 멤버를 불러오도록 계속 api를 요청하면 서버에 과부하가 걸릴 수 있기 때문에 debounce 훅을 구현해서 api 요청이 가도록 함
- 참석자 선택 및 자동완성 컴포넌트에 멤버 리스트 API 연결 및 선택한 멤버 리스트가 잘 표현되도록 일부 코드를 수정