### PR TITLE
Feat(TSK-22): 워크스페이스가 존재하지 않는 경우에 대한 홈 화면 퍼블리싱

### DIFF
--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import stylex from '@stylexjs/stylex';
+import { useSelector } from 'react-redux';
+import { RootState } from '@src/store';
 
 /**
  * 홈 화면의 타임라인을 나타내는 컴포넌트
+ * - 워크스페이스가 존재하지 않는 경우에 대한 화면도 같이 구현함.
  */
 const TimeLine = () => {
-  return (
+  const { isWorkspace } = useSelector((state: RootState) => state.workspace);
+
+  return isWorkspace ? (
+    // 워크스페이스가 존재할 때 보여지는 타임 라인
     <div {...stylex.props(Styles.container)}>
       <div {...stylex.props(Styles.timeAndMeetingDivider)} />
       <div {...stylex.props(Styles.scrollContainer)}>
@@ -20,6 +26,27 @@ const TimeLine = () => {
               <div {...stylex.props(Styles.categoryTag)}>기획</div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+  ) : (
+    // 워크스페이스가 존재하지 않을 때 보여지는 타임라인 (시간만 보여주고 스케줄 상세 설명 영역은 비어있음)
+    <div {...stylex.props(Styles.NoScheduleContainer)}>
+      <div {...stylex.props(Styles.timeAndMeetingDivider)} />
+      <div {...stylex.props(Styles.NoContentScrollContainer)}>
+        <div {...stylex.props(Styles.timeAndMeetingContent)}>
+          <div {...stylex.props(Styles.timeContent)}>
+            <span {...stylex.props(Styles.timeText)}>09:00</span>
+            <div {...stylex.props(Styles.timeDot)} />
+          </div>
+          <div {...stylex.props(Styles.NoMeetingContent)} />
+        </div>
+        <div {...stylex.props(Styles.timeAndMeetingContent)}>
+          <div {...stylex.props(Styles.timeContent)}>
+            <span {...stylex.props(Styles.timeText)}>10:00</span>
+            <div {...stylex.props(Styles.timeDot)} />
+          </div>
+          <div {...stylex.props(Styles.NoMeetingContent)} />
         </div>
       </div>
     </div>
@@ -68,6 +95,7 @@ const Styles = stylex.create({
     alignItems: 'center',
   },
   timeText: {
+    width: '47px',
     paddingRight: '9px',
     fontSize: '1.4rem',
     fontWeight: '400',
@@ -111,5 +139,24 @@ const Styles = stylex.create({
     fontWeight: 500,
     lineHeight: '100%',
     color: 'var(--Base-White)',
+  },
+  NoScheduleContainer: {
+    width: '100%',
+    height: '176px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '24px',
+    backgroundColor: '#FAFAFA',
+    position: 'relative',
+    borderTop: '1px solid #F2F2F2',
+    borderBottom: '1px solid #F2F2F2',
+  },
+  NoMeetingContent: {
+    height: '52px',
+  },
+  NoContentScrollContainer: {
+    paddingTop: '30px',
+    height: '176px',
+    overflowY: 'auto',
   },
 });

--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -13,7 +13,7 @@ const TimeLine = () => {
   return isWorkspace ? (
     // 워크스페이스가 존재할 때 보여지는 타임 라인
     <div {...stylex.props(Styles.container)}>
-      <div {...stylex.props(Styles.timeAndMeetingDivider)} />
+      <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
       <div {...stylex.props(Styles.scrollContainer)}>
         <div {...stylex.props(Styles.timeAndMeetingContent)}>
           <div {...stylex.props(Styles.timeContent)}>
@@ -32,7 +32,7 @@ const TimeLine = () => {
   ) : (
     // 워크스페이스가 존재하지 않을 때 보여지는 타임라인 (시간만 보여주고 스케줄 상세 설명 영역은 비어있음)
     <div {...stylex.props(Styles.NoScheduleContainer)}>
-      <div {...stylex.props(Styles.timeAndMeetingDivider)} />
+      <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
       <div {...stylex.props(Styles.NoContentScrollContainer)}>
         <div {...stylex.props(Styles.timeAndMeetingContent)}>
           <div {...stylex.props(Styles.timeContent)}>
@@ -77,13 +77,13 @@ const Styles = stylex.create({
     left: 0,
     overflowY: 'auto',
   },
-  timeAndMeetingDivider: {
+  timeAndMeetingDivider: (isWorkspace) => ({
     position: 'absolute',
     top: 0,
     left: '67px',
-    height: '100%',
+    height: isWorkspace ? '100vh' : '100%',
     borderRight: '1px solid #E2E2E2',
-  },
+  }),
   timeAndMeetingContent: {
     padding: '0 16px',
     display: 'flex',

--- a/src/features/home/components/UserGreeting/index.tsx
+++ b/src/features/home/components/UserGreeting/index.tsx
@@ -1,20 +1,20 @@
 import ProfileImg from '@src/components/ui/ProfileImg';
 import stylex from '@stylexjs/stylex';
 import React, { FC } from 'react';
-import useGetWorkspaceMainInfoQuery from '../../queries/useGetWorkspaceMainInfoQuery';
+import useGetMyPageProfileQuery from '@src/features/mypage/profile/queries/useGetMyPageProfileQuery';
 
 /**
  * 홈 화면에서 사용자에게 인사를 하는 내용을 담은 컴포넌트
  */
 const UserGreeting = () => {
-  const { data } = useGetWorkspaceMainInfoQuery();
+  const { data } = useGetMyPageProfileQuery();
 
   return (
     <div {...stylex.props(Styles.container)}>
-      <ProfileImg src={data.memberInfo.profileImgUrl} size={50} borderProperties={{ radius: '50%' }} />
+      <ProfileImg src={data?.profile.profileImgUrl} size={50} borderProperties={{ radius: '50%' }} />
       <div {...stylex.props(Styles.textContent)}>
         <p {...stylex.props(Styles.greetingText)}>룸렛에 오신걸 환영해요 🖐🏻</p>
-        <p {...stylex.props(Styles.nicknameText)}>{data.memberInfo.displayName}님</p>
+        <p {...stylex.props(Styles.nicknameText)}>{data?.profile.displayName}님</p>
       </div>
     </div>
   );

--- a/src/features/home/components/UserGreeting/nonWorkspaceUser.tsx
+++ b/src/features/home/components/UserGreeting/nonWorkspaceUser.tsx
@@ -1,0 +1,49 @@
+import ProfileImg from '@src/components/ui/ProfileImg';
+import stylex from '@stylexjs/stylex';
+import React, { FC } from 'react';
+import useGetMyPageProfileQuery from '@src/features/mypage/profile/queries/useGetMyPageProfileQuery';
+
+/**
+ * 홈 화면에서 아직 워크스페이스에 가입되지 않은 사용자에게 인사를 하는 내용을 담은 컴포넌트
+ */
+const NonWorkspaceUserGreeting = () => {
+  const { data } = useGetMyPageProfileQuery();
+
+  return (
+    <div {...stylex.props(Styles.container)}>
+      <ProfileImg src={data?.profile.profileImgUrl} size={50} borderProperties={{ radius: '50%' }} />
+      <div {...stylex.props(Styles.textContent)}>
+        <p {...stylex.props(Styles.greetingText)}>룸렛에 오신걸 환영해요 🖐🏻</p>
+        <p {...stylex.props(Styles.nicknameText)}>{data?.profile.displayName}님</p>
+      </div>
+    </div>
+  );
+};
+
+export default NonWorkspaceUserGreeting;
+
+const Styles = stylex.create({
+  container: {
+    width: '100%',
+    display: 'flex',
+    gap: '16px',
+    alignItems: 'center',
+  },
+  textContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  greetingText: {
+    fontSize: '1.4rem',
+    fontWeight: '400',
+    lineHeight: '1.8rem',
+    color: '#999999',
+  },
+  nicknameText: {
+    fontSize: '1.8rem',
+    fontWeight: '700',
+    lineHeight: '2.4rem',
+    color: '#333333',
+  },
+});

--- a/src/features/home/components/UserGreeting/workspaceUser.tsx
+++ b/src/features/home/components/UserGreeting/workspaceUser.tsx
@@ -1,26 +1,26 @@
 import ProfileImg from '@src/components/ui/ProfileImg';
 import stylex from '@stylexjs/stylex';
 import React, { FC } from 'react';
-import useGetMyPageProfileQuery from '@src/features/mypage/profile/queries/useGetMyPageProfileQuery';
+import useGetWorkspaceMainInfoQuery from '../../queries/useGetWorkspaceMainInfoQuery';
 
 /**
- * 홈 화면에서 사용자에게 인사를 하는 내용을 담은 컴포넌트
+ * 홈 화면에서 워크스페이스에 가입된 사용자에게 인사를 하는 내용을 담은 컴포넌트
  */
-const UserGreeting = () => {
-  const { data } = useGetMyPageProfileQuery();
+const WorkspaceUserGreeting = () => {
+  const { data } = useGetWorkspaceMainInfoQuery();
 
   return (
     <div {...stylex.props(Styles.container)}>
-      <ProfileImg src={data?.profile.profileImgUrl} size={50} borderProperties={{ radius: '50%' }} />
+      <ProfileImg src={data?.memberInfo.profileImgUrl} size={50} borderProperties={{ radius: '50%' }} />
       <div {...stylex.props(Styles.textContent)}>
         <p {...stylex.props(Styles.greetingText)}>룸렛에 오신걸 환영해요 🖐🏻</p>
-        <p {...stylex.props(Styles.nicknameText)}>{data?.profile.displayName}님</p>
+        <p {...stylex.props(Styles.nicknameText)}>{data?.memberInfo.displayName}님</p>
       </div>
     </div>
   );
 };
 
-export default UserGreeting;
+export default WorkspaceUserGreeting;
 
 const Styles = stylex.create({
   container: {

--- a/src/features/mypage/profile/queries/useGetMyPageProfileQuery.tsx
+++ b/src/features/mypage/profile/queries/useGetMyPageProfileQuery.tsx
@@ -1,0 +1,37 @@
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+interface ProfileInfo {
+  success: boolean;
+  code: number;
+  profile: {
+    displayName: string;
+    profileImgUrl: string | null;
+    email: string;
+  };
+}
+const getMyPageProfileApi = async (): Promise<ProfileInfo> => {
+  const response = await clientInstance.get(`/v1/mypage/profile`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 사용자 프로필 정보를 가져오는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 프로필 정보 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useGetMyPageProfileQuery = () => {
+  const result = useQuery({
+    queryKey: ['profile'],
+    queryFn: () => getMyPageProfileApi(),
+  });
+
+  return result;
+};
+
+export default useGetMyPageProfileQuery;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,8 +1,10 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import stylex from '@stylexjs/stylex';
 import { colors } from '../../public/styles/vars.stylex';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@src/store';
+import { workspaceExists } from '@src/slices/workspace';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 
 interface MainLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
   isScroll?: boolean; // 전체 화면에 스크롤이 적용되게 할지 말지 결정
@@ -13,6 +15,13 @@ interface MainLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
 const MainLayout: FC<MainLayoutProps> = (props) => {
   const { isScroll, backgroundColor, children } = props;
   const modal = useSelector((state: RootState) => state.modal);
+  const { data } = useGetWorkspaceListQuery();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    // 워크스페이스 존재 여부 체크
+    dispatch(workspaceExists(!!data?.workspaceCount));
+  }, []);
 
   return (
     <div id="main-layout" {...stylex.props(Styles.container(isScroll, backgroundColor))}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,9 +4,14 @@ import GnbNavLayout from '@src/layouts/GnbNavLayout';
 import UserGreeting from '@src/features/home/components/UserGreeting';
 import MeetingStatus from '@src/features/home/components/MeetingStatus';
 import TimeLine from '@src/features/home/components/TimeLine';
+import { colors, Typography } from '../../public/styles/vars.stylex';
+import PlusOutlined from '@src/components/icons/PlusOutlined';
+import Link from 'next/link';
+import { useSelector } from 'react-redux';
+import { RootState } from '@src/store';
 
 const Home = () => {
-  console.log('');
+  const { isWorkspace } = useSelector((state: RootState) => state.workspace);
 
   return (
     <GnbNavLayout backgroundColor="#FAFAFA">
@@ -24,6 +29,20 @@ const Home = () => {
         <h2 {...stylex.props(Styles.sectionTitle, Styles.timeLineSectionTitle)}>타임라인</h2>
         <TimeLine />
       </section>
+
+      {/* 워크스페이스가 없는 경우 */}
+      {!isWorkspace && (
+        <div {...stylex.props(Styles.CreateWorkspaceBtnWrapper)}>
+          {/* 워크스페이스 등록하기 버튼 */}
+          <Link
+            href="/mypage/create-workspace"
+            {...stylex.props(Typography.SubtitleSmallBold, Styles.CreateWorkspaceBtn)}
+          >
+            <PlusOutlined width={24} height={24} />
+            워크스페이스 등록하기
+          </Link>
+        </div>
+      )}
     </GnbNavLayout>
   );
 };
@@ -43,7 +62,7 @@ const Styles = stylex.create({
     marginBottom: '24px',
   },
   timeLineSection: {
-    height: '100%',
+    height: 'fit-content',
   },
   sectionTitle: {
     marginBottom: '16px',
@@ -54,5 +73,24 @@ const Styles = stylex.create({
   },
   timeLineSectionTitle: {
     padding: '0 16px',
+  },
+  CreateWorkspaceBtnWrapper: {
+    position: 'relative',
+    padding: '0 16px',
+  },
+  CreateWorkspaceBtn: {
+    maxWidth: '735px',
+    width: 'calc(100% - 32px)',
+    padding: '15px',
+    position: 'fixed',
+    bottom: '101px',
+    display: 'flex',
+    gap: '12px',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '16px',
+    background: colors.gray900,
+    color: colors.white500,
+    textDecoration: 'none',
   },
 });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import stylex from '@stylexjs/stylex';
 import GnbNavLayout from '@src/layouts/GnbNavLayout';
-import UserGreeting from '@src/features/home/components/UserGreeting';
+import WorkspaceUserGreeting from '@src/features/home/components/UserGreeting/workspaceUser';
+import NonWorkspaceUserGreeting from '@src/features/home/components/UserGreeting/nonWorkspaceUser';
 import MeetingStatus from '@src/features/home/components/MeetingStatus';
 import TimeLine from '@src/features/home/components/TimeLine';
 import { colors, Typography } from '../../public/styles/vars.stylex';
@@ -17,7 +18,7 @@ const Home = () => {
     <GnbNavLayout backgroundColor="#FAFAFA">
       {/* 프로필 섹션 */}
       <section {...stylex.props(Styles.userGreetingSection)}>
-        <UserGreeting />
+        {isWorkspace ? <WorkspaceUserGreeting /> : <NonWorkspaceUserGreeting />}
       </section>
       {/* 회의 현황 섹션 */}
       <section {...stylex.props(Styles.meetingStatusSection)}>

--- a/src/slices/workspace.tsx
+++ b/src/slices/workspace.tsx
@@ -1,0 +1,25 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export interface WorkspaceState {
+  isWorkspace: boolean;
+}
+
+const initialState: WorkspaceState = {
+  isWorkspace: false,
+};
+
+export const WorkspaceSlice = createSlice({
+  name: 'workspace',
+  initialState: initialState,
+  reducers: {
+    // 워크스페이스 존재 여부 데이터 저장
+    workspaceExists: (state, action: { payload: boolean }) => {
+      state.isWorkspace = action.payload;
+    },
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const { workspaceExists } = WorkspaceSlice.actions;
+
+export default WorkspaceSlice.reducer;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import congressRoomReducer from '@features/mypage/workspace/congress-room/slice/
 import modalReducer from '@src/slices/modal';
 import memberReducer from '@features/mypage/workspace/member/slices/member';
 import categoryReducer from '@features/mypage/workspace/category/slices/category';
+import workspaceReducer from '@src/slices/workspace';
 
 export const store = configureStore({
   reducer: {
@@ -14,6 +15,7 @@ export const store = configureStore({
     modal: modalReducer,
     member: memberReducer,
     category: categoryReducer,
+    workspace: workspaceReducer,
   },
 });
 


### PR DESCRIPTION
# 작업 내용
- 워크스페이스 존재 여부를 체크하기 위한 코드 추가
   - 메인 레이아웃 컴포넌트에서 워크스페이스 존재 여부를 체크할 수 있도록 코드 구현
      - 워크스페이스 여부 데이터를 저장하는 리듀서 생성
- 홈 화면에서 워크스페이스가 존재하지 않는 화면에 대해 퍼블리싱
   - 워크스페이스 존재 여부에 따라 홈 화면에서 프로필 데이터를 로드하는 api가 다르게 사용됨.
      - 워크스페이스가 존재하지 않는 경우에는 워크스페이스 메인 정보 로드 api를 사용할 수 없기 때문에 워크스페이스가 존재하는 유저용 프로필 컴포넌트와 그렇지 않은 유저를 다루는 프로필 컴포넌트를 별도로 생성해줌.
      - 워크스페이스가 존재하지 않는 유저 프로필을 가져오기 위해서 React-query를 사용하여 사용자 프로필 정보를 가져오는 커스텀 훅 구현
 