### PR TITLE
Feat(4TS-32): 회의실 제거 기능 구현 및 회의실 수정 API 연결

### DIFF
--- a/src/components/icons/CircleCloseFilled.tsx
+++ b/src/components/icons/CircleCloseFilled.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+const CircleCloseFilled = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg width={width} height={height} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <rect width={24} height={24} fill="#E9E9E9" rx={12} />
+      <path stroke="#969696" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="m16 8-8 8m0-8 8 8" />
+    </svg>
+  );
+};
+
+export default CircleCloseFilled;

--- a/src/components/ui/Modal/confirm/index.tsx
+++ b/src/components/ui/Modal/confirm/index.tsx
@@ -10,8 +10,8 @@ const confirmModalId = 'confirm-modal';
 
 interface ConfirmModalProps {
   content: string;
-  onOk: (e: React.MouseEvent) => void;
-  onCancel: (e: React.MouseEvent) => void;
+  onOk?: (e: React.MouseEvent) => void;
+  onCancel?: (e: React.MouseEvent) => void;
   okBtnName?: string;
   cancelBtnName?: string;
 }

--- a/src/features/mypage/workspace/congress-room/components/CongressRoomCard/index.tsx
+++ b/src/features/mypage/workspace/congress-room/components/CongressRoomCard/index.tsx
@@ -4,10 +4,12 @@ import { colors, Shadows, Typography } from '../../../../../../../public/styles/
 import { CongressRoomInfoItem } from '@src/queries/congress/useGetCongressRoomListQuery';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@src/store';
-import { saveCongressRoomList } from '../../slice/congressRoom';
+import { saveCongressRoomList, tempRemoveCongressRoom } from '../../slice/congressRoom';
+import CircleCloseFilled from '@src/components/icons/CircleCloseFilled';
+import { editCongressRoomItem } from '../../types/congressRoom';
 
 interface CongressRoomCardProps {
-  data: CongressRoomInfoItem;
+  data: editCongressRoomItem;
   isEdit?: boolean;
 }
 
@@ -41,32 +43,45 @@ const CongressRoomCard: FC<CongressRoomCardProps> = (props) => {
     [editCongressRoomList, data.RoomId, dispatch]
   );
 
