### PR TITLE
Feat(4TS-34): 멤버 편집에서 팀 추가 기능 화면 퍼블리싱

### DIFF
--- a/src/features/mypage/workspace/member/components/AddTeamBottomSheet/index.tsx
+++ b/src/features/mypage/workspace/member/components/AddTeamBottomSheet/index.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import stylex from '@stylexjs/stylex';
+import BottomSheet from '@src/components/ui/BottomSheet';
+import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
+import Input from '@src/components/ui/Input';
+import useInput from '@src/hooks/useInput';
+import { hideModal } from '@src/slices/modal';
+import { addTeam } from '../../slices/member';
+
+let bottomSheetId = 'add-congress-room-bottom-sheet';
+
+const AddTeamBottomSheet = () => {
+  const [name, handleChangeName] = useInput<string>('');
+  const dispatch = useDispatch();
+
+  const handleClickRegister = () => {
+    dispatch(addTeam({ teamName: name }));
+    dispatch(hideModal());
+  };
+
+  return (
+    <BottomSheet id={bottomSheetId} onClick={() => dispatch(hideModal())}>
+      <div {...stylex.props(Styles.Container)}>
+        <p {...stylex.props(Typography.SubtitleRegularSemiBold, Styles.Title)}>팀 추가</p>
+        <div {...stylex.props(Styles.InputContainer)}>
+          <Input type="text" placeholder="팀명을 입력해주세요" value={name} onChange={handleChangeName} />
+        </div>
+        <div {...stylex.props(Styles.ButtonContainer)}>
+          <button
+            type="button"
+            onClick={() => dispatch(hideModal())}
+            {...stylex.props(Styles.Button, Styles.CancelButton, Typography.TextSmallMedium)}
+          >
+            닫기
+          </button>
+          <button
+            type="button"
+            onClick={handleClickRegister}
+            {...stylex.props(Styles.Button, Styles.RegisterButton, Typography.TextSmallMedium)}
+          >
+            등록
+          </button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+};
+
+export default AddTeamBottomSheet;
+
+const Styles = stylex.create({
+  Container: {
+    padding: '24px 16px',
+  },
+  Title: {
+    marginBottom: '24px',
+    textAlign: 'center',
+  },
+  InputContainer: {
+    marginBottom: '24px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+  ButtonContainer: {
+    display: 'flex',
+    gap: '8px',
+    justifyContent: 'space-between',
+  },
+  Button: {
+    padding: '16px',
+    borderRadius: '20px',
+    flex: 1,
+  },
+  CancelButton: {
+    background: colors.gray20,
+    color: colors.gray60,
+  },
+  RegisterButton: {
+    background: colors.red500,
+    color: colors.white500,
+  },
+});

--- a/src/features/mypage/workspace/member/slices/member.ts
+++ b/src/features/mypage/workspace/member/slices/member.ts
@@ -18,10 +18,17 @@ export const MemberSlice = createSlice({
     saveTeamList: (state, action) => {
       state.editTeamList = action.payload;
     },
+    // 팀 추가
+    addTeam: (state, action) => {
+      // 임시로 생성한 팀을 제거할 때, 고유 id 값으로 판별하기 위해 tempTeamId 생성
+      const tempTeamId = state.editTeamList.filter((item) => item.tempTeamId).length + 1;
+
+      state.editTeamList = [...state.editTeamList, { ...action.payload, tempTeamId, memberList: [] }];
+    },
   },
 });
 
 // Action creators are generated for each case reducer function
-export const { saveTeamList } = MemberSlice.actions;
+export const { saveTeamList, addTeam } = MemberSlice.actions;
 
 export default MemberSlice.reducer;

