### PR TITLE
Feat(3TS-29): 마이페이지 홈 화면에서 보여지는 기능 구현 및 api 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "next": "^14.0.4",
         "react": "^18.2.0",
         "react-calendar": "^5.0.0",
+        "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.2.0",
         "react-mobile-picker": "^1.0.1",
         "react-redux": "^9.1.0",
@@ -7206,6 +7207,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-copy-to-clipboard": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
+      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+      "dependencies": {
+        "copy-to-clipboard": "^3.3.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || 16 || 17 || 18"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "^14.0.4",
     "react": "^18.2.0",
     "react-calendar": "^5.0.0",
+    "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "react-mobile-picker": "^1.0.1",
     "react-redux": "^9.1.0",

--- a/src/components/icons/AddOutlined.tsx
+++ b/src/components/icons/AddOutlined.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const AddOutlined: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <path
+        stroke="#242C33"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.8}
+        d="M12 8v8m-4-4h8m-8.2 9h8.4c1.68 0 2.52 0 3.162-.327a3 3 0 0 0 1.311-1.311C21 18.72 21 17.88 21 16.2V7.8c0-1.68 0-2.52-.327-3.162a3 3 0 0 0-1.311-1.311C18.72 3 17.88 3 16.2 3H7.8c-1.68 0-2.52 0-3.162.327a3 3 0 0 0-1.311 1.311C3 5.28 3 6.12 3 7.8v8.4c0 1.68 0 2.52.327 3.162a3 3 0 0 0 1.311 1.311C5.28 21 6.12 21 7.8 21"
+      />
+    </svg>
+  );
+};
+export default AddOutlined;

--- a/src/components/icons/CopyOutlined.tsx
+++ b/src/components/icons/CopyOutlined.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const CopyOutlined: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <path
+        stroke="#61686D"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M7.5 3h7.1c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C21 6.04 21 7.16 21 9.4v7.1M6.2 21h8.1c1.12 0 1.68 0 2.108-.218a2 2 0 0 0 .874-.874c.218-.428.218-.988.218-2.108V9.7c0-1.12 0-1.68-.218-2.108a2 2 0 0 0-.874-.874C15.98 6.5 15.42 6.5 14.3 6.5H6.2c-1.12 0-1.68 0-2.108.218a2 2 0 0 0-.874.874C3 8.02 3 8.58 3 9.7v8.1c0 1.12 0 1.68.218 2.108a2 2 0 0 0 .874.874C4.52 21 5.08 21 6.2 21"
+      />
+    </svg>
+  );
+};
+export default CopyOutlined;

--- a/src/components/icons/EntranceOutlined.tsx
+++ b/src/components/icons/EntranceOutlined.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const EntranceOutlined: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <path
+        stroke="#242C33"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.8}
+        d="m16 17 5-5m0 0-5-5m5 5H9m0-9H7.8c-1.68 0-2.52 0-3.162.327a3 3 0 0 0-1.311 1.311C3 5.28 3 6.12 3 7.8v8.4c0 1.68 0 2.52.327 3.162a3 3 0 0 0 1.311 1.311C5.28 21 6.12 21 7.8 21H9"
+      />
+    </svg>
+  );
+};
+export default EntranceOutlined;

--- a/src/components/ui/Modal/confirm/index.tsx
+++ b/src/components/ui/Modal/confirm/index.tsx
@@ -16,7 +16,7 @@ interface ConfirmModalProps {
   cancelBtnName?: string;
 }
 