+  const handleClickTempDelete = () => {
+    dispatch(tempRemoveCongressRoom(data.tempRoomId ? { tempRoomId: data.tempRoomId } : { ...data }));
+  };
+
   return (
     <div {...stylex.props(Styles.Container(isEdit))}>
       <img src={meetingRoomCubeImgUrl} width={24} height={24} />
-      <div {...stylex.props(Styles.InfoContainer)}>
-        {isEdit ? (
-          // 수정 상태일 때
-          <>
-            <input
-              type="text"
-              value={data.roomName}
-              onChange={handleChangeData('roomName')}
-              {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
-            />
-            <input
-              type="text"
-              value={data.roomDescription}
-              onChange={handleChangeData('roomDescription')}
-              {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
-            />
-          </>
-        ) : (
-          // 수정이 아닌 상태일 때
-          <>
-            <p {...stylex.props(Typography.TextSmallMedium)}>{data?.roomName}</p>
-            <p {...stylex.props(Typography.SubTextLargeMedium)}>{data?.roomDescription}</p>
-          </>
+      <div {...stylex.props(Styles.InputAndRemoveContainer)}>
+        <div {...stylex.props(Styles.InfoContainer)}>
+          {isEdit ? (
+            // 수정 상태일 때
+            <>
+              <input
+                type="text"
+                value={data.roomName}
+                onChange={handleChangeData('roomName')}
+                {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
+              />
+              <input
+                type="text"
+                value={data.roomDescription}
+                onChange={handleChangeData('roomDescription')}
+                {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
+              />
+            </>
+          ) : (
+            // 수정이 아닌 상태일 때
+            <>
+              <p {...stylex.props(Typography.TextSmallMedium)}>{data?.roomName}</p>
+              <p {...stylex.props(Typography.SubTextLargeMedium)}>{data?.roomDescription}</p>
+            </>
+          )}
+        </div>
+
+        {/* 임시 제거 */}
+        {isEdit && (
+          <button type="button" onClick={handleClickTempDelete}>
+            <CircleCloseFilled width={24} height={24} />
+          </button>
         )}
       </div>
     </div>
@@ -96,5 +111,11 @@ const Styles = stylex.create({
     background: colors.gray20,
     border: 'none',
     borderRadius: '4px',
+  },
+  InputAndRemoveContainer: {
+    width: '100%',
+    display: 'flex',
+    gap: '16px',
+    alignItems: 'flex-start',
   },
 });

--- a/src/features/mypage/workspace/congress-room/components/CongressRoomCard/index.tsx
+++ b/src/features/mypage/workspace/congress-room/components/CongressRoomCard/index.tsx
@@ -7,6 +7,7 @@ import { RootState } from '@src/store';
 import { saveCongressRoomList, tempRemoveCongressRoom } from '../../slice/congressRoom';
 import CircleCloseFilled from '@src/components/icons/CircleCloseFilled';
 import { editCongressRoomItem } from '../../types/congressRoom';
+import { confirm } from '@src/components/ui/Modal/confirm';
 
 interface CongressRoomCardProps {
   data: editCongressRoomItem;
@@ -44,7 +45,12 @@ const CongressRoomCard: FC<CongressRoomCardProps> = (props) => {
   );
 
   const handleClickTempDelete = () => {
-    dispatch(tempRemoveCongressRoom(data.tempRoomId ? { tempRoomId: data.tempRoomId } : { ...data }));
+    confirm({
+      content: '기존 회의 기록은 변하지 않지만,\n새로운 회의에서는 더이상 사용할 수 없어요.',
+      cancelBtnName: '유지할래요',
+      okBtnName: '삭제할래요',
+      onOk: () => dispatch(tempRemoveCongressRoom(data.tempRoomId ? { tempRoomId: data.tempRoomId } : { ...data })),
+    });
   };
 
   return (

--- a/src/features/mypage/workspace/congress-room/queries/usePutCongressRoomQuery.tsx
+++ b/src/features/mypage/workspace/congress-room/queries/usePutCongressRoomQuery.tsx
@@ -1,0 +1,61 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+
+type ResponseData = null;
+
+interface CongressRoomListInfo {
+  congressRoomList: {
+    RoomId: number;
+    roomName: string;
+    roomDescription: string;
+    roomSize: number;
+  }[];
+  deleteCongressRoomList: {
+    RoomId: number;
+    roomName: string;
+    roomDescription: string;
+    roomSize: number;
+  }[];
+}
+
+const putCongressRoomApi = async (WorkspaceId, data: CongressRoomListInfo): ResponseData => {
+  const response = await clientInstance.put(`/v1/workspace/@${WorkspaceId}/congress/room`, data);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 회의실 수정하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 회의실 데이터 수정 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const usePutCongressRoomQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: CongressRoomListInfo) => putCongressRoomApi(workspaceId, data),
+    onSuccess: (data, variables) => {
+      // 업데이트 후 회의실 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['roomList'] });
+    },
+    onError: (error, variables, context) => {
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
+  });
+
+  return mutation;
+};
+
+export default usePutCongressRoomQuery;

--- a/src/features/mypage/workspace/congress-room/slice/congressRoom.ts
+++ b/src/features/mypage/workspace/congress-room/slice/congressRoom.ts
@@ -22,10 +22,16 @@ export const CongressRoomSlice = createSlice({
     addCongressRoom: (state, action) => {
       state.editCongressRoomList = [...state.editCongressRoomList, action.payload];
     },
+    // 회의실 제거
+    tempRemoveCongressRoom: (state, action) => {
+      const filterRemoveCongressRoomList = state.editCongressRoomList.filter((item) => item.RoomId !== action.payload);
+
+      state.editCongressRoomList = filterRemoveCongressRoomList;
+    },
   },
 });
 
 // Action creators are generated for each case reducer function
-export const { saveCongressRoomList, addCongressRoom } = CongressRoomSlice.actions;
+export const { saveCongressRoomList, addCongressRoom, tempRemoveCongressRoom } = CongressRoomSlice.actions;
 
 export default CongressRoomSlice.reducer;

--- a/src/features/mypage/workspace/congress-room/slice/congressRoom.ts
+++ b/src/features/mypage/workspace/congress-room/slice/congressRoom.ts
@@ -1,13 +1,15 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { CongressRoomInfoItem } from '@src/queries/congress/useGetCongressRoomListQuery';
+import { editCongressRoomItem } from '../types/congressRoom';
 
 export interface CongressRoomState {
-  editCongressRoomList: CongressRoomInfoItem[];
+  editCongressRoomList: editCongressRoomItem[];
+  tempDeleteCongressRoomList: editCongressRoomItem[];
 }
 
 const initialState: CongressRoomState = {
   // 회의실 리스트 저장
-  editCongressRoomList: null,
+  editCongressRoomList: [],
+  tempDeleteCongressRoomList: [],
 };
 
 export const CongressRoomSlice = createSlice({
@@ -20,11 +22,26 @@ export const CongressRoomSlice = createSlice({
     },
     // 회의실 추가
     addCongressRoom: (state, action) => {
-      state.editCongressRoomList = [...state.editCongressRoomList, action.payload];
+      // 임시로 생성한 회의실을 제거할 때, 고유 id 값으로 판별하기 위해 tempRoomId 생성
+      const tempRoomId = state.editCongressRoomList.filter((item) => item.tempRoomId).length + 1;
+
+      state.editCongressRoomList = [...state.editCongressRoomList, { ...action.payload, tempRoomId }];
     },
     // 회의실 제거
     tempRemoveCongressRoom: (state, action) => {
-      const filterRemoveCongressRoomList = state.editCongressRoomList.filter((item) => item.RoomId !== action.payload);
+      // 회의실 제거 시, 임시로 생성한 회의실과 기존 회의실을 별도로 처리해서 제거
+      const filterRemoveCongressRoomList = state.editCongressRoomList.filter((item) => {
+        if (item.RoomId) {
+          return item.RoomId !== action.payload.RoomId;
+        }
+
+        return item.tempRoomId !== action.payload.tempRoomId;
+      });
+
+      // RoomId가 존재하는 경우에만 회의실 제거 리스트에 추가
+      if (action.payload.RoomId) {
+        state.tempDeleteCongressRoomList = [...state.tempDeleteCongressRoomList, action.payload];
+      }
 
       state.editCongressRoomList = filterRemoveCongressRoomList;
     },

--- a/src/features/mypage/workspace/congress-room/types/congressRoom.ts
+++ b/src/features/mypage/workspace/congress-room/types/congressRoom.ts
@@ -1,0 +1,8 @@
+import { CongressRoomInfoItem } from '@src/queries/congress/useGetCongressRoomListQuery';
+
+/**
+ * 회의실 편집용 아이템 타입
+ */
+export interface editCongressRoomItem extends CongressRoomInfoItem {
+  tempRoomId?: number;
+}

--- a/src/pages/mypage/workspace/congress-room.tsx
+++ b/src/pages/mypage/workspace/congress-room.tsx
@@ -12,9 +12,11 @@ import PlusOutlined from '@src/components/icons/PlusOutlined';
 import MainLayout from '@src/layouts/MainLayout';
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import AddCongressRoomBottomSheet from '@src/features/mypage/workspace/congress-room/components/AddCongressRoomBottomSheet';
+import usePutCongressRoomQuery from '@src/features/mypage/workspace/congress-room/queries/usePutCongressRoomQuery';
 
 const MeetingRoom = () => {
   const { data } = useGetCongressRoomListQuery();
+  const mutation = usePutCongressRoomQuery();
   const dispatch = useDispatch();
   const { editCongressRoomList, tempDeleteCongressRoomList } = useSelector((state: RootState) => state.congressRoom);
   const [isEdit, setIsEdit] = useState<boolean>(false);
@@ -31,7 +33,7 @@ const MeetingRoom = () => {
       });
 
       if (isEdit) {
-        console.log({
+        mutation.mutate({
           congressRoomList: removeTempRoomIdCongressRoomList,
           deleteCongressRoomList: tempDeleteCongressRoomList,
         });

--- a/src/pages/mypage/workspace/congress-room.tsx
+++ b/src/pages/mypage/workspace/congress-room.tsx
@@ -16,7 +16,7 @@ import AddCongressRoomBottomSheet from '@src/features/mypage/workspace/congress-
 const MeetingRoom = () => {
   const { data } = useGetCongressRoomListQuery();
   const dispatch = useDispatch();
-  const { editCongressRoomList } = useSelector((state: RootState) => state.congressRoom);
+  const { editCongressRoomList, tempDeleteCongressRoomList } = useSelector((state: RootState) => state.congressRoom);
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const { renderModal } = useRenderModal();
 
@@ -24,6 +24,18 @@ const MeetingRoom = () => {
     name: isEdit ? '완료' : '수정',
     isActive: isEdit,
     onClick: () => {
+      const removeTempRoomIdCongressRoomList = editCongressRoomList.map((item) => {
+        const { tempRoomId = null, ...anotherItem } = item;
+
+        return tempRoomId ? anotherItem : item;
+      });
+
+      if (isEdit) {
+        console.log({
+          congressRoomList: removeTempRoomIdCongressRoomList,
+          deleteCongressRoomList: tempDeleteCongressRoomList,
+        });
+      }
       setIsEdit(!isEdit);
     },
   };
@@ -45,7 +57,8 @@ const MeetingRoom = () => {
       <div {...stylex.props(Styles.Container)}>
         {/* 회의실 개수 */}
         <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
-          전체 회의실 <span {...stylex.props(Styles.Count)}>{data?.congressRoomCount}</span>
+          전체 회의실{' '}
+          <span {...stylex.props(Styles.Count)}>{isEdit ? editCongressRoomList?.length : data?.congressRoomCount}</span>
         </div>
 
         {/* 회의실 목록 */}


### PR DESCRIPTION
# 작업 내용
- 회의실 삭제 기능 구현
   - 임시로 생성된 회의실을 제거할려면 고유한 값이 있어야 해서 tempRoomId를 생성해줌.
   - tempRoomId가 존재하면 임시로 생성된 회의실이므로 editCongressRoomList에서만 지워주고 deleteRoomList에는 추가해주지 않음.
   - 그러나 원래 존재하던 희의실이라면 editCongressRoomList에서도 지워주고, deleteRoomList에 추가해서 삭제할 회의실 데이터라는 것을 서버에 알림.
- 리액트 쿼리를 사용하여 회의실 데이터 수정 기능 구현
   - 데이터 수정이 완료되면 쿼리 무효화를 통해 회의실 리스트 데이터를 다시 가져옴.