### PR TITLE
Feat(4TS-34): 팀 제거 기능 구현 및 멤버 수정 완료 기능 임시 구현

### DIFF
--- a/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
+++ b/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
@@ -20,7 +20,8 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
   const { data, selectMemberTeamIdx } = props;
   const dispatch = useDispatch();
   const { editTeamList } = useSelector((state: RootState) => state.member);
-  const [selectTeamIdx, setSelectTeamIdx] = useState<number>(0);
+  const selectOptionList = editTeamList.filter((item, index) => index !== selectMemberTeamIdx); // 이미 참여한 팀은 option에 나타나지 않게 함.
+  const [selectTeamIdx, setSelectTeamIdx] = useState<number>(selectOptionList[0].TeamId);
 
   const handleClickSelectTeam = (e) => {
     const value = Number(e.target.value);
@@ -38,7 +39,7 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
       }
 
       // 새로운 팀에서 멤버 추가
-      if (idx === selectTeamIdx) {
+      if (item.TeamId === selectTeamIdx) {
         return { ...item, memberList: [...item.memberList, data] };
       }
 
@@ -65,9 +66,9 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
               onChange={handleClickSelectTeam}
               {...stylex.props(Styles.Select, Typography.SubTextLargeRegular)}
             >
-              {editTeamList.map((item, index) =>
-                index !== selectMemberTeamIdx ? <option value={index}>{item.teamName}</option> : null
-              )}
+              {selectOptionList.map((item, index) => (
+                <option value={index}>{item.teamName}</option>
+              ))}
             </select>
           </div>
 

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -1,17 +1,19 @@
 import React, { FC, useCallback, useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import ArrowHeadOutlinedV2 from '@src/components/icons/ArrowHeadOutlinedV2';
-import { MemberInfoItem, TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
+import { MemberInfoItem } from '@src/queries/team/useGetTeamListQuery';
 import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
 import CircleCloseFilled from '@src/components/icons/CircleCloseFilled';
 import { useDispatch, useSelector } from 'react-redux';
-import { saveTeamList } from '../../slices/member';
+import { saveTeamList, tempRemoveTeam } from '../../slices/member';
 import { RootState } from '@src/store';
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import MoveMemberBottomSheet from '../MoveMemberBottomSheet';
+import { EditTeamItem } from '../../types/member';
+import { confirm } from '@src/components/ui/Modal/confirm';
 
 interface TeamToggleProps {
-  data: TeamInfoItem;
+  data: EditTeamItem;
   isEdit?: boolean;
   teamIdx: number;
   isLastIdx: boolean;
@@ -47,7 +49,14 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
     },
     [editTeamList, data.TeamId, dispatch]
   );
-  const handleClickTempDelete = () => {};
+  const handleClickTempDelete = () => {
+    confirm({
+      content: '팀 삭제를 하면 기존 팀원들은 미분류로 이동돼요.\n수정 완료 전까지 팀 변경 가능해요.',
+      cancelBtnName: '유지할래요',
+      okBtnName: '삭제할래요',
+      onOk: () => dispatch(tempRemoveTeam(data.tempTeamId ? { ...data, tempTeamId: data.tempTeamId } : { ...data })),
+    });
+  };
 
   const handleClickMoveMember = (item: MemberInfoItem, idx: number) => {
     renderModal(MoveMemberBottomSheet, { data: item, selectMemberTeamIdx: teamIdx });

--- a/src/features/mypage/workspace/member/queries/usePutTeamQuery.tsx
+++ b/src/features/mypage/workspace/member/queries/usePutTeamQuery.tsx
@@ -4,6 +4,8 @@ import { TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 import clientInstance from '@src/utils/api/clientInstance';
 import { useQueryClient } from '@tanstack/react-query';
+import { useDispatch } from 'react-redux';
+import { saveTeamList } from '../slices/member';
 
 type ResponseData = null;
 
@@ -32,6 +34,7 @@ const putTeamApi = async (WorkspaceId, data: TeamListInfo): ResponseData => {
 const usePutTeamQuery = () => {
   const { data } = useGetWorkspaceListQuery();
   const queryClient = useQueryClient();
+  const dispatch = useDispatch();
   const workspaceId = data?.workspaceList[0]?.WorkspaceId;
 
   const mutation = useCustomMutation({
@@ -39,6 +42,7 @@ const usePutTeamQuery = () => {
     onSuccess: (data, variables) => {
       // 업데이트 후 팀 리스트 데이터 재요청 (쿼리 무효화)
       queryClient.invalidateQueries({ queryKey: ['teamList'] });
+      dispatch(saveTeamList([]));
     },
     onError: (error, variables, context) => {
       // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기

--- a/src/features/mypage/workspace/member/queries/usePutTeamQuery.tsx
+++ b/src/features/mypage/workspace/member/queries/usePutTeamQuery.tsx
@@ -5,7 +5,7 @@ import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceList
 import clientInstance from '@src/utils/api/clientInstance';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';
-import { saveTeamList } from '../slices/member';
+import { resetTeamList } from '../slices/member';
 
 type ResponseData = null;
 
@@ -42,7 +42,9 @@ const usePutTeamQuery = () => {
     onSuccess: (data, variables) => {
       // 업데이트 후 팀 리스트 데이터 재요청 (쿼리 무효화)
       queryClient.invalidateQueries({ queryKey: ['teamList'] });
-      dispatch(saveTeamList([]));
+
+      // 리덕스에 저장된 팀 리스트 관련 state 모두 초기화
+      dispatch(resetTeamList());
     },
     onError: (error, variables, context) => {
       // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기

--- a/src/features/mypage/workspace/member/queries/usePutTeamQuery.tsx
+++ b/src/features/mypage/workspace/member/queries/usePutTeamQuery.tsx
@@ -47,8 +47,13 @@ const usePutTeamQuery = () => {
       dispatch(resetTeamList());
     },
     onError: (error, variables, context) => {
-      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
-      confirm({ content: error?.response.data.message.errMsg });
+      if (error.status !== 452) {
+        // alert 도 모달로 수정해주기
+        alert(`서버 에러가 발생했습니다. (code: ${error.status})`);
+      } else {
+        // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+        confirm({ content: error?.response.data.message.errMsg });
+      }
     },
   });
 

--- a/src/features/mypage/workspace/member/queries/usePutTeamQuery.tsx
+++ b/src/features/mypage/workspace/member/queries/usePutTeamQuery.tsx
@@ -1,0 +1,52 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import { TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+
+type ResponseData = null;
+
+interface TeamListInfo {
+  teamList: TeamInfoItem[];
+  deleteTeamList: TeamInfoItem[];
+}
+
+const putTeamApi = async (WorkspaceId, data: TeamListInfo): ResponseData => {
+  const response = await clientInstance.put(`/v1/workspace/@${WorkspaceId}/team`, data);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 팀 수정하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 팀 데이터 수정 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const usePutTeamQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: TeamListInfo) => putTeamApi(workspaceId, data),
+    onSuccess: (data, variables) => {
+      // 업데이트 후 팀 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['teamList'] });
+    },
+    onError: (error, variables, context) => {
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
+  });
+
+  return mutation;
+};
+
+export default usePutTeamQuery;

--- a/src/features/mypage/workspace/member/slices/member.ts
+++ b/src/features/mypage/workspace/member/slices/member.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { editTeamItem } from '../types/member';
+import { EditTeamItem } from '../types/member';
 
 export interface MemberState {
-  editTeamList: editTeamItem[];
+  editTeamList: EditTeamItem[];
 }
 
 const initialState: MemberState = {

--- a/src/features/mypage/workspace/member/slices/member.ts
+++ b/src/features/mypage/workspace/member/slices/member.ts
@@ -58,10 +58,15 @@ export const MemberSlice = createSlice({
 
       state.editTeamList = filterRemoveTeamList;
     },
+    // 편집용 팀 리스트 및 임시 팀 리스트 제거 state 초기화
+    resetTeamList: (state) => {
+      state.editTeamList = [];
+      state.tempDeleteTeamList = [];
+    },
   },
 });
 
 // Action creators are generated for each case reducer function
-export const { saveTeamList, addTeam, tempRemoveTeam } = MemberSlice.actions;
+export const { saveTeamList, addTeam, tempRemoveTeam, resetTeamList } = MemberSlice.actions;
 
 export default MemberSlice.reducer;

--- a/src/features/mypage/workspace/member/slices/member.ts
+++ b/src/features/mypage/workspace/member/slices/member.ts
@@ -3,11 +3,14 @@ import { EditTeamItem } from '../types/member';
 
 export interface MemberState {
   editTeamList: EditTeamItem[];
+  tempDeleteTeamList: EditTeamItem[];
 }
 
 const initialState: MemberState = {
   // 팀 리스트 저장
   editTeamList: [],
+  // 임시 팀 제거 리스트 저장
+  tempDeleteTeamList: [],
 };
 
 export const MemberSlice = createSlice({
@@ -25,10 +28,40 @@ export const MemberSlice = createSlice({
 
       state.editTeamList = [...state.editTeamList, { ...action.payload, tempTeamId, memberList: [] }];
     },
+    // 팀 제거
+    tempRemoveTeam: (state, action) => {
+      // 팀 제거 전, 미분류 팀으로 모두 이동
+      const moveMemberTeamList = state.editTeamList.map((item) => {
+        let memberList = item.memberList;
+
+        // [ ] teamType이 base로 설정되기 전까지 미분류 이름으로 나눌 수 있게 수정
+        if (item.teamType === 'base' || item.teamName === '미분류') {
+          memberList = [...item.memberList, ...action.payload.memberList];
+        }
+
+        return { ...item, memberList };
+      });
+
+      // 팀 제거 시, 임시로 생성한 팀과 기존 팀을 별도로 처리해서 제거
+      const filterRemoveTeamList = moveMemberTeamList.filter((item) => {
+        if (item.TeamId) {
+          return item.TeamId !== action.payload.TeamId;
+        }
+
+        return item.tempTeamId !== action.payload.tempTeamId;
+      });
+
+      // TeamId가 존재하는 경우에만 팀 제거 리스트에 추가
+      if (action.payload.TeamId) {
+        state.tempDeleteTeamList = [...state.tempDeleteTeamList, action.payload];
+      }
+
+      state.editTeamList = filterRemoveTeamList;
+    },
   },
 });
 
 // Action creators are generated for each case reducer function
-export const { saveTeamList, addTeam } = MemberSlice.actions;
+export const { saveTeamList, addTeam, tempRemoveTeam } = MemberSlice.actions;
 
 export default MemberSlice.reducer;

--- a/src/features/mypage/workspace/member/types/member.ts
+++ b/src/features/mypage/workspace/member/types/member.ts
@@ -3,6 +3,6 @@ import { TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
 /**
  * 팀 편집용 아이템 타입
  */
-export interface editTeamItem extends TeamInfoItem {
+export interface EditTeamItem extends TeamInfoItem {
   tempTeamId?: number;
 }

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -11,11 +11,13 @@ import PlusOutlined from '@src/components/icons/PlusOutlined';
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import MainLayout from '@src/layouts/MainLayout';
 import AddTeamBottomSheet from '@src/features/mypage/workspace/member/components/AddTeamBottomSheet';
+import usePutTeamQuery from '@src/features/mypage/workspace/member/queries/usePutTeamQuery';
 
 const Member = () => {
   const { data } = useGetTeamListQuery();
+  const mutation = usePutTeamQuery();
   const dispatch = useDispatch();
-  const { editTeamList } = useSelector((state: RootState) => state.member);
+  const { editTeamList, tempDeleteTeamList } = useSelector((state: RootState) => state.member);
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const { renderModal } = useRenderModal();
 
@@ -28,6 +30,18 @@ const Member = () => {
     name: isEdit ? '완료' : '수정',
     isActive: isEdit,
     onClick: () => {
+      const removeTempTeamIdInTemList = editTeamList.map((item) => {
+        const { tempTeamId = null, ...anotherItem } = item;
+
+        return tempTeamId ? anotherItem : item;
+      });
+
+      if (isEdit) {
+        mutation.mutate({
+          teamList: removeTempTeamIdInTemList,
+          deleteTeamList: tempDeleteTeamList,
+        });
+      }
       setIsEdit(!isEdit);
     },
   };

--- a/src/queries/team/useGetTeamListQuery.tsx
+++ b/src/queries/team/useGetTeamListQuery.tsx
@@ -47,7 +47,7 @@ const useGetTeamListQuery = () => {
   const workspaceId = data?.workspaceList[0]?.WorkspaceId;
 
   const result = useQuery({
-    queryKey: ['roomList'],
+    queryKey: ['teamList'],
     queryFn: () => getTeamListApi(workspaceId),
     enabled: Boolean(workspaceId),
   });


### PR DESCRIPTION
# 작업 내용
- 팀 제거 기능 구현
   - 팀 제거할 때 팀 안에 멤버가 있는 경우, 기존 멤버는 미분류로 이동되게 구현
- 멤버 수정 완료 버튼 클릭시 임의로 서버에 전달할 데이터 형태를 구현함.
   - 팀 수정 react query hook 임의 구현
      - 팀 수정 api가 아직 수정중이라서 기존 회의실 수정 데이터를 기반으로 비슷하게 데이터 형태를 구현함.