### PR TITLE
Feat(4TS-34): 멤버 편집에서 팀 멤버 이동 기능 구현

### DIFF
--- a/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
+++ b/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
@@ -1,0 +1,167 @@
+import React, { FC, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import stylex from '@stylexjs/stylex';
+import BottomSheet from '@src/components/ui/BottomSheet';
+import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
+import { hideModal } from '@src/slices/modal';
+import { saveTeamList } from '../../slices/member';
+import { MemberInfoItem } from '@src/queries/team/useGetTeamListQuery';
+import { RootState } from '@src/store';
+import TriangleFilled from '@src/components/icons/TriangleFilled';
+
+let bottomSheetId = 'move-member-bottom-sheet';
+
+interface MoveMemberBottomSheetProps {
+  data: MemberInfoItem;
+  selectMemberTeamIdx: number;
+}
+
+const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
+  const { data, selectMemberTeamIdx } = props;
+  const dispatch = useDispatch();
+  const { editTeamList } = useSelector((state: RootState) => state.member);
+  const [selectTeamIdx, setSelectTeamIdx] = useState<number>(null);
+
+  const handleClickSelectTeam = (e) => {
+    const value = Number(e.target.value);
+
+    setSelectTeamIdx(value);
+  };
+
+  const handleClickRegister = () => {
+    const moveMemberTeamList = editTeamList.map((item, idx) => {
+      // 원래 있던 팀에서 삭제
+      if (idx === selectMemberTeamIdx) {
+        const tempDeleteMemberList = item.memberList.filter((memberItem) => memberItem.MemberId !== data.MemberId);
+
+        return { ...item, memberList: tempDeleteMemberList };
+      }
+
+      // 새로운 팀에서 멤버 추가
+      if (idx === selectTeamIdx) {
+        return { ...item, memberList: [...item.memberList, data] };
+      }
+
+      return item;
+    });
+
+    dispatch(saveTeamList(moveMemberTeamList));
+    dispatch(hideModal());
+  };
+
+  return (
+    <BottomSheet id={bottomSheetId} onClick={() => dispatch(hideModal())}>
+      <div {...stylex.props(Styles.Container)}>
+        <p {...stylex.props(Typography.SubtitleRegularSemiBold, Styles.Title)}>멤버 수정</p>
+
+        {/* 팀 선택 영역 */}
+        <div {...stylex.props(Styles.TeamSelectContainer)}>
+          <div {...stylex.props(Styles.SelectContainer)}>
+            <div {...stylex.props(Styles.SelectIcon)}>
+              <TriangleFilled width={24} height={24} />
+            </div>
+            <select
+              name="team"
+              onChange={handleClickSelectTeam}
+              {...stylex.props(Styles.Select, Typography.SubTextLargeRegular)}
+            >
+              {editTeamList.map((item, index) => (
+                <option value={index}>{item.teamName}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* 팀 이동을 위해 선택한 멤버 */}
+          <div {...stylex.props(Styles.DisplayNameWrapper, Typography.SubTextLargeRegular)}>{data.displayName}</div>
+        </div>
+
+        {/* 닫기 및 적용 버튼 */}
+        <div {...stylex.props(Styles.ButtonContainer)}>
+          <button
+            type="button"
+            onClick={() => dispatch(hideModal())}
+            {...stylex.props(Styles.Button, Styles.CancelButton, Typography.TextSmallMedium)}
+          >
+            닫기
+          </button>
+          <button
+            type="button"
+            onClick={handleClickRegister}
+            {...stylex.props(Styles.Button, Styles.RegisterButton, Typography.TextSmallMedium)}
+          >
+            등록
+          </button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+};
+
+export default MoveMemberBottomSheet;
+
+const Styles = stylex.create({
+  Container: {
+    padding: '24px 16px',
+  },
+  Title: {
+    marginBottom: '24px',
+    textAlign: 'center',
+  },
+  TeamSelectContainer: {
+    width: '100%',
+    marginBottom: '24px',
+    display: 'flex',
+    gap: '8px',
+  },
+  ButtonContainer: {
+    display: 'flex',
+    gap: '8px',
+    justifyContent: 'space-between',
+  },
+  Button: {
+    padding: '16px',
+    borderRadius: '20px',
+    flex: 1,
+  },
+  CancelButton: {
+    background: colors.gray20,
+    color: colors.gray60,
+  },
+  RegisterButton: {
+    background: colors.red500,
+    color: colors.white500,
+  },
+  Select: {
+    width: '100%',
+    padding: '12px 12px',
+    // flex: 1,
+    boxShadow: `inset 0 0 0 1px ${colors.gray40}`,
+    borderRadius: '12px',
+    border: 'none',
+    color: colors.gray60,
+    '-webkit-appearance': 'none' /* for chrome */,
+    '-moz-appearance': 'none' /*for firefox*/,
+    appearance: 'none',
+    '::-ms-expand': {
+      display: 'none' /*for IE10,11*/,
+    },
+  },
+  DisplayNameWrapper: {
+    flex: 1,
+    padding: ' 12px',
+    color: colors.gray60,
+    borderRadius: '12px',
+    border: 'none',
+    boxShadow: `inset 0 0 0 1px ${colors.gray40}`,
+  },
+  SelectContainer: {
+    width: '100%',
+    position: 'relative',
+    flex: 1,
+  },
+  SelectIcon: {
+    position: 'absolute',
+    top: '10px',
+    right: '12px',
+  },
+});

--- a/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
+++ b/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
@@ -20,7 +20,7 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
   const { data, selectMemberTeamIdx } = props;
   const dispatch = useDispatch();
   const { editTeamList } = useSelector((state: RootState) => state.member);
-  const [selectTeamIdx, setSelectTeamIdx] = useState<number>(null);
+  const [selectTeamIdx, setSelectTeamIdx] = useState<number>(0);
 
   const handleClickSelectTeam = (e) => {
     const value = Number(e.target.value);
@@ -65,9 +65,9 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
               onChange={handleClickSelectTeam}
               {...stylex.props(Styles.Select, Typography.SubTextLargeRegular)}
             >
-              {editTeamList.map((item, index) => (
-                <option value={index}>{item.teamName}</option>
-              ))}
+              {editTeamList.map((item, index) =>
+                index !== selectMemberTeamIdx ? <option value={index}>{item.teamName}</option> : null
+              )}
             </select>
           </div>
 

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -14,10 +14,11 @@ interface TeamToggleProps {
   data: TeamInfoItem;
   isEdit?: boolean;
   teamIdx: number;
+  isLastIdx: boolean;
 }
 
 const TeamToggle: FC<TeamToggleProps> = (props) => {
-  const { data, isEdit, teamIdx } = props;
+  const { data, isEdit, teamIdx, isLastIdx } = props;
   const dispatch = useDispatch();
   const { renderModal } = useRenderModal();
   const { editTeamList } = useSelector((state: RootState) => state.member);
@@ -53,7 +54,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
   };
 
   return (
-    <div>
+    <div {...stylex.props(isLastIdx && Styles.LastIdxContainer)}>
       {/* 팀 이름 */}
       {isEdit ? (
         <div {...stylex.props(Styles.EditToggleContainer)}>
@@ -109,6 +110,9 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
 export default TeamToggle;
 
 const Styles = stylex.create({
+  LastIdxContainer: {
+    paddingBottom: '104px',
+  },
   ToggleButton: {
     width: '100%',
     padding: '16px',

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -1,21 +1,25 @@
 import React, { FC, useCallback, useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import ArrowHeadOutlinedV2 from '@src/components/icons/ArrowHeadOutlinedV2';
-import { TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
+import { MemberInfoItem, TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
 import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
 import CircleCloseFilled from '@src/components/icons/CircleCloseFilled';
 import { useDispatch, useSelector } from 'react-redux';
 import { saveTeamList } from '../../slices/member';
 import { RootState } from '@src/store';
+import useRenderModal from '@src/hooks/ui/useRenderModal';
+import MoveMemberBottomSheet from '../MoveMemberBottomSheet';
 
 interface TeamToggleProps {
   data: TeamInfoItem;
   isEdit?: boolean;
+  teamIdx: number;
 }
 
 const TeamToggle: FC<TeamToggleProps> = (props) => {
-  const { data, isEdit } = props;
+  const { data, isEdit, teamIdx } = props;
   const dispatch = useDispatch();
+  const { renderModal } = useRenderModal();
   const { editTeamList } = useSelector((state: RootState) => state.member);
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
@@ -42,8 +46,11 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
     },
     [editTeamList, data.TeamId, dispatch]
   );
-
   const handleClickTempDelete = () => {};
+
+  const handleClickMoveMember = (item: MemberInfoItem, idx: number) => {
+    renderModal(MoveMemberBottomSheet, { data: item, selectMemberTeamIdx: teamIdx });
+  };
 
   return (
     <div>
@@ -76,8 +83,21 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
       {isOpen && (
         <div {...stylex.props(Styles.MemberListWrapper)}>
           <ul {...stylex.props(Styles.MemberList)}>
-            {data.memberList.map((item) => (
-              <li {...stylex.props(Typography.SubtitleRegularSemiBold)}>{item.displayName}</li>
+            {data.memberList.map((item, idx) => (
+              <li {...stylex.props(Typography.SubtitleRegularSemiBold)}>
+                <div {...stylex.props(Styles.MemberItemContainer)}>
+                  <span>{item.displayName}</span>
+                  {isEdit && (
+                    <button
+                      type="button"
+                      onClick={() => handleClickMoveMember(item, idx)}
+                      {...stylex.props(Styles.MoveButton, Typography.SubTextRegularSemiBold)}
+                    >
+                      이동
+                    </button>
+                  )}
+                </div>
+              </li>
             ))}
           </ul>
         </div>
@@ -124,5 +144,16 @@ const Styles = stylex.create({
   },
   MiniToggleButton: {
     marginRight: '12px',
+  },
+  MoveButton: {
+    padding: '4px 12px',
+    background: colors.black400,
+    color: colors.white500,
+    borderRadius: '13px',
+  },
+  MemberItemContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
   },
 });

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -57,9 +57,17 @@ const Member = () => {
         <div {...stylex.props(Styles.TeamListContainer)}>
           {isEdit
             ? editTeamList?.map((item, idx) => (
-                <TeamToggle key={item.TeamId} data={item} teamIdx={idx} isEdit={isEdit} />
+                <TeamToggle
+                  key={item.TeamId}
+                  data={item}
+                  teamIdx={idx}
+                  isEdit={isEdit}
+                  isLastIdx={editTeamList.length - 1 === idx}
+                />
               ))
-            : data?.teamList?.map((item, idx) => <TeamToggle key={item.TeamId} data={item} teamIdx={idx} />)}
+            : data?.teamList?.map((item, idx) => (
+                <TeamToggle key={item.TeamId} data={item} teamIdx={idx} isLastIdx={editTeamList.length - 1 === idx} />
+              ))}
         </div>
 
         {/* 팀 추가 */}
@@ -99,10 +107,11 @@ const Styles = stylex.create({
     flexDirection: 'column',
   },
   AddTeamBtn: {
-    width: '100%',
+    maxWidth: '735px',
+    width: 'calc(100% - 32px)',
     padding: '16px',
-    position: 'sticky',
-    bottom: '8px',
+    position: 'fixed',
+    bottom: '16px',
     display: 'flex',
     gap: '8px',
     justifyContent: 'center',

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -56,8 +56,10 @@ const Member = () => {
         {/* 팀 목록 */}
         <div {...stylex.props(Styles.TeamListContainer)}>
           {isEdit
-            ? editTeamList?.map((item) => <TeamToggle key={item.TeamId} data={item} isEdit={isEdit} />)
-            : data?.teamList?.map((item) => <TeamToggle key={item.TeamId} data={item} />)}
+            ? editTeamList?.map((item, idx) => (
+                <TeamToggle key={item.TeamId} data={item} teamIdx={idx} isEdit={isEdit} />
+              ))
+            : data?.teamList?.map((item, idx) => <TeamToggle key={item.TeamId} data={item} teamIdx={idx} />)}
         </div>
 
         {/* 팀 추가 */}


### PR DESCRIPTION
# 작업 내용
- 멤버 편집에서 '이동'버튼을 눌렀을 때 팀 이동 bottom sheet가 나타나면서 원하는 팀에 이동이 가능하게 구현
   - 팀 이동시 선택할 수 있는 팀 목록은 현재 소속된 팀을 제외한 목록이 나타남.
- 팀 목록이 많아졌을 때, 팀 추가 버튼이 팀 목록을 가려버려서 팀을 제대로 볼 수 없는 문제가 있어서 팀 추가 버튼 css를 수정해줌.
   - 팀 추가 버튼을 항상 맨 마지막에 버튼이 위치되게 하려고 했으나, 팀 목록이 많이 생성되어 스크롤을 하면 팀 추가 버튼이 목록 중간에 위치하게 되는 문제가 발생함.
   - 팀 추가 버튼의 position을 sticky로 했을 떄 발생한 문제였음. sticky로 했을 때 버튼이 메인 레이아웃 영역을 벗어나지 않는 문제 때문에 설정했는데 의도치 않게 스크롤을 하면 중간에 버튼이 위치해버림. 그래서 fixed로 수정해서 문제를 해결해줌.
   - 그리고 팀 추가 버튼이 fixed이다 보니 항상 버튼이 팀 목록을 가릴 수 밖에 없는데, 팀 목록 하단에 팀 추가 버튼 만큼의 여백이 없으니 마지막 팀 토글은 팀 추가 버튼에 가려져 버리는 문제가 발생함. 그래서 lastIndex를 체크해서 마지막 팀 토글 요소에는 padding-bottom을 적용해서 여백이 생기게 함.