### PR TITLE
Feat(4TS-33): 카테고리 추가, 제거 기능 구현 및 카테고리 수정 API 연결

### DIFF
--- a/src/features/mypage/workspace/category/components/AddCategoryBottomSheet/index.tsx
+++ b/src/features/mypage/workspace/category/components/AddCategoryBottomSheet/index.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import stylex from '@stylexjs/stylex';
+import BottomSheet from '@src/components/ui/BottomSheet';
+import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
+import Input from '@src/components/ui/Input';
+import useInput from '@src/hooks/useInput';
+import { hideModal } from '@src/slices/modal';
+import { addCategory } from '../../slices/category';
+
+let bottomSheetId = 'add-category-bottom-sheet';
+
+const AddCategoryBottomSheet = () => {
+  const [name, handleChangeName] = useInput<string>('');
+  const dispatch = useDispatch();
+
+  const handleClickRegister = () => {
+    dispatch(addCategory({ categoryName: name }));
+    dispatch(hideModal());
+  };
+
+  return (
+    <BottomSheet id={bottomSheetId} onClick={() => dispatch(hideModal())}>
+      <div {...stylex.props(Styles.Container)}>
+        <p {...stylex.props(Typography.SubtitleRegularSemiBold, Styles.Title)}>카테고리 추가</p>
+        <div {...stylex.props(Styles.InputContainer)}>
+          <Input type="text" placeholder="카테고리 명을 입력해주세요" value={name} onChange={handleChangeName} />
+        </div>
+        <div {...stylex.props(Styles.ButtonContainer)}>
+          <button
+            type="button"
+            onClick={() => dispatch(hideModal())}
+            {...stylex.props(Styles.Button, Styles.CancelButton, Typography.TextSmallMedium)}
+          >
+            닫기
+          </button>
+          <button
+            type="button"
+            onClick={handleClickRegister}
+            {...stylex.props(Styles.Button, Styles.RegisterButton, Typography.TextSmallMedium)}
+          >
+            등록
+          </button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+};
+
+export default AddCategoryBottomSheet;
+
+const Styles = stylex.create({
+  Container: {
+    padding: '24px 16px',
+  },
+  Title: {
+    marginBottom: '24px',
+    textAlign: 'center',
+  },
+  InputContainer: {
+    marginBottom: '24px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+  ButtonContainer: {
+    display: 'flex',
+    gap: '8px',
+    justifyContent: 'space-between',
+  },
+  Button: {
+    padding: '16px',
+    borderRadius: '20px',
+    flex: 1,
+  },
+  CancelButton: {
+    background: colors.gray20,
+    color: colors.gray60,
+  },
+  RegisterButton: {
+    background: colors.red500,
+    color: colors.white500,
+  },
+});

--- a/src/features/mypage/workspace/category/components/CategoryItem/index.tsx
+++ b/src/features/mypage/workspace/category/components/CategoryItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import stylex from '@stylexjs/stylex';
 import FileOutlined from '@src/components/icons/FileOutlined';
 import { CongressCategoryItem } from '@src/queries/category/useGetCategoryListQuery';
@@ -6,9 +6,10 @@ import useInput from '@src/hooks/useInput';
 import CircleCloseFilled from '@src/components/icons/CircleCloseFilled';
 import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
 import { confirm } from '@src/components/ui/Modal/confirm';
-import { useDispatch } from 'react-redux';
-import { tempRemoveCategory } from '../../slices/category';
+import { useDispatch, useSelector } from 'react-redux';
+import { saveCategoryList, tempRemoveCategory } from '../../slices/category';
 import { editCongressCategoryItem } from '../../types/category';
+import { RootState } from '@src/store';
 
 interface CategoryItemProps {
   data: editCongressCategoryItem;
@@ -17,8 +18,30 @@ interface CategoryItemProps {
 
 const CategoryItem: FC<CategoryItemProps> = (props) => {
   const { isEdit, data } = props;
+  const { editCongressCategoryList } = useSelector((state: RootState) => state.category);
   const [categoryName, handleChangeCategoryName] = useInput<string>(data?.categoryName);
   const dispatch = useDispatch();
+
+  // 회의실 카테고리 이름값 변경을 다루는 함수
+  const handleChangeCategory = useCallback(
+    (key: 'categoryName') => (e) => {
+      const value = e.target.value;
+      const mappingCongressRoomList = editCongressCategoryList.map((item) =>
+        item.CongressCategoryId === data.CongressCategoryId ? { ...item, [key]: value } : item
+      );
+      const index = editCongressCategoryList.findIndex((item) => item.CongressCategoryId === data.CongressCategoryId);
+
+      if (index === -1) {
+        return null;
+      }
+
+      const updateCongressCategoryList = [...editCongressCategoryList];
+      updateCongressCategoryList[index] = { ...updateCongressCategoryList[index], [key]: value };
+
+      dispatch(saveCategoryList(mappingCongressRoomList));
+    },
+    [editCongressCategoryList, data.CongressCategoryId, dispatch]
+  );
 
   const handleClickDelete = () => {
     confirm({
@@ -41,7 +64,7 @@ const CategoryItem: FC<CategoryItemProps> = (props) => {
         <div {...stylex.props(Styles.InputAndCloseBtnContainer)}>
           <input
             value={categoryName}
-            onChange={handleChangeCategoryName}
+            onChange={handleChangeCategory('categoryName')}
             {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
           />
           <button type="button" onClick={handleClickDelete}>

--- a/src/features/mypage/workspace/category/components/CategoryItem/index.tsx
+++ b/src/features/mypage/workspace/category/components/CategoryItem/index.tsx
@@ -5,17 +5,34 @@ import { CongressCategoryItem } from '@src/queries/category/useGetCategoryListQu
 import useInput from '@src/hooks/useInput';
 import CircleCloseFilled from '@src/components/icons/CircleCloseFilled';
 import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
+import { confirm } from '@src/components/ui/Modal/confirm';
+import { useDispatch } from 'react-redux';
+import { tempRemoveCategory } from '../../slices/category';
+import { editCongressCategoryItem } from '../../types/category';
 
 interface CategoryItemProps {
-  data: CongressCategoryItem;
+  data: editCongressCategoryItem;
   isEdit?: boolean;
 }
 
 const CategoryItem: FC<CategoryItemProps> = (props) => {
   const { isEdit, data } = props;
   const [categoryName, handleChangeCategoryName] = useInput<string>(data?.categoryName);
+  const dispatch = useDispatch();
 
-  const handleClickDelete = () => {};
+  const handleClickDelete = () => {
+    confirm({
+      content: '기존 회의 기록은 변하지 않지만,\n새로운 회의에서는 더이상 사용할 수 없어요.',
+      cancelBtnName: '유지할래요',
+      okBtnName: '삭제할래요',
+      onOk: () =>
+        dispatch(
+          tempRemoveCategory(
+            data.tempCongressCategoryId ? { tempCongressCategoryId: data.tempCongressCategoryId } : { ...data }
+          )
+        ),
+    });
+  };
 
   return (
     <div {...stylex.props(Styles.Container)}>

--- a/src/features/mypage/workspace/category/queries/usePutCongressCategory.tsx
+++ b/src/features/mypage/workspace/category/queries/usePutCongressCategory.tsx
@@ -1,0 +1,56 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+
+type ResponseData = null;
+
+interface CongressCategoryItem {
+  CongressCategoryId: number;
+  categoryName: string;
+}
+
+interface CongressCategoryListInfo {
+  congressCategoryList: CongressCategoryItem[];
+  deleteCongressCategoryList: CongressCategoryItem[];
+}
+
+const putCongressCategoryApi = async (WorkspaceId, data: CongressCategoryListInfo): ResponseData => {
+  const response = await clientInstance.put(`/v1/workspace/@${WorkspaceId}/congress/cateogy`, data);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 회의실 카테고리를 수정하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 회의실 카테고리 수정 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const usePutCongressCategory = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: CongressCategoryListInfo) => putCongressCategoryApi(workspaceId, data),
+    onSuccess: (data, variables) => {
+      // 업데이트 후 회의실 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['categoryList'] });
+    },
+    onError: (error, variables, context) => {
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
+  });
+
+  return mutation;
+};
+
+export default usePutCongressCategory;

--- a/src/features/mypage/workspace/category/slices/category.ts
+++ b/src/features/mypage/workspace/category/slices/category.ts
@@ -3,11 +3,14 @@ import { editCongressCategoryItem } from '../types/category';
 
 export interface CategoryState {
   editCongressCategoryList: editCongressCategoryItem[];
+  tempDeleteCongressCategoryList: editCongressCategoryItem[];
 }
 
 const initialState: CategoryState = {
   // 회의실 카테고리 저장
   editCongressCategoryList: [],
+  // 삭제한 회의실 카테고리 임시 리스트
+  tempDeleteCongressCategoryList: [],
 };
 
 export const CategorySlice = createSlice({
@@ -29,10 +32,28 @@ export const CategorySlice = createSlice({
         { ...action.payload, tempCongressCategoryId },
       ];
     },
+    // 회의실 카테고리 제거
+    tempRemoveCategory: (state, action) => {
+      // 회의실 카테고리 제거 시, 임시로 생성한 카테고리와 기존 카테고리를 별도로 처리해서 제거
+      const filterRemoveCategoryList = state.editCongressCategoryList.filter((item) => {
+        if (item.CongressCategoryId) {
+          return item.CongressCategoryId !== action.payload.CongressCategoryId;
+        }
+
+        return item.tempCongressCategoryId !== action.payload.tempRoomId;
+      });
+
+      // RoomId가 존재하는 경우에만 회의실 제거 리스트에 추가
+      if (action.payload.RoomId) {
+        state.tempDeleteCongressCategoryList = [...state.tempDeleteCongressCategoryList, action.payload];
+      }
+
+      state.editCongressCategoryList = filterRemoveCategoryList;
+    },
   },
 });
 
 // Action creators are generated for each case reducer function
-export const { saveCategoryList, addCategory } = CategorySlice.actions;
+export const { saveCategoryList, addCategory, tempRemoveCategory } = CategorySlice.actions;
 
 export default CategorySlice.reducer;

--- a/src/features/mypage/workspace/category/slices/category.ts
+++ b/src/features/mypage/workspace/category/slices/category.ts
@@ -40,11 +40,11 @@ export const CategorySlice = createSlice({
           return item.CongressCategoryId !== action.payload.CongressCategoryId;
         }
 
-        return item.tempCongressCategoryId !== action.payload.tempRoomId;
+        return item.tempCongressCategoryId !== action.payload.tempCongressCategoryId;
       });
 
-      // RoomId가 존재하는 경우에만 회의실 제거 리스트에 추가
-      if (action.payload.RoomId) {
+      // CongressCategoryId가 존재하는 경우에만 회의실 제거 리스트에 추가
+      if (action.payload.CongressCategoryId) {
         state.tempDeleteCongressCategoryList = [...state.tempDeleteCongressCategoryList, action.payload];
       }
 

--- a/src/features/mypage/workspace/category/slices/category.ts
+++ b/src/features/mypage/workspace/category/slices/category.ts
@@ -18,10 +18,21 @@ export const CategorySlice = createSlice({
     saveCategoryList: (state, action) => {
       state.editCongressCategoryList = action.payload;
     },
+    // 회의실 카테고리 추가
+    addCategory: (state, action) => {
+      // 임시로 생성한 카테고리를 제거할 때, 고유 id 값으로 판별하기 위해 tempCongressCategoryId 생성
+      const tempCongressCategoryId =
+        state.editCongressCategoryList.filter((item) => item.tempCongressCategoryId).length + 1;
+
+      state.editCongressCategoryList = [
+        ...state.editCongressCategoryList,
+        { ...action.payload, tempCongressCategoryId },
+      ];
+    },
   },
 });
 
 // Action creators are generated for each case reducer function
-export const { saveCategoryList } = CategorySlice.actions;
+export const { saveCategoryList, addCategory } = CategorySlice.actions;
 
 export default CategorySlice.reducer;

--- a/src/pages/mypage/workspace/category.tsx
+++ b/src/pages/mypage/workspace/category.tsx
@@ -11,11 +11,15 @@ import useGetCategoryListQuery from '@src/queries/category/useGetCategoryListQue
 import { saveCategoryList } from '@src/features/mypage/workspace/category/slices/category';
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import AddCategoryBottomSheet from '@src/features/mypage/workspace/category/components/AddCategoryBottomSheet';
+import usePutCongressCategory from '@src/features/mypage/workspace/category/queries/usePutCongressCategory';
 
 const Category = () => {
   const { data } = useGetCategoryListQuery();
+  const mutation = usePutCongressCategory();
   const dispatch = useDispatch();
-  const { editCongressCategoryList } = useSelector((state: RootState) => state.category);
+  const { editCongressCategoryList, tempDeleteCongressCategoryList } = useSelector(
+    (state: RootState) => state.category
+  );
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const { renderModal } = useRenderModal();
 
@@ -23,6 +27,18 @@ const Category = () => {
     name: isEdit ? '완료' : '수정',
     isActive: isEdit,
     onClick: () => {
+      const removeTempCongressCategoryIdCongressCategoryList = editCongressCategoryList.map((item) => {
+        const { tempCongressCategoryId = null, ...anotherItem } = item;
+
+        return tempCongressCategoryId ? anotherItem : item;
+      });
+
+      if (isEdit) {
+        mutation.mutate({
+          congressCategoryList: removeTempCongressCategoryIdCongressCategoryList,
+          deleteCongressCategoryList: tempDeleteCongressCategoryList,
+        });
+      }
       setIsEdit(!isEdit);
     },
   };

--- a/src/pages/mypage/workspace/category.tsx
+++ b/src/pages/mypage/workspace/category.tsx
@@ -9,12 +9,15 @@ import MainLayout from '@src/layouts/MainLayout';
 import CategoryItem from '@src/features/mypage/workspace/category/components/CategoryItem';
 import useGetCategoryListQuery from '@src/queries/category/useGetCategoryListQuery';
 import { saveCategoryList } from '@src/features/mypage/workspace/category/slices/category';
+import useRenderModal from '@src/hooks/ui/useRenderModal';
+import AddCategoryBottomSheet from '@src/features/mypage/workspace/category/components/AddCategoryBottomSheet';
 
 const Category = () => {
   const { data } = useGetCategoryListQuery();
   const dispatch = useDispatch();
   const { editCongressCategoryList } = useSelector((state: RootState) => state.category);
   const [isEdit, setIsEdit] = useState<boolean>(false);
+  const { renderModal } = useRenderModal();
 
   const completeBtnProps = {
     name: isEdit ? '완료' : '수정',
@@ -22,6 +25,10 @@ const Category = () => {
     onClick: () => {
       setIsEdit(!isEdit);
     },
+  };
+
+  const handleClickAddCategory = () => {
+    renderModal(AddCategoryBottomSheet, null);
   };
 
   useEffect(() => {
@@ -50,7 +57,11 @@ const Category = () => {
 
         {/* 카테고리 추가 */}
         {isEdit && (
-          <button type="button" {...stylex.props(Styles.AddCategoryBtn, Typography.TextSmallMedium)} onClick={null}>
+          <button
+            type="button"
+            {...stylex.props(Styles.AddCategoryBtn, Typography.TextSmallMedium)}
+            onClick={handleClickAddCategory}
+          >
             <PlusOutlined width={24} height={24} />
             <span>카테고리 추가</span>
           </button>

--- a/src/pages/mypage/workspace/category.tsx
+++ b/src/pages/mypage/workspace/category.tsx
@@ -33,7 +33,7 @@ const Category = () => {
 
   useEffect(() => {
     if (isEdit) {
-      dispatch(saveCategoryList(data.congressCategoryList));
+      dispatch(saveCategoryList(data?.congressCategoryList));
     }
   }, [isEdit]);
 

--- a/src/queries/category/useGetCategoryListQuery.tsx
+++ b/src/queries/category/useGetCategoryListQuery.tsx
@@ -37,7 +37,7 @@ const useGetCategoryListQuery = () => {
   const workspaceId = data?.workspaceList[0]?.WorkspaceId;
 
   const result = useQuery({
-    queryKey: ['category'],
+    queryKey: ['categoryList'],
     queryFn: () => getCongressCategoryListApi(workspaceId),
     enabled: Boolean(workspaceId),
   });


### PR DESCRIPTION
# 작업 내용
- 카테고리 추가 기능 구현
   - 카테고리 추가를 위한 Bottom Sheet 컴포넌트 구현
- 카테고리 삭제 기능 구현
   - 회의실 수정 기능과 동일한 방식으로 구현함.
   - 임시로 생성된 카테고리를 제거할려면 고유한 값이 있어야 해서 tempCongressCategoryId를 생성해줌.
   - tempCongressCategoryId가 존재하면 임시로 생성된 카테고리이므로 editCongressCategoryList에서만 지워주고 deleteCongressCategoryList에는 추가해주지 않음.
   - 그러나 원래 존재하던 카테고리라면 editCongressCategoryList에서도 지워주고, deleteCongressCategoryList에 추가해서 삭제할 카테고리 데이터라는 것을 서버에 알림.
- 리액트 쿼리를 사용하여 회의실 카테고리 수정 기능 구현
   - 데이터 수정이 완료되면 쿼리 무효화를 통해 회의실 카테고리 데이터를 다시 가져옴.
- 카테고리 리스트 로드 Query Key 이름 변경
   - Category를 CategoryList로 변경했는데 Category라는 쿼리 키 이름이 한개의 카테고리를 로드하는 느낌이 들어서 수정함.