### PR TITLE
Feat(4TS-33): 카테고리 정보 화면 구현 및 API 연결, 카테고리 이름 수정 기능 구현

### DIFF
--- a/src/components/icons/FileOutlined.tsx
+++ b/src/components/icons/FileOutlined.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const FileOutlined: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <path
+        stroke="#444"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.8}
+        d="m13 7-1.116-2.231c-.32-.642-.481-.963-.72-1.198a2 2 0 0 0-.748-.462C10.1 3 9.74 3 9.022 3H5.2c-1.12 0-1.68 0-2.108.218a2 2 0 0 0-.874.874C2 4.52 2 5.08 2 6.2V7m0 0h15.2c1.68 0 2.52 0 3.162.327a3 3 0 0 1 1.311 1.311C22 9.28 22 10.12 22 11.8v4.4c0 1.68 0 2.52-.327 3.162a3 3 0 0 1-1.311 1.311C19.72 21 18.88 21 17.2 21H6.8c-1.68 0-2.52 0-3.162-.327a3 3 0 0 1-1.311-1.311C2 18.72 2 17.88 2 16.2z"
+      />
+    </svg>
+  );
+};
+
+export default FileOutlined;

--- a/src/features/mypage/workspace/category/components/CategoryItem/index.tsx
+++ b/src/features/mypage/workspace/category/components/CategoryItem/index.tsx
@@ -1,0 +1,63 @@
+import React, { FC } from 'react';
+import stylex from '@stylexjs/stylex';
+import FileOutlined from '@src/components/icons/FileOutlined';
+import { CongressCategoryItem } from '@src/queries/category/useGetCategoryListQuery';
+import useInput from '@src/hooks/useInput';
+import CircleCloseFilled from '@src/components/icons/CircleCloseFilled';
+import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
+
+interface CategoryItemProps {
+  data: CongressCategoryItem;
+  isEdit?: boolean;
+}
+
+const CategoryItem: FC<CategoryItemProps> = (props) => {
+  const { isEdit, data } = props;
+  const [categoryName, handleChangeCategoryName] = useInput<string>(data?.categoryName);
+
+  const handleClickDelete = () => {};
+
+  return (
+    <div {...stylex.props(Styles.Container)}>
+      <FileOutlined width={24} height={24} />
+      {isEdit ? (
+        <div {...stylex.props(Styles.InputAndCloseBtnContainer)}>
+          <input
+            value={categoryName}
+            onChange={handleChangeCategoryName}
+            {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
+          />
+          <button type="button" onClick={handleClickDelete}>
+            <CircleCloseFilled width={24} height={24} />
+          </button>
+        </div>
+      ) : (
+        <p {...stylex.props(Typography.TextSmallMedium)}>{data.categoryName}</p>
+      )}
+    </div>
+  );
+};
+
+export default CategoryItem;
+
+const Styles = stylex.create({
+  Container: {
+    width: '100%',
+    padding: '16px',
+    display: 'flex',
+    gap: '8px',
+    alignItems: 'center',
+  },
+  InputAndCloseBtnContainer: {
+    width: '100%',
+    display: 'flex',
+    gap: '16px',
+  },
+  TextInput: {
+    width: '100%',
+    padding: '4px 8px',
+    background: colors.gray20,
+    border: 'none',
+    borderRadius: '4px',
+  },
+});

--- a/src/features/mypage/workspace/category/slices/category.ts
+++ b/src/features/mypage/workspace/category/slices/category.ts
@@ -1,0 +1,27 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { editCongressCategoryItem } from '../types/category';
+
+export interface CategoryState {
+  editCongressCategoryList: editCongressCategoryItem[];
+}
+
+const initialState: CategoryState = {
+  // 회의실 카테고리 저장
+  editCongressCategoryList: [],
+};
+
+export const CategorySlice = createSlice({
+  name: 'category',
+  initialState,
+  reducers: {
+    // 회의실 카테고리 리스트 저장
+    saveCategoryList: (state, action) => {
+      state.editCongressCategoryList = action.payload;
+    },
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const { saveCategoryList } = CategorySlice.actions;
+
+export default CategorySlice.reducer;

--- a/src/features/mypage/workspace/category/types/category.ts
+++ b/src/features/mypage/workspace/category/types/category.ts
@@ -1,0 +1,8 @@
+import { CongressCategoryItem } from '@src/queries/category/useGetCategoryListQuery';
+
+/**
+ * 회의실 카테고리 편집용 아이템 타입
+ */
+export interface editCongressCategoryItem extends CongressCategoryItem {
+  tempCongressCategoryId?: number;
+}

--- a/src/pages/mypage/workspace/category.tsx
+++ b/src/pages/mypage/workspace/category.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import stylex from '@stylexjs/stylex';
+import Header from '@src/components/ui/Header';
+import { colors, Typography } from '../../../../public/styles/vars.stylex';
+import { RootState } from '@src/store';
+import PlusOutlined from '@src/components/icons/PlusOutlined';
+import MainLayout from '@src/layouts/MainLayout';
+import CategoryItem from '@src/features/mypage/workspace/category/components/CategoryItem';
+import useGetCategoryListQuery from '@src/queries/category/useGetCategoryListQuery';
+import { saveCategoryList } from '@src/features/mypage/workspace/category/slices/category';
+
+const Category = () => {
+  const { data } = useGetCategoryListQuery();
+  const dispatch = useDispatch();
+  const { editCongressCategoryList } = useSelector((state: RootState) => state.category);
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+
+  const completeBtnProps = {
+    name: isEdit ? '완료' : '수정',
+    isActive: isEdit,
+    onClick: () => {
+      setIsEdit(!isEdit);
+    },
+  };
+
+  useEffect(() => {
+    if (isEdit) {
+      dispatch(saveCategoryList(data.congressCategoryList));
+    }
+  }, [isEdit]);
+
+  return (
+    <MainLayout>
+      <Header title={isEdit ? '수정하기' : '카테고리'} prevUrl="/mypage/workspace" rightBtnInfo={completeBtnProps} />
+      {/* 검색 */}
+
+      <div {...{ ...stylex.props(Styles.Container) }}>
+        {/* 전체 카테고리 수 */}
+        <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
+          전체 카테고리 ({data?.congressCategoryCount})
+        </div>
+
+        {/* 카테고리 목록 */}
+        <div {...stylex.props(Styles.CategoryListContainer)}>
+          {isEdit
+            ? editCongressCategoryList?.map((item, idx) => <CategoryItem data={item} isEdit />)
+            : data?.congressCategoryList?.map((item, idx) => <CategoryItem data={item} />)}
+        </div>
+
+        {/* 카테고리 추가 */}
+        {isEdit && (
+          <button type="button" {...stylex.props(Styles.AddCategoryBtn, Typography.TextSmallMedium)} onClick={null}>
+            <PlusOutlined width={24} height={24} />
+            <span>카테고리 추가</span>
+          </button>
+        )}
+      </div>
+    </MainLayout>
+  );
+};
+
+export default Category;
+
+const Styles = stylex.create({
+  Container: {
+    width: '100%',
+    height: 'calc(100vh - 60px)',
+    position: 'relative',
+    padding: '16px',
+    marginBottom: '24px',
+    overflowY: 'auto',
+  },
+  TotalCountWrapper: {
+    padding: '16px',
+  },
+  CategoryListContainer: {
+    width: '100%',
+    height: 'calc(100vh - 212px)',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  AddCategoryBtn: {
+    maxWidth: '735px',
+    width: 'calc(100% - 32px)',
+    padding: '16px',
+    position: 'fixed',
+    bottom: '16px',
+    display: 'flex',
+    gap: '8px',
+    justifyContent: 'center',
+    alignItems: 'center',
+    background: colors.red500,
+    color: colors.white500,
+    borderRadius: '20px',
+  },
+});

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -23,7 +23,12 @@ const WorkspaceHome = () => {
       href: `/${commonUrl}/member`,
     },
     { id: 2, name: '회의실 정보', icon: <BoxOutlined width={24} height={24} />, href: `/${commonUrl}/congress-room` },
-    { id: 3, name: '카테고리 정보', icon: <CategoryGroupOutlined width={24} height={24} />, href: '' },
+    {
+      id: 3,
+      name: '카테고리 정보',
+      icon: <CategoryGroupOutlined width={24} height={24} />,
+      href: `/${commonUrl}/category`,
+    },
   ];
 
   const completeBtnProps = {

--- a/src/queries/category/useGetCategoryListQuery.tsx
+++ b/src/queries/category/useGetCategoryListQuery.tsx
@@ -1,0 +1,48 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+export interface CongressCategoryItem {
+  CongressCategoryId: number;
+  categoryType: string;
+  categoryName: string;
+  hexcode: string;
+  congressCount: number;
+}
+
+interface CongressCategoryList {
+  success: boolean;
+  code: number;
+  congressCategoryList: CongressCategoryItem[];
+  congressCategoryCount: number;
+}
+
+const getCongressCategoryListApi = async (WorkspaceId: number): Promise<CongressCategoryList> => {
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/congress/category/list`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 회의실 카테고리 목록을 불러오는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 카테고리 리스트 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useGetCategoryListQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const result = useQuery({
+    queryKey: ['category'],
+    queryFn: () => getCongressCategoryListApi(workspaceId),
+    enabled: Boolean(workspaceId),
+  });
+
+  return result;
+};
+
+export default useGetCategoryListQuery;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,6 +4,7 @@ import bookingReducer from '@features/booking/slices/booking';
 import congressRoomReducer from '@features/mypage/workspace/congress-room/slice/congressRoom';
 import modalReducer from '@src/slices/modal';
 import memberReducer from '@features/mypage/workspace/member/slices/member';
+import categoryReducer from '@features/mypage/workspace/category/slices/category';
 
 export const store = configureStore({
   reducer: {
@@ -12,6 +13,7 @@ export const store = configureStore({
     congressRoom: congressRoomReducer,
     modal: modalReducer,
     member: memberReducer,
+    category: categoryReducer,
   },
 });
 


### PR DESCRIPTION
# 작업 내용
- 마이페이지 워크스페이스 설정 화면의 메뉴 리스트에서 카테고리 정보 href 수정
- 마이페이지 워크스페이스 카테고리 목록 화면 구현
   - react-query를 사용하여 카테고리 리스트 로드 api 연결
   - 카테고리 편집을 위해 카테고리 리스트를 저장 리듀서 구현
- 카테고리 이름을 수정할 수 있는 화면 퍼블리싱
   - 수정 api 연결은 카테고리 추가 기능 구현 후 연결할 예정