-const ConfirmModal: FC<ModalProps & ConfirmModalProps> = (props) => {
+const ConfirmModal: FC<ConfirmModalProps> = (props) => {
   const { content, onOk, onCancel, okBtnName, cancelBtnName } = props;
 
   /**
@@ -81,7 +81,7 @@ const ConfirmModal: FC<ModalProps & ConfirmModalProps> = (props) => {
   );
 };
 
-const confirm = (props) => {
+const confirm = (props: ConfirmModalProps) => {
   // body 태그에 div 태그를 추가하여 모달 띄우기
   const divElement = document.createElement('div');
   divElement.id = confirmModalId;
@@ -95,7 +95,7 @@ export { confirm };
 
 const Styles = stylex.create({
   container: {
-    minWidth: '300px',
+    maxWidth: '300px',
     width: '100%',
     padding: '24px 16px',
     background: colors.white500,

--- a/src/features/home/queries/useGetWorkspaceMainInfoQuery.tsx
+++ b/src/features/home/queries/useGetWorkspaceMainInfoQuery.tsx
@@ -33,7 +33,7 @@ const getWorkspaceInfoApi = async (WorkspaceId: number): Promise<WorkspaceInfo> 
  */
 const useGetWorkspaceMainInfoQuery = () => {
   const { data } = useGetWorkspaceListQuery();
-  const workspaceId = data?.workspaceList[0].WorkspaceId;
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
 
   const result = useQuery({
     queryKey: ['workspaceInfo', workspaceId],
@@ -48,7 +48,7 @@ const useGetWorkspaceMainInfoQuery = () => {
       },
       workspaceCongressStatus: { workspaceCongressCount: 0, myCongressCount: 0 },
     },
-    enabled: Boolean(workspaceId), // InviteId가 정의되어 있지 않은 경우, 첫 렌더링시 요청이 이뤄지지 않게 함.
+    enabled: Boolean(workspaceId), // workspaceId가 정의되어 있지 않은 경우, 첫 렌더링시 요청이 이뤄지지 않게 함.
   });
 
   return result;

--- a/src/features/mypage/compontents/MyPageInviteModal/index.tsx
+++ b/src/features/mypage/compontents/MyPageInviteModal/index.tsx
@@ -1,0 +1,79 @@
+import React, { FC } from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import stylex from '@stylexjs/stylex';
+import Modal from '@src/components/ui/Modal';
+import usePostInviteCodeQuery from '../../queries/usePostInviteCodeQuery';
+import CopyOutlined from '@src/components/icons/CopyOutlined';
+import { colors, Typography } from '../../../../../public/styles/vars.stylex';
+
+interface MyPageInviteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * 마이페이지 멤버 초대 모달 컴포넌트
+ */
+const MyPageInviteModal: FC<MyPageInviteModalProps> = (props) => {
+  const { isOpen, onClose } = props;
+  const { data } = usePostInviteCodeQuery();
+  const copyUrl = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/invite?InviteId=${data?.inviteInfo.InviteId}`;
+
+  const handleClickClose = () => {
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen}>
+      <div {...stylex.props(Styles.Container)}>
+        <p {...stylex.props(Typography.SubTextLargeRegular)}>함께할 멤버를 초대해 보세요.</p>
+        <div {...stylex.props(Styles.CopyTextContainer)}>
+          <input
+            type="text"
+            readOnly
+            {...stylex.props(Typography.SubTextLargeRegular, Styles.CopyTextInput)}
+            value={copyUrl}
+          />
+          {/* 복사 버튼 */}
+          <CopyToClipboard text={copyUrl}>
+            <button>
+              <CopyOutlined width={24} height={24} />
+            </button>
+          </CopyToClipboard>
+        </div>
+
+        {/* 닫기 */}
+        <button type="button" onClick={handleClickClose} {...stylex.props(Typography.SubTextLargeSemiBold)}>
+          닫기
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default MyPageInviteModal;
+
+const Styles = stylex.create({
+  Container: {
+    width: '300px',
+    padding: '24px 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    background: colors.white500,
+    borderRadius: '16px',
+  },
+  CopyTextContainer: {
+    margin: '12px 0 16px',
+    padding: '12px 16px',
+    display: 'flex',
+    gap: '8px',
+    border: `1px solid ${colors.gray40}`,
+    borderRadius: '8px',
+  },
+  CopyTextInput: {
+    border: 'none',
+    outline: 'none',
+    color: '#666666',
+  },
+});

--- a/src/features/mypage/compontents/MypageMenu/index.tsx
+++ b/src/features/mypage/compontents/MypageMenu/index.tsx
@@ -18,10 +18,19 @@ const MypageMenu: FC<MypageMenuProps> = (props) => {
       <ul {...stylex.props(Styles.List)}>
         {menuList.map((item) => (
           <li key={item.id} {...stylex.props(Styles.Item)}>
-            <Link href={item.href} {...stylex.props(Styles.MenuLink)}>
-              <span>{item.icon}</span>
-              <span {...stylex.props(Typography.TextSmallMedium)}>{item.name}</span>
-            </Link>
+            {/* onClick으로 메뉴 사용할 때 */}
+            {item.onClick ? (
+              <button type="button" onClick={item.onClick} {...stylex.props(Styles.MenuButton)}>
+                <span>{item.icon}</span>
+                <span {...stylex.props(Typography.TextSmallMedium)}>{item.name}</span>
+              </button>
+            ) : (
+              // 메뉴 클릭시 링크 이동할 때
+              <Link href={item.href} {...stylex.props(Styles.MenuLink)}>
+                <span>{item.icon}</span>
+                <span {...stylex.props(Typography.TextSmallMedium)}>{item.name}</span>
+              </Link>
+            )}
           </li>
         ))}
       </ul>
@@ -49,5 +58,12 @@ const Styles = stylex.create({
     alignItems: 'center',
     textDecoration: 'none',
     color: colors.black400,
+  },
+  MenuButton: {
+    width: '100%',
+    display: 'flex',
+    gap: '16px',
+    alignItems: 'center',
+    textAlign: 'left',
   },
 });

--- a/src/features/mypage/compontents/MypageMenu/index.type.ts
+++ b/src/features/mypage/compontents/MypageMenu/index.type.ts
@@ -2,5 +2,6 @@ export type MenuListType = {
   id: number;
   name: string;
   icon: React.JSX.Element;
-  href: string;
+  href?: string;
+  onClick?: (e: React.MouseEvent) => void;
 }[];

--- a/src/features/mypage/compontents/MypageSummaryProfile/index.tsx
+++ b/src/features/mypage/compontents/MypageSummaryProfile/index.tsx
@@ -4,16 +4,19 @@ import ProfileImg from '@src/components/ui/ProfileImg';
 import { Typography, colors } from '../../../../../public/styles/vars.stylex';
 import ArrowHeadOutlinedV2 from '@src/components/icons/ArrowHeadOutlinedV2';
 import Link from 'next/link';
+import useGetMypageInfoQuery from '../../queries/useGetMypageInfoQuery';
 
 const MypageSummaryProfile = () => {
+  const { data } = useGetMypageInfoQuery();
+
   return (
     <div {...stylex.props(Styles.Container)}>
       <Link href="/mypage/profile" {...stylex.props(Styles.ProfileLink)} passHref>
-        <ProfileImg src={null} size={60} />
+        <ProfileImg src={data?.myInfo.profileImgUrl} size={60} />
         <div {...stylex.props(Styles.UserInfoContainer)}>
           <div>
-            <p {...stylex.props(Styles.NameText, Typography.SubTextRegularBold)}>이나현</p>
-            <p {...stylex.props(Styles.emailText, Typography.SubTextLargeRegular)}>abc@naver.com</p>
+            <p {...stylex.props(Styles.NameText, Typography.SubTextRegularBold)}>{data?.myInfo.displayName}</p>
+            <p {...stylex.props(Styles.emailText, Typography.SubTextLargeRegular)}>{data?.myInfo.email}</p>
           </div>
           <ArrowHeadOutlinedV2 width={24} height={24} color={colors.gray60} />
         </div>

--- a/src/features/mypage/queries/useGetMypageInfoQuery.tsx
+++ b/src/features/mypage/queries/useGetMypageInfoQuery.tsx
@@ -1,0 +1,50 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+interface MypageInfo {
+  myInfo: {
+    MemberId: number;
+    displayName: string;
+    profileImgUrl: string;
+    position: string;
+    isAdmin: boolean;
+    email: string;
+    teamInfo: {
+      TeamId: number;
+      teamName: string;
+    };
+  };
+}
+
+const getMypageInfoApi = async (WorkspaceId: number): Promise<MypageInfo> => {
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/mypage/info`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 내 정보를 가져오는 커스텀 훅
+ * 자주 사용되는 훅이라서 gcTime을 설정함.
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 내 정보 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useGetMypageInfoQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const workspaceId = data?.workspaceList[0].WorkspaceId;
+
+  const result = useQuery({
+    queryKey: ['mypageInfo'],
+    queryFn: () => getMypageInfoApi(workspaceId),
+    gcTime: 3 * 60 * 1000,
+    enabled: Boolean(workspaceId),
+  });
+
+  return result;
+};
+
+export default useGetMypageInfoQuery;

--- a/src/features/mypage/queries/useGetMypageInfoQuery.tsx
+++ b/src/features/mypage/queries/useGetMypageInfoQuery.tsx
@@ -35,7 +35,7 @@ const getMypageInfoApi = async (WorkspaceId: number): Promise<MypageInfo> => {
  */
 const useGetMypageInfoQuery = () => {
   const { data } = useGetWorkspaceListQuery();
-  const workspaceId = data?.workspaceList[0].WorkspaceId;
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
 
   const result = useQuery({
     queryKey: ['mypageInfo'],

--- a/src/features/mypage/queries/usePostInviteCodeQuery.tsx
+++ b/src/features/mypage/queries/usePostInviteCodeQuery.tsx
@@ -26,7 +26,7 @@ const postInviteCodeApi = async (WorkspaceId: number): Promise<InviteCodeInfo> =
  */
 const usePostInviteCodeQuery = () => {
   const { data } = useGetWorkspaceListQuery();
-  const workspaceId = data?.workspaceList[0].WorkspaceId;
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
 
   const result = useQuery({
     queryKey: ['inviteCode'],

--- a/src/features/mypage/queries/usePostInviteCodeQuery.tsx
+++ b/src/features/mypage/queries/usePostInviteCodeQuery.tsx
@@ -1,0 +1,41 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+interface InviteCodeInfo {
+  inviteInfo: {
+    InviteId: string;
+  };
+}
+
+const postInviteCodeApi = async (WorkspaceId: number): Promise<InviteCodeInfo> => {
+  const response = await clientInstance.post(`/v1/workspace/@${WorkspaceId}/invite`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 초대 코드를 생성하는 커스텀 훅
+ * 자주 사용되는 훅이라서 gcTime을 설정함.
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 생성된 초대 코드 정본 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const usePostInviteCodeQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const workspaceId = data?.workspaceList[0].WorkspaceId;
+
+  const result = useQuery({
+    queryKey: ['inviteCode'],
+    queryFn: () => postInviteCodeApi(workspaceId),
+    gcTime: 60 * 60 * 1000,
+    enabled: Boolean(workspaceId),
+  });
+
+  return result;
+};
+
+export default usePostInviteCodeQuery;

--- a/src/pages/mypage/create-workspace.tsx
+++ b/src/pages/mypage/create-workspace.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import stylex from '@stylexjs/stylex';
+import MainLayout from '@src/layouts/MainLayout';
+import RoomletTextLogo from '@src/components/logos/text';
+import { colors, Typography } from '../../../public/styles/vars.stylex';
+import Input from '@src/components/ui/Input';
+import useInput from '@src/hooks/useInput';
+import Button from '@src/components/ui/Button';
+import usePostWorkspaceJoinQuery from '@src/features/invite/queries/usePostWorkspaceJoinQuery';
+
+const CreateWorkspace = () => {
+  const [workspaceName, handleChangeWorkspaceName] = useInput('');
+  const mutation = usePostWorkspaceJoinQuery();
+  const router = useRouter();
+  const letterImgUrl = 'https://roomlet.s3.ap-northeast-2.amazonaws.com/public/images/mypage/create-workspace.png';
+
+  const handleClickCreate = () => {
+    // mutation.mutate({
+    //   WorkspaceId: data.inviteInfo.workspace.WorkspaceId,
+    //   joinInfo: { workspaceName, InviteId: data.inviteInfo.InviteId },
+    // });
+  };
+
+  const handleClickDenyCreate = () => {
+    router.push('/');
+  };
+
+  return (
+    <MainLayout isScroll>
+      <div {...stylex.props(Styles.Container)}>
+        <div {...stylex.props(Styles.logoAndInfoWrapper)}>
+          <div {...stylex.props(Styles.logoAndInfoContainer)}>
+            {/* 룸렛 텍스트 로고 */}
+            <div className="logo-wrapper" {...stylex.props(Styles.logoWrapper)}>
+              <RoomletTextLogo width={164} height={24} />
+            </div>
+
+            {/* 초대 내용 */}
+            <div {...stylex.props(Typography.M3BodyLarge)}>
+              <img src={letterImgUrl} alt="메세지 이미지" {...stylex.props(Styles.letterImg)} />
+              <div {...stylex.props(Styles.contentWrapper, Typography.M3BodyLarge)}>
+                룸렛에서 워크스페이스를 만들어 <br />
+                함께 회의를 준비해보세요.
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="" {...stylex.props(Styles.formContainer)}>
+          {/* 닉네임 */}
+          <Input
+            onChange={handleChangeWorkspaceName}
+            value={workspaceName}
+            placeholder="사용하실 워크스페이스 명을 입력 해 주세요."
+          />
+
+          {/* 생성하기 및 생성하지 않기 버튼 */}
+          <Button type="button" onClick={handleClickCreate}>
+            생성하기
+          </Button>
+          <button
+            type="button"
+            onClick={handleClickDenyCreate}
+            {...stylex.props(Styles.dontParticipateButton, Typography.M3BodyLarge)}
+          >
+            생성하지 않기
+          </button>
+        </div>
+      </div>
+    </MainLayout>
+  );
+};
+
+export default CreateWorkspace;
+
+const Styles = stylex.create({
+  Container: {
+    display: 'flex',
+    height: '100%',
+    justifyContent: 'space-between',
+    flexDirection: 'column',
+  },
+  logoAndInfoWrapper: {
+    width: '100%',
+    paddingTop: '86px',
+    margin: '0 auto',
+  },
+  logoAndInfoContainer: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignContent: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+  },
+  logoWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: '56px',
+  },
+  letterImg: {
+    margin: '0 auto',
+    marginBottom: '52px',
+    width: '220px',
+    height: '189px',
+  },
+  contentWrapper: {
+    marginBottom: '75px',
+    textAlign: 'center',
+  },
+  formContainer: {
+    width: '100%',
+    padding: '16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+  dontParticipateButton: {
+    width: '100%',
+    justifySelf: 'center',
+    padding: '14px 12px',
+    background: 'none',
+    color: colors.gray50,
+  },
+});

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -11,9 +11,13 @@ import ExitOutlined from '@src/components/icons/ExitOutlined';
 import BoundaryArea from '@src/components/ui/BoundaryArea';
 import { confirm } from '@src/components/ui/Modal/confirm';
 import MyPageInviteModal from '@src/features/mypage/compontents/MyPageInviteModal';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import AddOutlined from '@src/components/icons/AddOutlined';
+import EntranceOutlined from '@src/components/icons/EntranceOutlined';
 
 const MyPageHome = () => {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
+  const { data } = useGetWorkspaceListQuery();
   const commonUrl = 'mypage';
 
   // 멤버 초대 모달을 열고 닫게하는 함수
@@ -21,36 +25,53 @@ const MyPageHome = () => {
     setIsInviteModalOpen(!isInviteModalOpen);
   };
 
-  const menuList = [
-    {
-      id: 1,
-      name: '워크스페이스 설정',
-      icon: <SettingOutlined width={24} height={24} />,
-      href: `/${commonUrl}/workspace`,
-    },
-    {
-      id: 2,
-      name: '멤버초대',
-      icon: <AddUserOutlined width={24} height={24} />,
-      onClick: () => handleClickInviteModal(),
-    },
-    { id: 4, name: '알림 설정', icon: <BellOutlined width={24} height={24} />, href: `/${commonUrl}/alarm` },
-    {
-      id: 5,
-      name: '워크스페이스 나가기',
-      icon: <ExitOutlined width={24} height={24} />,
-      onClick: () => {
-        confirm({
-          content:
-            '워크스페이스를 나가도 작성된 회의 내용은 남아있어요. 다시 참여를 원하시면 초대 링크를 입력 후 참여 가능합니다.',
-          okBtnName: '나갈래요',
-          onOk: null,
-          cancelBtnName: '유지할래요',
-          onCancel: null,
-        });
-      },
-    },
-  ];
+  const menuList = data?.workspaceCount
+    ? [
+        // 워크 스페이스가 존재하는 경우
+        {
+          id: 1,
+          name: '워크스페이스 설정',
+          icon: <SettingOutlined width={24} height={24} />,
+          href: `/${commonUrl}/workspace`,
+        },
+        {
+          id: 2,
+          name: '멤버초대',
+          icon: <AddUserOutlined width={24} height={24} />,
+          onClick: () => handleClickInviteModal(),
+        },
+        { id: 4, name: '알림 설정', icon: <BellOutlined width={24} height={24} />, href: `/${commonUrl}/alarm` },
+        {
+          id: 5,
+          name: '워크스페이스 나가기',
+          icon: <ExitOutlined width={24} height={24} />,
+          onClick: () => {
+            confirm({
+              content:
+                '워크스페이스를 나가도 작성된 회의 내용은 남아있어요. 다시 참여를 원하시면 초대 링크를 입력 후 참여 가능합니다.',
+              okBtnName: '나갈래요',
+              onOk: null,
+              cancelBtnName: '유지할래요',
+              onCancel: null,
+            });
+          },
+        },
+      ]
+    : [
+        // 워크 스페이스가 존재하지 않는 경우
+        {
+          id: 1,
+          name: '워크스페이스 생성하기',
+          icon: <AddOutlined width={24} height={24} />,
+          href: `/create-workspace`,
+        },
+        {
+          id: 2,
+          name: '워크스페이스 입장하기',
+          icon: <EntranceOutlined width={24} height={24} />,
+          href: `/${commonUrl}/workspace`,
+        },
+      ];
 
   return (
     <>

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -6,10 +6,10 @@ import MypageSummaryProfile from '@src/features/mypage/compontents/MypageSummary
 import MypageMenu from '@src/features/mypage/compontents/MypageMenu';
 import SettingOutlined from '@src/components/icons/SettingOutlined';
 import AddUserOutlined from '@src/components/icons/AddUserOutlined';
-import MegaphoneOutlined from '@src/components/icons/MegaphoneOutlined';
 import BellOutlined from '@src/components/icons/BellOutlined';
 import ExitOutlined from '@src/components/icons/ExitOutlined';
 import BoundaryArea from '@src/components/ui/BoundaryArea';
+import { confirm } from '@src/components/ui/Modal/confirm';
 
 const MyPageHome = () => {
   const commonUrl = 'mypage';
@@ -22,7 +22,22 @@ const MyPageHome = () => {
     },
     { id: 2, name: '멤버초대', icon: <AddUserOutlined width={24} height={24} />, href: '' },
     { id: 4, name: '알림 설정', icon: <BellOutlined width={24} height={24} />, href: `/${commonUrl}/alarm` },
-    { id: 5, name: '워크스페이스 나가기', icon: <ExitOutlined width={24} height={24} />, href: '' },
+    {
+      id: 5,
+      name: '워크스페이스 나가기',
+      icon: <ExitOutlined width={24} height={24} />,
+      onClick: () => {
+        console.log('dd');
+        confirm({
+          content:
+            '워크스페이스를 나가도 작성된 회의 내용은 남아있어요. 다시 참여를 원하시면 초대 링크를 입력 후 참여 가능합니다.',
+          okBtnName: '나갈래요',
+          onOk: null,
+          cancelBtnName: '유지할래요',
+          onCancel: null,
+        });
+      },
+    },
   ];
 
   return (

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Header from '@src/components/ui/Header';
 import GnbNavLayout from '@src/layouts/GnbNavLayout';
 import { colors } from '../.../../../../public/styles/vars.stylex';
@@ -10,9 +10,17 @@ import BellOutlined from '@src/components/icons/BellOutlined';
 import ExitOutlined from '@src/components/icons/ExitOutlined';
 import BoundaryArea from '@src/components/ui/BoundaryArea';
 import { confirm } from '@src/components/ui/Modal/confirm';
+import MyPageInviteModal from '@src/features/mypage/compontents/MyPageInviteModal';
 
 const MyPageHome = () => {
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
   const commonUrl = 'mypage';
+
+  // 멤버 초대 모달을 열고 닫게하는 함수
+  const handleClickInviteModal = () => {
+    setIsInviteModalOpen(!isInviteModalOpen);
+  };
+
   const menuList = [
     {
       id: 1,
@@ -20,14 +28,18 @@ const MyPageHome = () => {
       icon: <SettingOutlined width={24} height={24} />,
       href: `/${commonUrl}/workspace`,
     },
-    { id: 2, name: '멤버초대', icon: <AddUserOutlined width={24} height={24} />, href: '' },
+    {
+      id: 2,
+      name: '멤버초대',
+      icon: <AddUserOutlined width={24} height={24} />,
+      onClick: () => handleClickInviteModal(),
+    },
     { id: 4, name: '알림 설정', icon: <BellOutlined width={24} height={24} />, href: `/${commonUrl}/alarm` },
     {
       id: 5,
       name: '워크스페이스 나가기',
       icon: <ExitOutlined width={24} height={24} />,
       onClick: () => {
-        console.log('dd');
         confirm({
           content:
             '워크스페이스를 나가도 작성된 회의 내용은 남아있어요. 다시 참여를 원하시면 초대 링크를 입력 후 참여 가능합니다.',
@@ -41,17 +53,22 @@ const MyPageHome = () => {
   ];
 
   return (
-    <GnbNavLayout backgroundColor={colors.white500}>
-      <Header title="마이페이지" />
-      {/* 프로필 페이지로 이동 */}
-      <MypageSummaryProfile />
+    <>
+      <GnbNavLayout backgroundColor={colors.white500}>
+        <Header title="마이페이지" />
+        {/* 프로필 페이지로 이동 */}
+        <MypageSummaryProfile />
 
-      {/* 경계선 */}
-      <BoundaryArea />
+        {/* 경계선 */}
+        <BoundaryArea />
 
-      {/* 마이페이지 메뉴 */}
-      <MypageMenu menuList={menuList} />
-    </GnbNavLayout>
+        {/* 마이페이지 메뉴 */}
+        <MypageMenu menuList={menuList} />
+      </GnbNavLayout>
+
+      {/* 멤버 초대 모달 열기 */}
+      <MyPageInviteModal isOpen={isInviteModalOpen} onClose={handleClickInviteModal} />
+    </>
   );
 };
 


### PR DESCRIPTION
# 작업 내용
- 마이페이지 홈 화면에서 보여지는 기능 구현 및 api 연결
  - 워크스페이스가 존재하는 사용자
     - 마이페이지 홈 화면에서 보여지는 프로필에 api 연결
     - 멤버 초대 모달 구현 및 api 연결
        - react-copy-to-clipboard를 사용하여 링크 복사 기능 구현
     - 워크스페이스 나가기 모달 구현
        - api 연결은 추후 작업
  
  - 워크스페이스가 존재하지 않는 사용자 
     - 워크스페이스가 존재하지 않는 사용자에 맞게 메뉴 별도 구성
     - 워크스페이스 생성하기 페이지 구현
         - api 연결은 추후 작업
     - 워크스페이스가 없는 사람에 대한 프로필 api 연결 작업은 추후에 할 예정이라 프로필이 제대로 보이지 않는 이슈가 있음.

# 개선이 필요한 작업
- 초대하기 페이지와 워크스페이스 생성하기 페이지 UI, UX가 동일함. 한 개의 컴포넌트로 서로 다른 2가지를 관리를 할 수 있다면 좋을 것 같은데 추가 기능이 들어갈 여지도 있어서 지켜보고 리팩토링하기

# 트러블 슈팅
- TypeError: getStaticPaths is not a function 에러 발생
   - 문제가 발생한 상황
      - useGetMypageInfoQuery를 호출하니 에러가 발생함.
   - 문제가 발생한 원인
      - 이유는 제대로 파악하지 못함. 원인 분석 후 다시 기록 예정.
   - 해결 방법
      - npm i로 다시 설치하니 문제가 해결됨.
   - 참고
      https://www.reddit.com/r/nextjs/comments/15fci1e/server_error_typeerror_getstaticpaths_is_not_a/?rdt=34140