### PR TITLE
Feat(TSK-22): 홈 화면 타임라인에 회의 리스트 API 연결

### DIFF
--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import stylex from '@stylexjs/stylex';
 import { useSelector } from 'react-redux';
 import { RootState } from '@src/store';
+import useGetWorkspaceCongressListQuery from '@src/queries/workspace/useGetWorkspaceCongressListQuery';
+import dayjs from 'dayjs';
+import Link from 'next/link';
 
 /**
  * 홈 화면의 타임라인을 나타내는 컴포넌트
@@ -9,24 +12,32 @@ import { RootState } from '@src/store';
  */
 const TimeLine = () => {
   const { isWorkspace } = useSelector((state: RootState) => state.workspace);
+  const { data } = useGetWorkspaceCongressListQuery({ date: dayjs().format('YYYY-MM-DD') });
 
   return isWorkspace ? (
     // 워크스페이스가 존재할 때 보여지는 타임 라인
     <div {...stylex.props(Styles.container)}>
       <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
       <div {...stylex.props(Styles.scrollContainer)}>
-        <div {...stylex.props(Styles.timeAndMeetingContent)}>
-          <div {...stylex.props(Styles.timeContent)}>
-            <span {...stylex.props(Styles.timeText)}>09:00</span>
-            <div {...stylex.props(Styles.timeDot)} />
-          </div>
-          <div {...stylex.props(Styles.meetingContent)}>
-            <div {...stylex.props(Styles.detailContent)}>
-              <p {...stylex.props(Styles.titleText)}>룸렛 회의</p>
-              <div {...stylex.props(Styles.categoryTag)}>기획</div>
+        {data.congressList.map((item) => (
+          <div {...stylex.props(Styles.timeAndMeetingContent)}>
+            <div {...stylex.props(Styles.timeContent)}>
+              <span {...stylex.props(Styles.timeText)}>{item.startTime}</span>
+              <div {...stylex.props(Styles.timeDot)} />
             </div>
+
+            <Link href={`/reservations/${item.CongressId}`} {...stylex.props(Styles.meetingLink)}>
+              <div {...stylex.props(Styles.meetingContent)}>
+                <div {...stylex.props(Styles.detailContent(item.congressCategory.hexcode))}>
+                  <p {...stylex.props(Styles.titleText)}>{item.congressTitle}</p>
+                  <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
+                    {item.congressCategory.categoryName}
+                  </div>
+                </div>
+              </div>
+            </Link>
           </div>
-        </div>
+        ))}
       </div>
     </div>
   ) : (
@@ -68,6 +79,9 @@ const Styles = stylex.create({
     borderTop: '1px solid #F2F2F2',
   },
   scrollContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '14px',
     width: '100%',
     height: 'calc(100vh - 374px)',
     paddingTop: '30px',
@@ -117,29 +131,29 @@ const Styles = stylex.create({
     flexDirection: 'column',
     gap: '14px',
   },
-  detailContent: {
+  detailContent: (hexcode) => ({
     padding: '16px',
     display: 'flex',
     justifyContent: 'space-between',
     backgroundColor: 'var(--Base-White)',
-    borderLeft: '2px solid var(--Blue-300)',
+    borderLeft: `2px solid ${hexcode}`,
     borderRadius: '0 16px 16px 0',
-  },
+  }),
   titleText: {
     fontSize: '1.4rem',
     fontWeight: 700,
     lineHeight: '2rem',
     color: '#61686D',
   },
-  categoryTag: {
+  categoryTag: (hexcode) => ({
     padding: '4px 8px',
-    backgroundColor: 'var(--Blue-300)',
+    backgroundColor: hexcode,
     borderRadius: '20px',
     fontSize: '1.2rem',
     fontWeight: 500,
     lineHeight: '100%',
     color: 'var(--Base-White)',
-  },
+  }),
   NoScheduleContainer: {
     width: '100%',
     height: '176px',
@@ -158,5 +172,9 @@ const Styles = stylex.create({
     paddingTop: '30px',
     height: '176px',
     overflowY: 'auto',
+  },
+  meetingLink: {
+    width: '100%',
+    textDecoration: 'none',
   },
 });

--- a/src/queries/workspace/useGetWorkspaceCongressListQuery.tsx
+++ b/src/queries/workspace/useGetWorkspaceCongressListQuery.tsx
@@ -1,0 +1,84 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+interface CongressInfo {
+  success: boolean;
+  code: number;
+  congressList: CongressListItem[];
+  date: string;
+  congressCount: number;
+}
+
+interface CongressListItem {
+  startTime: string;
+  endTime: string;
+  date: string;
+  CongressId: number;
+  congressTitle: string;
+  congressCategory: CongressCategory;
+  congressRoom: CongressRoom;
+  attendMemberList: AttendMemberListItem[];
+  attendTeamList: AttendTeamListItem[];
+}
+
+interface AttendTeamListItem {
+  TeamId: number;
+  teamName: string;
+}
+
+interface AttendMemberListItem {
+  MemberId: number;
+  displayName: string;
+  profileImgUrl: null;
+}
+
+interface CongressRoom {
+  RoomId: number;
+  roomName: string;
+}
+
+interface CongressCategory {
+  CongressCategoryId: number;
+  categoryType: string;
+  categoryName: string;
+  hexcode: string;
+}
+
+interface Params {
+  date?: string;
+  cc?: number;
+  my?: number | string;
+  rct?: string;
+}
+
+const getWorkspaceCongressListApi = async (WorkspaceId: number, params: Params): Promise<CongressInfo> => {
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/congress/list`, { params });
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 회의 리스트를 불러오는 커스텀 훅
+ * @param skeywd 검색어
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 회의 리스트 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useGetWorkspaceCongressListQuery = (params: Params) => {
+  const { data } = useGetWorkspaceListQuery();
+  const WorkspaceId = data?.workspaceList[0].WorkspaceId;
+
+  const result = useQuery({
+    queryKey: ['congressList', ...Object.values(params)],
+    queryFn: () => getWorkspaceCongressListApi(WorkspaceId, params),
+    enabled: Boolean(WorkspaceId), // WorkspaceId가 정의되어 있지 않은 경우, 첫 렌더링시 요청이 이뤄지지 않게 함.
+  });
+
+  return result;
+};
+
+export default useGetWorkspaceCongressListQuery;


### PR DESCRIPTION
# 작업 내용
- 홈 화면 타임라인에 회의 리스트 API 연결
   - React-query를 사용하여 워크스페이스 회의 리스트를 불러오는 커스텀 훅 구현