### PR TITLE
Feat(4TS-34): 멤버 정보 화면 구현 및 팀 리스트 로드 API 연결, 팀 이름 수정 기능 구현

### DIFF
--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -1,0 +1,67 @@
+import React, { FC, useState } from 'react';
+import stylex from '@stylexjs/stylex';
+import ArrowHeadOutlinedV2 from '@src/components/icons/ArrowHeadOutlinedV2';
+import { TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
+import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
+
+interface TeamToggleProps {
+  data: TeamInfoItem;
+}
+
+const TeamToggle: FC<TeamToggleProps> = (props) => {
+  const { data } = props;
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleClickTeamName = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div>
+      {/* 팀 이름 */}
+      <button type="button" onClick={handleClickTeamName} {...stylex.props(Styles.TeamNameButton)}>
+        <p {...stylex.props(Typography.TextSmallMedium)}>
+          {data.teamName}({data.memberList.length})
+        </p>
+        <ArrowHeadOutlinedV2 width={24} height={24} rotate={isOpen ? 270 : 90} />
+      </button>
+
+      {/* 토글이 열렸을 떄 */}
+      {isOpen && (
+        <div {...stylex.props(Styles.MemberListWrapper)}>
+          <ul {...stylex.props(Styles.MemberList)}>
+            {data.memberList.map((item) => (
+              <li {...stylex.props(Typography.SubtitleRegularSemiBold)}>{item.displayName}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TeamToggle;
+
+const Styles = stylex.create({
+  TeamNameButton: {
+    width: '100%',
+    padding: '16px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  MemberListWrapper: {
+    margin: '8px 16px',
+    padding: '12px 16px',
+    background: colors.gray20,
+    borderRadius: '12px',
+  },
+  MemberList: {
+    padding: '12px 16px',
+    width: '100%',
+    display: 'flex',
+    gap: '8px',
+    flexDirection: 'column',
+    listStyle: 'disc',
+  },
+});

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -1,30 +1,76 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import ArrowHeadOutlinedV2 from '@src/components/icons/ArrowHeadOutlinedV2';
 import { TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
 import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
+import CircleCloseFilled from '@src/components/icons/CircleCloseFilled';
+import { useDispatch, useSelector } from 'react-redux';
+import { saveTeamList } from '../../slices/member';
+import { RootState } from '@src/store';
 
 interface TeamToggleProps {
   data: TeamInfoItem;
+  isEdit?: boolean;
 }
 
 const TeamToggle: FC<TeamToggleProps> = (props) => {
-  const { data } = props;
+  const { data, isEdit } = props;
+  const dispatch = useDispatch();
+  const { editTeamList } = useSelector((state: RootState) => state.member);
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const handleClickTeamName = () => {
+  const handleClickToggle = () => {
     setIsOpen(!isOpen);
   };
+
+  const handleChangeData = useCallback(
+    (key: 'teamName') => (e) => {
+      const value = e.target.value;
+      const mappingTeamList = editTeamList.map((item) =>
+        item.TeamId === data.TeamId ? { ...item, [key]: value } : item
+      );
+      const index = editTeamList.findIndex((item) => item.TeamId === data.TeamId);
+
+      if (index === -1) {
+        return null;
+      }
+
+      const updateTeamList = [...editTeamList];
+      updateTeamList[index] = { ...updateTeamList[index], [key]: value };
+
+      dispatch(saveTeamList(mappingTeamList));
+    },
+    [editTeamList, data.TeamId, dispatch]
+  );
+
+  const handleClickTempDelete = () => {};
 
   return (
     <div>
       {/* 팀 이름 */}
-      <button type="button" onClick={handleClickTeamName} {...stylex.props(Styles.TeamNameButton)}>
-        <p {...stylex.props(Typography.TextSmallMedium)}>
-          {data.teamName}({data.memberList.length})
-        </p>
-        <ArrowHeadOutlinedV2 width={24} height={24} rotate={isOpen ? 270 : 90} />
-      </button>
+      {isEdit ? (
+        <div {...stylex.props(Styles.EditToggleContainer)}>
+          <input
+            type="text"
+            value={data.teamName}
+            onChange={handleChangeData('teamName')}
+            {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
+          />
+          <button type="button" onClick={handleClickToggle} {...stylex.props(Styles.MiniToggleButton)}>
+            <ArrowHeadOutlinedV2 width={24} height={24} rotate={isOpen ? 270 : 90} />
+          </button>
+          <button type="button" onClick={handleClickTempDelete}>
+            <CircleCloseFilled width={24} height={24} />
+          </button>
+        </div>
+      ) : (
+        <button type="button" onClick={handleClickToggle} {...stylex.props(Styles.ToggleButton)}>
+          <p {...stylex.props(Typography.TextSmallMedium)}>
+            {data.teamName}({data.memberList.length})
+          </p>
+          <ArrowHeadOutlinedV2 width={24} height={24} rotate={isOpen ? 270 : 90} />
+        </button>
+      )}
 
       {/* 토글이 열렸을 떄 */}
       {isOpen && (
@@ -43,7 +89,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
 export default TeamToggle;
 
 const Styles = stylex.create({
-  TeamNameButton: {
+  ToggleButton: {
     width: '100%',
     padding: '16px',
     display: 'flex',
@@ -63,5 +109,20 @@ const Styles = stylex.create({
     gap: '8px',
     flexDirection: 'column',
     listStyle: 'disc',
+  },
+  TextInput: {
+    width: '100%',
+    marginRight: '8px',
+    padding: '4px 8px',
+    background: colors.gray20,
+    border: 'none',
+    borderRadius: '4px',
+  },
+  EditToggleContainer: {
+    padding: '16px',
+    display: 'flex',
+  },
+  MiniToggleButton: {
+    marginRight: '12px',
   },
 });

--- a/src/features/mypage/workspace/member/slices/member.ts
+++ b/src/features/mypage/workspace/member/slices/member.ts
@@ -1,0 +1,27 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { editTeamItem } from '../types/member';
+
+export interface MemberState {
+  editTeamList: editTeamItem[];
+}
+
+const initialState: MemberState = {
+  // 팀 리스트 저장
+  editTeamList: [],
+};
+
+export const MemberSlice = createSlice({
+  name: 'member',
+  initialState,
+  reducers: {
+    // 팀 리스트 저장
+    saveTeamList: (state, action) => {
+      state.editTeamList = action.payload;
+    },
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const { saveTeamList } = MemberSlice.actions;
+
+export default MemberSlice.reducer;

--- a/src/features/mypage/workspace/member/types/member.ts
+++ b/src/features/mypage/workspace/member/types/member.ts
@@ -1,0 +1,8 @@
+import { TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
+
+/**
+ * 팀 편집용 아이템 타입
+ */
+export interface editTeamItem extends TeamInfoItem {
+  tempRoomId?: number;
+}

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -1,22 +1,42 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import GnbNavLayout from '@src/layouts/GnbNavLayout';
 import Header from '@src/components/ui/Header';
 import { Typography } from '../../../../public/styles/vars.stylex';
 import TeamToggle from '@src/features/mypage/workspace/member/components/TeamToggle';
 import useGetTeamListQuery from '@src/queries/team/useGetTeamListQuery';
+import { useDispatch, useSelector } from 'react-redux';
+import { saveTeamList } from '@src/features/mypage/workspace/member/slices/member';
+import { RootState } from '@src/store';
 
 const Member = () => {
   const { data } = useGetTeamListQuery();
+  const dispatch = useDispatch();
+  const { editTeamList } = useSelector((state: RootState) => state.member);
+  const [isEdit, setIsEdit] = useState<boolean>(false);
 
   const totalMemberCount = data?.teamList?.reduce(
     (prevValue, currentValue) => prevValue + currentValue?.memberList?.length,
     0
   );
 
+  const completeBtnProps = {
+    name: isEdit ? '완료' : '수정',
+    isActive: isEdit,
+    onClick: () => {
+      setIsEdit(!isEdit);
+    },
+  };
+
+  useEffect(() => {
+    if (isEdit) {
+      dispatch(saveTeamList(data.teamList));
+    }
+  }, [isEdit]);
+
   return (
     <GnbNavLayout>
-      <Header title="멤버" prevUrl="/mypage/workspace" rightBtnInfo={null} />
+      <Header title="멤버" prevUrl="/mypage/workspace" rightBtnInfo={completeBtnProps} />
       {/* 검색 */}
 
       {/* 전체 멤버수 */}
@@ -24,7 +44,9 @@ const Member = () => {
 
       {/* 팀 목록 */}
       <div {...stylex.props(Styles.TeamListContainer)}>
-        {data?.teamList?.map((item) => <TeamToggle key={item.TeamId} data={item} />)}
+        {isEdit
+          ? editTeamList?.map((item) => <TeamToggle key={item.TeamId} data={item} isEdit={isEdit} />)
+          : data?.teamList?.map((item) => <TeamToggle key={item.TeamId} data={item} />)}
       </div>
     </GnbNavLayout>
   );

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import stylex from '@stylexjs/stylex';
+import GnbNavLayout from '@src/layouts/GnbNavLayout';
+import Header from '@src/components/ui/Header';
+import { Typography } from '../../../../public/styles/vars.stylex';
+import TeamToggle from '@src/features/mypage/workspace/member/components/TeamToggle';
+import useGetTeamListQuery from '@src/queries/team/useGetTeamListQuery';
+
+const Member = () => {
+  const { data } = useGetTeamListQuery();
+
+  const totalMemberCount = data?.teamList?.reduce(
+    (prevValue, currentValue) => prevValue + currentValue?.memberList?.length,
+    0
+  );
+
+  return (
+    <GnbNavLayout>
+      <Header title="멤버" prevUrl="/mypage/workspace" rightBtnInfo={null} />
+      {/* 검색 */}
+
+      {/* 전체 멤버수 */}
+      <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>전체 멤버 ({totalMemberCount})</div>
+
+      {/* 팀 목록 */}
+      <div {...stylex.props(Styles.TeamListContainer)}>
+        {data?.teamList?.map((item) => <TeamToggle key={item.TeamId} data={item} />)}
+      </div>
+    </GnbNavLayout>
+  );
+};
+
+export default Member;
+
+const Styles = stylex.create({
+  TotalCountWrapper: {
+    padding: '16px',
+  },
+  TeamListContainer: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+});

--- a/src/queries/team/useGetTeamListQuery.tsx
+++ b/src/queries/team/useGetTeamListQuery.tsx
@@ -1,0 +1,58 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+export interface MemberInfoItem {
+  MemberId: number;
+  displayName: string;
+  profileImgUrl: string;
+  position: string;
+  isAdmin: boolean;
+  email: string;
+}
+
+export interface TeamInfoItem {
+  TeamId: number;
+  teamType: string;
+  teamName: string;
+  memberList: MemberInfoItem[];
+}
+
+interface TeamList {
+  success: boolean;
+  code: number;
+  WorkspaceId: number;
+  workspaceName: string;
+  teamList: TeamInfoItem[];
+  teamCount: number;
+}
+
+const getTeamListApi = async (WorkspaceId: number): Promise<TeamList> => {
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/team`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 팀 목록을 불러오는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 팀 리스트 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useGetTeamListQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const result = useQuery({
+    queryKey: ['roomList'],
+    queryFn: () => getTeamListApi(workspaceId),
+    enabled: Boolean(workspaceId),
+  });
+
+  return result;
+};
+
+export default useGetTeamListQuery;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import onboardingReducer from '@features/onboarding/slices/onboarding';
 import bookingReducer from '@features/booking/slices/booking';
 import congressRoomReducer from '@features/mypage/workspace/congress-room/slice/congressRoom';
 import modalReducer from '@src/slices/modal';
+import memberReducer from '@features/mypage/workspace/member/slices/member';
 
 export const store = configureStore({
   reducer: {
@@ -10,6 +11,7 @@ export const store = configureStore({
     booking: bookingReducer,
     congressRoom: congressRoomReducer,
     modal: modalReducer,
+    member: memberReducer,
   },
 });
 


### PR DESCRIPTION
# 작업 내용
- '워크스페이스 설정 > 멤버 정보' 화면 퍼블리싱
   - 멤버 수정 버튼 구현
- React-query를 사용하여 워크스페이스 팀 목록을 불러오는 커스텀 훅 구현
- 팀 수정을 위해 복사본 팀 리스트 데이터가 필요해서 그래서 팀 리스트 저장 리듀서 구현함. 
   - 해당 데이터로 임시 삭제, 임시 팀 추가 등의 작업을 진행함. 
- 팀 이름 수정 기능 구현