### PR TITLE
Feat(4TS-32): 회의실 정보 화면 구현 및 API 연결, 회의실 이름 및 설명 수정 기능 구현

### DIFF
--- a/src/components/ui/Header/index.tsx
+++ b/src/components/ui/Header/index.tsx
@@ -29,11 +29,11 @@ const Header: FC<HeaderProps> = (props) => {
       {rightBtnInfo && (
         <button
           type="button"
-          {...(rightBtnInfo.isActive ? { onClick: rightBtnInfo.onClick } : {})}
+          onClick={rightBtnInfo.onClick}
           {...stylex.props(
             Typography.SubTextLargeRegular,
             Styles.rightBtn,
-            rightBtnInfo.isActive ? Styles.isActiveRightBtn : Styles.isInactiveRightBtn
+            rightBtnInfo.isActive && Styles.isActiveRightBtn
           )}
         >
           {rightBtnInfo.name}
@@ -51,6 +51,7 @@ const Styles = stylex.create({
     padding: '16px',
     gap: '16px',
     alignItems: 'center',
+    background: colors.white500,
   },
   withRightBtn: {
     justifyContent: 'space-between',
@@ -61,8 +62,5 @@ const Styles = stylex.create({
   },
   isActiveRightBtn: {
     color: '#3859CE',
-  },
-  isInactiveRightBtn: {
-    cursor: 'not-allowed',
   },
 });

--- a/src/features/mypage/workspace/congress-room/components/CongressRoomCard/index.tsx
+++ b/src/features/mypage/workspace/congress-room/components/CongressRoomCard/index.tsx
@@ -1,25 +1,73 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
 import { CongressRoomInfoItem } from '@src/queries/congress/useGetCongressRoomListQuery';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@src/store';
+import { saveCongressRoomList } from '../../slice/congressRoom';
 
 interface CongressRoomCardProps {
   data: CongressRoomInfoItem;
+  isEdit?: boolean;
 }
 
 /**
- *  회의실 정보에서 보여줄 회의실 카드 컴포넌트
+ *  회의실 정보에서 보여줄 회의실 카드 컴포넌트 (회의실 이름 및 설명 수정 기능 포함)
  */
 const CongressRoomCard: FC<CongressRoomCardProps> = (props) => {
-  const { data } = props;
+  const { data, isEdit } = props;
+  const dispatch = useDispatch();
+  const { editCongressRoomList } = useSelector((state: RootState) => state.congressRoom);
   const meetingRoomCubeImgUrl = `${process.env.NEXT_PUBLIC_S3_URL}/public/images/mypage/meeting-room-cube.png`;
+
+  // 회의실 이름 및 설명값 변경을 다루는 함수
+  const handleChangeData = useCallback(
+    (key: 'roomName' | 'roomDescription') => (e) => {
+      const value = e.target.value;
+      const mappingCongressRoomList = editCongressRoomList.map((item) =>
+        item.RoomId === data.RoomId ? { ...item, [key]: value } : item
+      );
+      const index = editCongressRoomList.findIndex((item) => item.RoomId === data.RoomId);
+
+      if (index === -1) {
+        return null;
+      }
+
+      const updateCongressRoomList = [...editCongressRoomList];
+      updateCongressRoomList[index] = { ...updateCongressRoomList[index], [key]: value };
+
+      dispatch(saveCongressRoomList(mappingCongressRoomList));
+    },
+    [editCongressRoomList, data.RoomId, dispatch]
+  );
 
   return (
     <div {...stylex.props(Styles.Container)}>
       <img src={meetingRoomCubeImgUrl} width={24} height={24} />
       <div {...stylex.props(Styles.InfoContainer)}>
-        <p {...stylex.props(Typography.TextSmallMedium)}>{data?.roomName}</p>
-        <p {...stylex.props(Typography.SubTextLargeMedium)}>{data?.roomDescription}</p>
+        {isEdit ? (
+          // 수정 상태일 때
+          <>
+            <input
+              type="text"
+              value={data.roomName}
+              onChange={handleChangeData('roomName')}
+              {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
+            />
+            <input
+              type="text"
+              value={data.roomDescription}
+              onChange={handleChangeData('roomDescription')}
+              {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
+            />
+          </>
+        ) : (
+          // 수정이 아닌 상태일 때
+          <>
+            <p {...stylex.props(Typography.TextSmallMedium)}>{data?.roomName}</p>
+            <p {...stylex.props(Typography.SubTextLargeMedium)}>{data?.roomDescription}</p>
+          </>
+        )}
       </div>
     </div>
   );
@@ -37,8 +85,15 @@ const Styles = stylex.create({
     background: colors.white500,
   },
   InfoContainer: {
+    width: '100%',
     display: 'flex',
     flexDirection: 'column',
     gap: '12px',
+  },
+  TextInput: {
+    width: '100%',
+    padding: '4px',
+    background: colors.gray20,
+    border: 'none',
   },
 });

--- a/src/features/mypage/workspace/congress-room/components/CongressRoomCard/index.tsx
+++ b/src/features/mypage/workspace/congress-room/components/CongressRoomCard/index.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from 'react';
+import stylex from '@stylexjs/stylex';
+import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
+import { CongressRoomInfoItem } from '@src/queries/congress/useGetCongressRoomListQuery';
+
+interface CongressRoomCardProps {
+  data: CongressRoomInfoItem;
+}
+
+/**
+ *  회의실 정보에서 보여줄 회의실 카드 컴포넌트
+ */
+const CongressRoomCard: FC<CongressRoomCardProps> = (props) => {
+  const { data } = props;
+  const meetingRoomCubeImgUrl = `${process.env.NEXT_PUBLIC_S3_URL}/public/images/mypage/meeting-room-cube.png`;
+
+  return (
+    <div {...stylex.props(Styles.Container)}>
+      <img src={meetingRoomCubeImgUrl} width={24} height={24} />
+      <div {...stylex.props(Styles.InfoContainer)}>
+        <p {...stylex.props(Typography.TextSmallMedium)}>{data?.roomName}</p>
+        <p {...stylex.props(Typography.SubTextLargeMedium)}>{data?.roomDescription}</p>
+      </div>
+    </div>
+  );
+};
+
+export default CongressRoomCard;
+
+const Styles = stylex.create({
+  Container: {
+    padding: '16px',
+    display: 'flex',
+    gap: '12px',
+    border: `1px solid ${colors.gray20}`,
+    borderRadius: '16px',
+    background: colors.white500,
+  },
+  InfoContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+});

--- a/src/features/mypage/workspace/congress-room/slice/congressRoom.ts
+++ b/src/features/mypage/workspace/congress-room/slice/congressRoom.ts
@@ -1,0 +1,27 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { CongressRoomInfoItem } from '@src/queries/congress/useGetCongressRoomListQuery';
+
+export interface CongressRoomState {
+  editCongressRoomList: CongressRoomInfoItem[];
+}
+
+const initialState: CongressRoomState = {
+  // 회의실 리스트 저장
+  editCongressRoomList: null,
+};
+
+export const CongressRoomSlice = createSlice({
+  name: 'congressRoom',
+  initialState,
+  reducers: {
+    // 회의실 리스트 저장
+    saveCongressRoomList: (state, action) => {
+      state.editCongressRoomList = action.payload;
+    },
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const { saveCongressRoomList } = CongressRoomSlice.actions;
+
+export default CongressRoomSlice.reducer;

--- a/src/pages/mypage/workspace/congress-room.tsx
+++ b/src/pages/mypage/workspace/congress-room.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import stylex from '@stylexjs/stylex';
+import GnbNavLayout from '@src/layouts/GnbNavLayout';
+import Header from '@src/components/ui/Header';
+import useGetCongressRoomListQuery from '@src/queries/congress/useGetCongressRoomListQuery';
+import CongressRoomCard from '@src/features/mypage/workspace/congress-room/components/CongressRoomCard';
+import { colors, Typography } from '../../../../public/styles/vars.stylex';
+import { useDispatch, useSelector } from 'react-redux';
+import { saveCongressRoomList } from '@src/features/mypage/workspace/congress-room/slice/congressRoom';
+import { RootState } from '@src/store';
+
+const MeetingRoom = () => {
+  const { data } = useGetCongressRoomListQuery();
+  const dispatch = useDispatch();
+  const { editCongressRoomList } = useSelector((state: RootState) => state.congressRoom);
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+
+  const completeBtnProps = {
+    name: isEdit ? '완료' : '수정',
+    isActive: isEdit,
+    onClick: () => {
+      setIsEdit(!isEdit);
+    },
+  };
+
+  useEffect(() => {
+    if (isEdit) {
+      dispatch(saveCongressRoomList(data.congressRoomList));
+    }
+  }, [isEdit]);
+
+  return (
+    <GnbNavLayout backgroundColor="#FAFAFA">
+      <Header title="회의실" prevUrl="/mypage/workspace" rightBtnInfo={completeBtnProps} />
+
+      {/* 회의실 개수 */}
+      <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
+        전체 회의실 <span {...stylex.props(Styles.Count)}>{data?.congressRoomCount}</span>
+      </div>
+
+      {/* 회의실 목록 */}
+      <div {...stylex.props(Styles.RoomListWrapper)}>
+        {isEdit
+          ? // 수정 상태 일 때
+            editCongressRoomList.map((item) => <CongressRoomCard data={item} isEdit={isEdit} />)
+          : // 수정 상태가 아닐 때
+            data?.congressRoomList.map((item) => <CongressRoomCard data={item} />)}
+      </div>
+    </GnbNavLayout>
+  );
+};
+
+export default MeetingRoom;
+
+const Styles = stylex.create({
+  TotalCountWrapper: {
+    padding: '16px',
+  },
+  RoomListWrapper: {
+    padding: '0 16px',
+    display: 'flex',
+    gap: '12px',
+    flexDirection: 'column',
+  },
+  Count: {
+    color: colors.red500,
+  },
+});

--- a/src/pages/mypage/workspace/congress-room.tsx
+++ b/src/pages/mypage/workspace/congress-room.tsx
@@ -42,7 +42,7 @@ const MeetingRoom = () => {
       <div {...stylex.props(Styles.RoomListWrapper)}>
         {isEdit
           ? // 수정 상태 일 때
-            editCongressRoomList.map((item) => <CongressRoomCard data={item} isEdit={isEdit} />)
+            editCongressRoomList?.map((item) => <CongressRoomCard data={item} isEdit={isEdit} />)
           : // 수정 상태가 아닐 때
             data?.congressRoomList.map((item) => <CongressRoomCard data={item} />)}
       </div>

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -22,7 +22,7 @@ const WorkspaceHome = () => {
       icon: <UserGroupOutlined width={24} height={24} />,
       href: `/${commonUrl}/member`,
     },
-    { id: 2, name: '회의실 정보', icon: <BoxOutlined width={24} height={24} />, href: '' },
+    { id: 2, name: '회의실 정보', icon: <BoxOutlined width={24} height={24} />, href: `/${commonUrl}/congress-room` },
     { id: 3, name: '카테고리 정보', icon: <CategoryGroupOutlined width={24} height={24} />, href: '' },
   ];
 

--- a/src/queries/congress/useGetCongressRoomListQuery.tsx
+++ b/src/queries/congress/useGetCongressRoomListQuery.tsx
@@ -1,0 +1,47 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+export interface CongressRoomInfoItem {
+  RoomId: number;
+  roomName: string;
+  roomDescription: string;
+  roomSize: number;
+}
+
+interface CongressRoomList {
+  success: boolean;
+  code: number;
+  congressRoomList: CongressRoomInfoItem[];
+  congressRoomCount: number;
+}
+
+const getCongressRoomListApi = async (WorkspaceId: number): Promise<CongressRoomList> => {
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/congress/room/list`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 회의실 목록을 불러오는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 회의실 리스트 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useGetCongressRoomListQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const result = useQuery({
+    queryKey: ['roomList'],
+    queryFn: () => getCongressRoomListApi(workspaceId),
+    enabled: Boolean(workspaceId),
+  });
+
+  return result;
+};
+
+export default useGetCongressRoomListQuery;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import onboardingReducer from '@features/onboarding/slices/onboarding';
 import bookingReducer from '@features/booking/slices/booking';
+import congressRoomReducer from '@features/mypage/workspace/congress-room/slice/congressRoom';
 
 export const store = configureStore({
   reducer: {
     onboarding: onboardingReducer,
     booking: bookingReducer,
+    congressRoom: congressRoomReducer,
   },
 });
 


### PR DESCRIPTION
# 작업 내용
- 회의실 정보를 보여주는 페이지 구현
   - 회의실 리스트 로드 API 연결
- 회의실 정보에서 이름과 설명을 수정하는 기능 구현
  - 회의실 수정은 회의실 페이지 코드에서 진행할 예정이기 때문에 리듀서를 사용하여 수정 데이터를 다룸. 
  - 수정 api 연결은 회의실 추가 및 삭제까지 구현 완료한 후에 연결할 예정 