### PR TITLE
Feat(TSK-28): 회의 예약 상세 정보 페이지 디자인 수정 및 API 연결

### DIFF
--- a/src/components/ui/Header/index.tsx
+++ b/src/components/ui/Header/index.tsx
@@ -5,7 +5,7 @@ import { Typography, colors } from '../../../../public/styles/vars.stylex';
 import ArrowHeadOutlined from '@src/components/icons/ArrowHeadOutlined';
 
 type HeaderProps = {
-  title: string; // 제목
+  title?: string; // 제목
   prevUrl?: string; // 이전으로 이동할 url
   rightBtnInfo?: {
     name: string;

--- a/src/features/reservation/components/ReservationInfo/index.tsx
+++ b/src/features/reservation/components/ReservationInfo/index.tsx
@@ -2,15 +2,25 @@ import React from 'react';
 import stylex from '@stylexjs/stylex';
 import { colors, Typography } from '../../../../../public/styles/vars.stylex';
 import EllipsisOutlined from '@src/components/icons/EllipsisOutlined';
+import ProfileImg from '@src/components/ui/ProfileImg';
+import useGetWorkspaceCongressQuery from '../../queries/useGetWorkspaceCongressQuery';
+import dayjs from 'dayjs';
+import { useRouter } from 'next/router';
 
 const ReservationInfo = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const { data } = useGetWorkspaceCongressQuery({ cgsid: Number(id) });
+
   return (
     <div>
       {/* 카테고리 태그 및 회의 제목 */}
       <div {...stylex.props(Styles.categoryAndTitleContainer)}>
-        <div {...stylex.props(Styles.categoryTag)}>디자인</div>
+        <div {...stylex.props(Styles.categoryTag(data?.congress.congressCategory.hexcode))}>
+          {data?.congress.congressCategory.categoryName}
+        </div>
         <div {...stylex.props(Styles.TitleAndShowMoreContainer)}>
-          <h1 {...stylex.props(Typography.TextLargeBold)}>사용성 관련 기획 회의</h1>
+          <h1 {...stylex.props(Typography.TextLargeBold)}>{data?.congress.congressTitle}</h1>
           <button type="button">
             <EllipsisOutlined width="24" height="24" />
           </button>
@@ -22,21 +32,37 @@ const ReservationInfo = () => {
         <ul {...stylex.props(Styles.List)}>
           <li {...stylex.props(Styles.horizonItem)}>
             <div {...stylex.props(Typography.SubtitleRegularSemiBold, Styles.CommonItem)}>장소</div>
-            <div {...stylex.props(Typography.TextSmallRegular)}>C 회의실</div>
+            <div {...stylex.props(Typography.TextSmallRegular)}>{data?.congress.congressRoom.roomName}</div>
           </li>
           <li {...stylex.props(Styles.horizonItem)}>
             <div {...stylex.props(Typography.SubtitleRegularSemiBold, Styles.CommonItem)}>날짜/시간</div>
-            <div {...stylex.props(Typography.TextSmallRegular)}>2024-03-06 10:00 ~ 11:00</div>
+            <div {...stylex.props(Typography.TextSmallRegular)}>
+              {dayjs(data?.congress.date).format('YY-MM-DD')} {data?.congress.startTime} ~ {data?.congress.endTime}
+            </div>
           </li>
           <li {...stylex.props(Styles.horizonItem)}>
             <div {...stylex.props(Typography.SubtitleRegularSemiBold, Styles.CommonItem)}>참여자</div>
-            <div>
-              <div>기획팀</div>
+
+            {/* 팀목록 */}
+            <div {...stylex.props(Styles.TeamListContainer)}>
+              {data?.congress.attendTeamList.map((teamItem) => (
+                <div {...stylex.props(Styles.TeamContainer)}>
+                  <p {...stylex.props(Styles.TeamName)}>{teamItem.teamName}</p>
+                  <div {...stylex.props(Styles.MemberListContainer)}>
+                    {teamItem.memberList.map((memberItem) => (
+                      <div {...stylex.props(Styles.MemberInfoContainer)}>
+                        <ProfileImg size={20} src={memberItem.profileImgUrl} />
+                        <span {...stylex.props(Typography.TagLargeMedium)}>{memberItem.displayName}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
             </div>
           </li>
           <li {...stylex.props(Styles.verticalItem)}>
             <div {...stylex.props(Typography.SubtitleRegularSemiBold, Styles.CommonItem)}>상세내용</div>
-            <pre {...stylex.props(Styles.ContentWrapper)}>홍길동 인턴: 당뇨 관리앱 분석 조사 발표</pre>
+            <pre {...stylex.props(Styles.ContentWrapper)}>{data?.congress.congressDescription}</pre>
           </li>
         </ul>
       </div>
@@ -47,10 +73,36 @@ const ReservationInfo = () => {
 export default ReservationInfo;
 
 const Styles = stylex.create({
+  TeamListContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+  TeamContainer: {
+    alignItems: 'center',
+    display: 'flex',
+    gap: '16px',
+  },
+  MemberListContainer: {
+    display: 'inline-flex',
+    flexWrap: 'wrap',
+    gap: '6px',
+  },
+  MemberInfoContainer: {
+    display: 'flex',
+    gap: '4px',
+    alignContent: 'center',
+  },
+  TeamName: {
+    width: '56px',
+    fontWeight: 400,
+    fontSize: '1.6rem',
+    lineHeight: '2.4rem',
+  },
   categoryAndTitleContainer: {
     padding: '16px',
   },
-  categoryTag: {
+  categoryTag: (hexcode) => ({
     width: 'fit-content',
     padding: '4px 8px',
     marginBottom: '12px',
@@ -58,8 +110,8 @@ const Styles = stylex.create({
     fontSize: '1.2rem',
     fontWeight: 500,
     color: colors.white500,
-    background: colors.red300,
-  },
+    background: hexcode,
+  }),
   TitleAndShowMoreContainer: {
     display: 'flex',
     justifyContent: 'space-between',

--- a/src/features/reservation/queries/useGetWorkspaceCongressQuery.tsx
+++ b/src/features/reservation/queries/useGetWorkspaceCongressQuery.tsx
@@ -1,0 +1,81 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+interface ResponseData {
+  success: boolean;
+  code: number;
+  congress: CongressInfo;
+}
+
+export interface CongressInfo {
+  startTime: string;
+  endTime: string;
+  date: string;
+  CongressId: number;
+  congressTitle: string;
+  congressDescription: string;
+  congressCategory: CongressCategory;
+  congressRoom: CongressRoom;
+  attendMemberList: any[];
+  attendTeamList: AttendTeamListItem[];
+}
+
+interface AttendTeamListItem {
+  TeamId: number;
+  teamName: string;
+  memberList: MemberList[];
+}
+
+interface MemberList {
+  MemberId: number;
+  displayName: string;
+  profileImgUrl: null;
+}
+
+interface CongressRoom {
+  RoomId: number;
+  roomName: string;
+}
+
+interface CongressCategory {
+  CongressCategoryId: number;
+  categoryType: string;
+  categoryName: string;
+  hexcode: string;
+}
+
+interface Params {
+  cgsid: number | string;
+}
+
+const getWorkspaceCongressApi = async (WorkspaceId: number, params: Params): Promise<ResponseData> => {
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/congress`, { params });
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 회의 정보를 불러오는 커스텀 훅
+ * @param skeywd 검색어
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 회의 정보 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useGetWorkspaceCongressQuery = (params: Params) => {
+  const { data } = useGetWorkspaceListQuery();
+  const WorkspaceId = data?.workspaceList[0].WorkspaceId;
+
+  const result = useQuery({
+    queryKey: ['congressInfo'],
+    queryFn: () => getWorkspaceCongressApi(WorkspaceId, params),
+    enabled: Boolean(WorkspaceId), // WorkspaceId가 정의되어 있지 않은 경우, 첫 렌더링시 요청이 이뤄지지 않게 함.
+  });
+
+  return result;
+};
+
+export default useGetWorkspaceCongressQuery;

--- a/src/pages/reservations/[id].tsx
+++ b/src/pages/reservations/[id].tsx
@@ -5,10 +5,13 @@ import MainLayout from '@src/layouts/MainLayout';
 import CommentTextarea from '@src/features/comment/components/CommentTextarea';
 import CommentList from '@src/features/comment/components/CommentList';
 import ReservationInfo from '@src/features/reservation/components/ReservationInfo';
+import Header from '@src/components/ui/Header';
 
 const MeetingDetails = () => {
   return (
     <MainLayout isScroll>
+      {/* 직전 페이지로 이동할 수 잇게 구현하기 */}
+      <Header prevUrl="/calendar" />
       <ReservationInfo />
 
       {/* 경계선 */}


### PR DESCRIPTION
# 작업 내용
- 회의 예약 상세 정보 페이지 디자인 수정
   - 헤더를 추가하여 뒤로가기 이동 버튼 추가
   - 참여자 부분 디자인 수정
- 회의 정보 로드 API 연결
   - React-query를 사용하여 워크스페이스 회의 정보를 불러오는 커스텀 훅 구현