--- a/src/features/mypage/workspace/member/types/member.ts
+++ b/src/features/mypage/workspace/member/types/member.ts
@@ -4,5 +4,5 @@ import { TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
  * 팀 편집용 아이템 타입
  */
 export interface editTeamItem extends TeamInfoItem {
-  tempRoomId?: number;
+  tempTeamId?: number;
 }

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -1,19 +1,23 @@
 import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import stylex from '@stylexjs/stylex';
-import GnbNavLayout from '@src/layouts/GnbNavLayout';
 import Header from '@src/components/ui/Header';
-import { Typography } from '../../../../public/styles/vars.stylex';
+import { colors, Typography } from '../../../../public/styles/vars.stylex';
 import TeamToggle from '@src/features/mypage/workspace/member/components/TeamToggle';
 import useGetTeamListQuery from '@src/queries/team/useGetTeamListQuery';
-import { useDispatch, useSelector } from 'react-redux';
 import { saveTeamList } from '@src/features/mypage/workspace/member/slices/member';
 import { RootState } from '@src/store';
+import PlusOutlined from '@src/components/icons/PlusOutlined';
+import useRenderModal from '@src/hooks/ui/useRenderModal';
+import MainLayout from '@src/layouts/MainLayout';
+import AddTeamBottomSheet from '@src/features/mypage/workspace/member/components/AddTeamBottomSheet';
 
 const Member = () => {
   const { data } = useGetTeamListQuery();
   const dispatch = useDispatch();
   const { editTeamList } = useSelector((state: RootState) => state.member);
   const [isEdit, setIsEdit] = useState<boolean>(false);
+  const { renderModal } = useRenderModal();
 
   const totalMemberCount = data?.teamList?.reduce(
     (prevValue, currentValue) => prevValue + currentValue?.memberList?.length,
@@ -28,6 +32,10 @@ const Member = () => {
     },
   };
 
+  const handleClickAddTeam = () => {
+    renderModal(AddTeamBottomSheet, null);
+  };
+
   useEffect(() => {
     if (isEdit) {
       dispatch(saveTeamList(data.teamList));
@@ -35,32 +43,70 @@ const Member = () => {
   }, [isEdit]);
 
   return (
-    <GnbNavLayout>
+    <MainLayout>
       <Header title="멤버" prevUrl="/mypage/workspace" rightBtnInfo={completeBtnProps} />
       {/* 검색 */}
 
-      {/* 전체 멤버수 */}
-      <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>전체 멤버 ({totalMemberCount})</div>
+      <div {...{ ...stylex.props(Styles.Container) }}>
+        {/* 전체 멤버수 */}
+        <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
+          전체 멤버 ({totalMemberCount})
+        </div>
 
-      {/* 팀 목록 */}
-      <div {...stylex.props(Styles.TeamListContainer)}>
-        {isEdit
-          ? editTeamList?.map((item) => <TeamToggle key={item.TeamId} data={item} isEdit={isEdit} />)
-          : data?.teamList?.map((item) => <TeamToggle key={item.TeamId} data={item} />)}
+        {/* 팀 목록 */}
+        <div {...stylex.props(Styles.TeamListContainer)}>
+          {isEdit
+            ? editTeamList?.map((item) => <TeamToggle key={item.TeamId} data={item} isEdit={isEdit} />)
+            : data?.teamList?.map((item) => <TeamToggle key={item.TeamId} data={item} />)}
+        </div>
+
+        {/* 팀 추가 */}
+        {isEdit && (
+          <button
+            type="button"
+            {...stylex.props(Styles.AddTeamBtn, Typography.TextSmallMedium)}
+            onClick={handleClickAddTeam}
+          >
+            <PlusOutlined width={24} height={24} />
+            <span>팀 추가</span>
+          </button>
+        )}
       </div>
-    </GnbNavLayout>
+    </MainLayout>
   );
 };
 
 export default Member;
 
 const Styles = stylex.create({
+  Container: {
+    width: '100%',
+    height: 'calc(100vh - 60px)',
+    position: 'relative',
+    padding: '16px',
+    marginBottom: '24px',
+    overflowY: 'auto',
+  },
   TotalCountWrapper: {
     padding: '16px',
   },
   TeamListContainer: {
     width: '100%',
+    height: 'calc(100vh - 212px)',
     display: 'flex',
     flexDirection: 'column',
+  },
+  AddTeamBtn: {
+    width: '100%',
+    padding: '16px',
+    position: 'sticky',
+    bottom: '8px',
+    display: 'flex',
+    gap: '8px',
+    justifyContent: 'center',
+    alignItems: 'center',
+    background: colors.red500,
+    color: colors.white500,
+    borderRadius: '20px',
   },
 });


### PR DESCRIPTION
# 작업 내용
- 멤버 편집 화면에서 '팀 추가' 버튼 구현
- 멤버 편집에서 팀 추가를 할 수 있는 Bottom Sheet 컴포넌트 생성
- 팀 추가를 위한 리듀서 생성