### PR TITLE
Refactor(3TS-12): 캘린더 페이지에서 월간 캘린더 컴포넌트 리팩토링 및 회의 캘린더 정보, 회의 리스트 API 연결

### DIFF
--- a/src/features/calendar/components/MeetingSchedule/index.tsx
+++ b/src/features/calendar/components/MeetingSchedule/index.tsx
@@ -1,41 +1,38 @@
-import React from 'react';
+import React, { FC } from 'react';
 import stylex from '@stylexjs/stylex';
+import useGetWorkspaceCongressListQuery from '@src/queries/workspace/useGetWorkspaceCongressListQuery';
+import dayjs from 'dayjs';
+import router from 'next/router';
 
-const MeetingSchedule = () => {
+const MeetingSchedule: FC<{ selectDate: string }> = ({ selectDate }) => {
+  const { data } = useGetWorkspaceCongressListQuery({
+    date: selectDate,
+  });
+
+  const handleMeetingClick = (congressId: number) => {
+    router.push(`/reservations/${congressId}`);
+  };
+
   return (
     <div {...stylex.props(Styles.container)}>
-      <h3 {...stylex.props(Styles.selectedDateTitle)}>7.수</h3>
+      <h3 {...stylex.props(Styles.selectedDateTitle)}>{dayjs(selectDate).format('D.ddd')}</h3>
       <div {...stylex.props(Styles.meetingListContent)}>
-        <div {...stylex.props(Styles.meetingContent)}>
-          <div {...stylex.props(Styles.meetingCategoryLine)} />
-          <div {...stylex.props(Styles.detailContent)}>
-            <div {...stylex.props(Styles.infoContent)}>
-              <p {...stylex.props(Styles.titleText)}>룸렛 회의</p>
-              <p {...stylex.props(Styles.timeText)}>9시 ~ 10시</p>
+        {data?.congressList.map((item) => (
+          <div {...stylex.props(Styles.meetingContent)} onClick={() => handleMeetingClick(item.CongressId)}>
+            <div {...stylex.props(Styles.meetingCategoryLine(item.congressCategory.hexcode))} />
+            <div {...stylex.props(Styles.detailContent)}>
+              <div {...stylex.props(Styles.infoContent)}>
+                <p {...stylex.props(Styles.titleText)}>{item.congressTitle}</p>
+                <p {...stylex.props(Styles.timeText)}>
+                  {item.startTime} ~ {item.endTime}
+                </p>
+              </div>
+              <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
+                {item.congressCategory.categoryName}
+              </div>
             </div>
-            <div {...stylex.props(Styles.categoryTag)}>기획</div>
           </div>
-        </div>
-        <div {...stylex.props(Styles.meetingContent)}>
-          <div {...stylex.props(Styles.meetingCategoryLine)} />
-          <div {...stylex.props(Styles.detailContent)}>
-            <div {...stylex.props(Styles.infoContent)}>
-              <p {...stylex.props(Styles.titleText)}>룸렛 회의</p>
-              <p {...stylex.props(Styles.timeText)}>9시 ~ 10시</p>
-            </div>
-            <div {...stylex.props(Styles.categoryTag)}>기획</div>
-          </div>
-        </div>
-        <div {...stylex.props(Styles.meetingContent)}>
-          <div {...stylex.props(Styles.meetingCategoryLine)} />
-          <div {...stylex.props(Styles.detailContent)}>
-            <div {...stylex.props(Styles.infoContent)}>
-              <p {...stylex.props(Styles.titleText)}>룸렛 회의</p>
-              <p {...stylex.props(Styles.timeText)}>9시 ~ 10시</p>
-            </div>
-            <div {...stylex.props(Styles.categoryTag)}>기획</div>
-          </div>
-        </div>
+        ))}
       </div>
     </div>
   );
@@ -67,24 +64,25 @@ const Styles = stylex.create({
     height: 'auto',
     display: 'flex',
     gap: '16px',
+    cursor: 'pointer',
   },
-  meetingCategoryLine: {
+  meetingCategoryLine: (hexcode) => ({
     width: '4px',
     borderRadius: '20px',
-    backgroundColor: 'var(--Red-300)',
-  },
+    backgroundColor: hexcode,
+  }),
   detailContent: { width: '100%', display: 'flex', justifyContent: 'space-between' },
   infoContent: { display: 'flex', flexDirection: 'column', gap: '8px' },
   titleText: { fontSize: '1.6rem', fontWeight: '500', lineHeight: '2.4rem' },
   timeText: { fontSize: '1.4rem', fontWeight: '400', lineHeight: '2rem', color: 'var(--Gray-10)' },
-  categoryTag: {
+  categoryTag: (hexcode) => ({
     padding: '4px 8px',
     alignSelf: 'center',
-    backgroundColor: 'var(--Red-300)',
+    backgroundColor: hexcode,
     borderRadius: '20px',
     fontSize: '1.2rem',
     fontWeight: 500,
     lineHeight: '100%',
     color: 'var(--Base-White)',
-  },
+  }),
 });

--- a/src/features/calendar/components/MonthlyCalendar/index.tsx
+++ b/src/features/calendar/components/MonthlyCalendar/index.tsx
@@ -1,245 +1,95 @@
-import dayjs from 'dayjs';
-import React, { useEffect, useState } from 'react';
-import stylex from '@stylexjs/stylex';
-import { Swiper, SwiperSlide } from 'swiper/react';
+import React, { useEffect, useRef, useState } from 'react';
+import Slider from 'react-slick';
 
-// Import Swiper styles
-import 'swiper/css';
+import Calendar from 'react-calendar';
+import stylex from '@stylexjs/stylex';
+
+import dayjs from 'dayjs';
+import { Typography } from 'public/styles/vars.stylex';
 
 const MonthlyCalendar = () => {
-  const currentMonth = dayjs().format('YYYY-MM');
-  const prevMonth = dayjs().subtract(1, 'M').format('YYYY-MM');
-  const nextMonth = dayjs().add(1, 'M').format('YYYY-MM');
-  const [monthList, setMonthList] = useState<string[]>([prevMonth, currentMonth, nextMonth]);
-  const [selectDate, setSelectDate] = useState<number>(dayjs().date());
-  const dayOfTheWeek = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
-  const getCurrentMonth = (ym) => dayjs(ym).month();
-  const getStartDay = (ym) => Number(dayjs(ym).startOf('month').month(getCurrentMonth(ym)).day()); // 1일에 해당하는 요일
-  //   const endDay = Number(dayjs('2024-03').endOf('month').month(currentMonth).day()); // 마지막날에 해당하는 요일
-  const getLastDateOfTheMonth = (ym) => Number(dayjs('2024-03').month(getCurrentMonth(ym)).endOf('month').format('DD')); // 이번달의 마지막 날
-  const getNumOfWeek = (ym) => Math.floor(getLastDateOfTheMonth(ym) / 7) + (getStartDay(ym) > 4 ? 2 : 1); // 1일이 금요일부터 시작되면 한 주를 더 해준다.
-  const getLastDateOfTheLastMonth = (ym) =>
-    Number(
-      dayjs(ym)
-        .subtract(1, 'month')
-        .endOf('month')
-        .month(0 - 1 === -1 ? 11 : 0)
-        .format('DD')
-    ); // 지난달의 마지막 날
+  const [date, setDate] = useState<string>(dayjs().format('YYYY-MM-DD'));
+  const [slides, setSlides] = useState([
+    dayjs().format('YYYY-MM-DD'),
+    dayjs().add(1, 'month').format('YYYY-MM-DD'),
+    dayjs().add(2, 'month').format('YYYY-MM-DD'),
+  ]);
+  let sliderRef = useRef(null);
 
-  const getColorDay = (day) => {
-    switch (day) {
-      // 일요일
-      case 0:
-        return 'var(--Red-300)';
-      // 토요일
-      case 6:
-        return 'var(--Blue-300)';
-      default:
-        return '#5F5656';
-    }
+  const handleChangeDate = (value) => {
+    const selectedDate = dayjs(value).format('YYYY-MM-DD');
+
+    setDate(selectedDate);
   };
 
-  const handleClickDate = (date) => {
-    setSelectDate(date);
+  const handleFormatDay = (locale, date) => dayjs(date).format('D');
+
+  const handleFormatShortWeekday = (locale, date) => {
+    const day = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+    return day[Number(dayjs(date).format('d'))];
   };
 
-  const handleSlideChange = (swiper) => {
-    const monthFormat = 'YYYY-MM';
+  const settings = {
+    slidesToShow: 1,
+    swipeToSlide: true,
+    infinite: false,
+    adaptiveHeight: true,
+    initialSlide: 0, // 기본적으로 1번 인덱스의 슬라이드 표시
+    afterChange: (current, next) => {
+      if (current === 0) {
+        const prevMonth = dayjs(slides[0]).subtract(1, 'month').format('YYYY-MM-DD');
 
-    // 첫번째 요소를 만났을 때, 미리 이전 2달치 로드
-    if (swiper.activeIndex === 0) {
-      const firstMonthIndex = monthList[0];
-      setMonthList([
-        dayjs(firstMonthIndex).subtract(2, 'M').format(monthFormat),
-        dayjs(firstMonthIndex).subtract(1, 'M').format(monthFormat),
-        ...monthList,
-      ]);
-      swiper.slideTo(2, 0);
-    }
+        setSlides([prevMonth, ...slides]);
+      }
+      if (current === slides.length - 1) {
+        const nextMonth = dayjs(slides[slides.length - 1])
+          .add(1, 'month')
+          .format('YYYY-MM-DD');
 
-    if (swiper.activeIndex === monthList.length - 1) {
-      // 마지막 요소를 만났을 때, 미리 뒤의 2달치 로드
-      const lastMonthIndex = monthList[monthList.length - 1];
-
-      setMonthList([
-        ...monthList,
-        dayjs(lastMonthIndex).add(1, 'M').format(monthFormat),
-        dayjs(lastMonthIndex).add(2, 'M').format(monthFormat),
-      ]);
-      swiper.slideTo(monthList.length, 0);
-    }
+        setSlides([...slides, nextMonth]);
+      }
+    },
   };
 
   return (
-    <Swiper spaceBetween={50} slidesPerView={1} initialSlide={1} onSlideChange={handleSlideChange}>
-      {monthList.map((ym) => (
-        <SwiperSlide {...stylex.props(Styles.scrollContent)}>
-          <div {...stylex.props(Styles.monthlyContent)}>
-            <h1 {...stylex.props(Styles.currentMonthText)}>{dayjs(ym).format('YYYY.MM')}</h1>
-            <table {...stylex.props(Styles.calenderContent)}>
-              <thead>
-                <tr {...stylex.props(Styles.daysContent)}>
-                  {React.Children.toArray(
-                    dayOfTheWeek.map((day, idx) => <th {...stylex.props(Styles.dayText(getColorDay(idx)))}>{day}</th>)
-                  )}
-                </tr>
-              </thead>
-              <tbody>
-                {React.Children.toArray(
-                  Array(getNumOfWeek(ym))
-                    .fill('')
-                    .map((_, weekIdx) => (
-                      <tr {...stylex.props(Styles.weekContent)}>
-                        {React.Children.toArray(
-                          Array(7)
-                            .fill('')
-                            .map((_, dateIdx) => {
-                              const dateValue = weekIdx * 7 - getStartDay(ym) + (dateIdx + 1);
-                              // 이번달
-                              if (dateValue > 0 && dateValue <= getLastDateOfTheMonth(ym)) {
-                                return (
-                                  <td {...stylex.props(Styles.dateContent)}>
-                                    <button
-                                      type="button"
-                                      onClick={() => handleClickDate(dateValue)}
-                                      {...stylex.props(
-                                        Styles.currentMonthDateText(getColorDay(dateIdx)),
-                                        dateValue === selectDate && Styles.selectedDate
-                                      )}
-                                    >
-                                      <span {...stylex.props(Styles.dateText)}>{dateValue}</span>
-                                    </button>
-                                  </td>
-                                );
-                              }
-                              // 지난달
-                              if (dateValue <= 0) {
-                                return (
-                                  <td {...stylex.props(Styles.dateContent)}>
-                                    <button
-                                      type="button"
-                                      onClick={() => handleClickDate(dateValue)}
-                                      {...stylex.props(
-                                        Styles.notCurrentMonthDateText,
-                                        Styles.dateBtn,
-                                        dateValue === selectDate && Styles.selectedDate
-                                      )}
-                                    >
-                                      <span {...stylex.props(Styles.dateText)}>
-                                        {dateValue + getLastDateOfTheLastMonth(ym)}
-                                      </span>
-                                    </button>
-                                  </td>
-                                );
-                              }
-                              // 다음달
-                              if (dateValue > getLastDateOfTheMonth(ym)) {
-                                return (
-                                  <td {...stylex.props(Styles.dateContent)}>
-                                    <button
-                                      type="button"
-                                      onClick={() => handleClickDate(dateValue)}
-                                      {...stylex.props(
-                                        Styles.notCurrentMonthDateText,
-                                        Styles.dateBtn,
-                                        dateValue === selectDate && Styles.selectedDate
-                                      )}
-                                    >
-                                      <span {...stylex.props(Styles.dateText)}>
-                                        {dateValue - getLastDateOfTheMonth(ym)}
-                                      </span>
-                                    </button>
-                                  </td>
-                                );
-                              }
-                            })
-                        )}
-                      </tr>
-                    ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </SwiperSlide>
-      ))}
-    </Swiper>
+    <>
+      <div {...stylex.props(Styles.SliderWrapper)}>
+        <Slider {...settings} ref={sliderRef}>
+          {slides.map((slideContent, index) => (
+            <div key={index}>
+              <div style={{ height: '460px' }}>
+                <p {...stylex.props(Styles.CurrentSlideMonth, Typography.TitleRegularBold)}>
+                  {dayjs(slideContent).format('YYYY.M')}
+                </p>
+                <Calendar
+                  onChange={handleChangeDate}
+                  value={dayjs(date).toDate()} // dayjs를 Date로 변환
+                  showNavigation={false}
+                  formatDay={handleFormatDay}
+                  formatShortWeekday={handleFormatShortWeekday} // 요일을 표현하는 방식 커스텀
+                  locale="en-GB"
+                  activeStartDate={dayjs(slideContent).toDate()} // dayjs를 Date로 변환
+                  calendarType="gregory" // 일주일의 시작이 sun으로 시작되게 수정
+                  tileClassName="main-calendar-title"
+                  className="main-calendar"
+                />
+              </div>
+            </div>
+          ))}
+        </Slider>
+      </div>
+    </>
   );
 };
 
 export default MonthlyCalendar;
 
 const Styles = stylex.create({
-  scrollWrapper: {
-    display: 'flex',
-    overflow: 'auto',
+  SliderWrapper: {
+    height: '406px',
   },
-  scrollContent: { width: '100%', height: 'auto', display: 'flex', flexShrink: 0 },
-  monthlyContent: { width: '100%', height: '100%' },
-  currentMonthText: {
-    padding: '16px 20px',
-    fontSize: '2rem',
-    fontWeight: '700',
-    lineHeight: '2.6rem',
-    color: '#333333',
-  },
-  calenderContent: {
-    width: '100%',
-    fontSize: '1.6rem',
-    fontWeight: '700',
-    lineHeight: '2.4rem',
-    color: '#5F5656',
-  },
-  daysContent: {
-    padding: '16px 20px',
-    display: 'flex',
-    justifyContent: 'space-between',
-  },
-  dayText: (color) => ({
-    width: '24px',
-    height: '24px',
-    display: 'flex',
-    justifyContent: 'center',
-    color,
-  }),
-  weekContent: {
-    padding: '16px 20px',
-    display: 'flex',
-    justifyContent: 'space-between',
-  },
-  dateContent: {
-    width: '24px',
-    height: '24px',
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  currentMonthDateText: (color) => ({
-    color,
-  }),
-  notCurrentMonthDateText: {
-    color: '#E2E2E2',
-  },
-  dateText: {
-    paddingTop: '1px',
-  },
-  dateBtn: {
-    width: '24px',
-    height: '24px',
-    background: 'none',
-    border: 'none',
-  },
-  selectedDate: {
-    width: '24px',
-    height: '24px',
-    display: 'flex',
-    flexShrink: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    color: `var(--Base-White)`,
-    backgroundColor: '#191616',
-    borderRadius: '50%',
-    fontSize: '1.4rem',
-    lineHeight: '1rem',
-    fontWeight: '600',
+  CurrentSlideMonth: {
+    padding: '16px',
   },
 });

--- a/src/features/calendar/components/MonthlyCalendar/index.tsx
+++ b/src/features/calendar/components/MonthlyCalendar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { FC, useEffect, useRef, useState } from 'react';
 import Slider from 'react-slick';
 
 import Calendar from 'react-calendar';
@@ -8,7 +8,11 @@ import dayjs from 'dayjs';
 import { Typography } from 'public/styles/vars.stylex';
 import useGetWorkspaceCongressCalendarQuery from '../../queries/useGetWorkspaceCongressCalendarQuery';
 
-const MonthlyCalendar = () => {
+interface MonthlyCalendarProps {
+  onSelectDate: (date: string) => void;
+}
+
+const MonthlyCalendar: FC<MonthlyCalendarProps> = ({ onSelectDate }) => {
   const [date, setDate] = useState<string>(dayjs().format('YYYY-MM-DD'));
   const [activeSlide, setActiveSlide] = useState(0);
   const [slides, setSlides] = useState([
@@ -24,6 +28,7 @@ const MonthlyCalendar = () => {
   const handleChangeDate = (value) => {
     const selectedDate = dayjs(value).format('YYYY-MM-DD');
 
+    onSelectDate(selectedDate);
     setDate(selectedDate);
   };
 

--- a/src/features/calendar/components/MonthlyCalendar/index.tsx
+++ b/src/features/calendar/components/MonthlyCalendar/index.tsx
@@ -20,7 +20,7 @@ const MonthlyCalendar: FC<MonthlyCalendarProps> = ({ onSelectDate }) => {
     dayjs().add(1, 'month').format('YYYY-MM-DD'),
     dayjs().add(2, 'month').format('YYYY-MM-DD'),
   ]);
-  let sliderRef = useRef(null);
+
   const { data, isLoading } = useGetWorkspaceCongressCalendarQuery({
     ym: dayjs(slides[activeSlide]).format('YYYYMM'),
   });
@@ -47,18 +47,28 @@ const MonthlyCalendar: FC<MonthlyCalendarProps> = ({ onSelectDate }) => {
     adaptiveHeight: true,
     initialSlide: 0, // 기본적으로 1번 인덱스의 슬라이드 표시
     afterChange: (current, next) => {
+      let newDateList = slides;
+
       if (current === 0) {
         const prevMonth = dayjs(slides[0]).subtract(1, 'month').format('YYYY-MM-DD');
+        newDateList = [prevMonth, ...slides];
 
-        setSlides([prevMonth, ...slides]);
+        setSlides(newDateList);
       }
       if (current === slides.length - 1) {
         const nextMonth = dayjs(slides[slides.length - 1])
           .add(1, 'month')
           .format('YYYY-MM-DD');
+        newDateList = [...slides, nextMonth];
 
         setSlides([...slides, nextMonth]);
       }
+
+      // 현재 보고 있는 슬라이드 month의 첫번째 날짜 선택
+      const firstDate = dayjs(newDateList[current]).format('YYYY-MM-01');
+
+      onSelectDate(firstDate);
+      setDate(firstDate);
 
       setActiveSlide(current);
     },
@@ -67,7 +77,7 @@ const MonthlyCalendar: FC<MonthlyCalendarProps> = ({ onSelectDate }) => {
   return (
     <>
       <div {...stylex.props(Styles.SliderWrapper)}>
-        <Slider {...settings} ref={sliderRef}>
+        <Slider {...settings}>
           {slides.map((slideContent, index) => (
             <div key={index}>
               <div style={{ height: '460px' }}>

--- a/src/features/calendar/components/MonthlyCalendar/index.tsx
+++ b/src/features/calendar/components/MonthlyCalendar/index.tsx
@@ -6,15 +6,20 @@ import stylex from '@stylexjs/stylex';
 
 import dayjs from 'dayjs';
 import { Typography } from 'public/styles/vars.stylex';
+import useGetWorkspaceCongressCalendarQuery from '../../queries/useGetWorkspaceCongressCalendarQuery';
 
 const MonthlyCalendar = () => {
   const [date, setDate] = useState<string>(dayjs().format('YYYY-MM-DD'));
+  const [activeSlide, setActiveSlide] = useState(0);
   const [slides, setSlides] = useState([
     dayjs().format('YYYY-MM-DD'),
     dayjs().add(1, 'month').format('YYYY-MM-DD'),
     dayjs().add(2, 'month').format('YYYY-MM-DD'),
   ]);
   let sliderRef = useRef(null);
+  const { data, isLoading } = useGetWorkspaceCongressCalendarQuery({
+    ym: dayjs(slides[activeSlide]).format('YYYYMM'),
+  });
 
   const handleChangeDate = (value) => {
     const selectedDate = dayjs(value).format('YYYY-MM-DD');
@@ -49,6 +54,8 @@ const MonthlyCalendar = () => {
 
         setSlides([...slides, nextMonth]);
       }
+
+      setActiveSlide(current);
     },
   };
 
@@ -73,6 +80,18 @@ const MonthlyCalendar = () => {
                   calendarType="gregory" // 일주일의 시작이 sun으로 시작되게 수정
                   tileClassName="main-calendar-title"
                   className="main-calendar"
+                  tileContent={({ activeStartDate, date, view }) => {
+                    // 날짜 밑에 dot로 회의 표시
+                    const congressHexcode = data?.congressCountByDayList.filter(
+                      (congressDateItem) => congressDateItem.day === dayjs(date).format('DD')
+                    )[0]?.hexcodeList;
+
+                    return congressHexcode?.length > 0 && !isLoading ? (
+                      <div {...stylex.props(Styles.DotContainer)}>
+                        {congressHexcode?.map((hexcode) => <span {...stylex.props(Styles.Dot(hexcode))} />)}
+                      </div>
+                    ) : null;
+                  }}
                 />
               </div>
             </div>
@@ -92,4 +111,18 @@ const Styles = stylex.create({
   CurrentSlideMonth: {
     padding: '16px',
   },
+  DotContainer: {
+    position: 'absolute',
+    top: '38px',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    display: 'flex',
+    gap: '1px',
+  },
+  Dot: (hexcode) => ({
+    backgroundColor: hexcode,
+    width: '4px',
+    height: '4px',
+    borderRadius: '50%',
+  }),
 });

--- a/src/features/calendar/components/MonthlyCalendar/index.tsx
+++ b/src/features/calendar/components/MonthlyCalendar/index.tsx
@@ -74,13 +74,15 @@ const MonthlyCalendar: FC<MonthlyCalendarProps> = ({ onSelectDate }) => {
     },
   };
 
+  console.log('data', data);
+
   return (
     <>
       <div {...stylex.props(Styles.SliderWrapper)}>
         <Slider {...settings}>
           {slides.map((slideContent, index) => (
             <div key={index}>
-              <div style={{ height: '460px' }}>
+              <div style={{ height: '406px' }}>
                 <p {...stylex.props(Styles.CurrentSlideMonth, Typography.TitleRegularBold)}>
                   {dayjs(slideContent).format('YYYY.M')}
                 </p>
@@ -128,7 +130,7 @@ const Styles = stylex.create({
   },
   DotContainer: {
     position: 'absolute',
-    top: '38px',
+    top: 'calc(50% + 16px)', // 중앙에서 16px 아래
     left: '50%',
     transform: 'translateX(-50%)',
     display: 'flex',

--- a/src/features/calendar/queries/useGetWorkspaceCongressCalendarQuery.tsx
+++ b/src/features/calendar/queries/useGetWorkspaceCongressCalendarQuery.tsx
@@ -1,0 +1,59 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQuery } from '@tanstack/react-query';
+
+interface CongressCalendarInfo {
+  success: boolean;
+  code: number;
+  congressCountByDayList: CongressCountByDayListItem[];
+  ym: string;
+  holidayList: number[];
+  congressCountByDayCount: number;
+}
+
+interface CongressCountByDayListItem {
+  date: string;
+  day: string;
+  congressCount: number;
+  hexcodeList: string[];
+}
+
+interface Params {
+  ym: string;
+}
+
+const getWorkspaceCongressCalendarApi = async (WorkspaceId: number, params: Params): Promise<CongressCalendarInfo> => {
+  const { ym } = params;
+
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/congress/calender`, {
+    params: {
+      ym,
+    },
+  });
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 회의 캘린더 정보를 불러오는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 회의 캘린더 정보 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const useGetWorkspaceCongressCalendarQuery = (params: Params) => {
+  const { data } = useGetWorkspaceListQuery();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const result = useQuery({
+    queryKey: ['workspaceCongressCalendar', ...Object.values(params)],
+    queryFn: () => getWorkspaceCongressCalendarApi(workspaceId, params),
+    enabled: Boolean(workspaceId) && Boolean(params),
+  });
+
+  return result;
+};
+
+export default useGetWorkspaceCongressCalendarQuery;

--- a/src/features/calendar/styles/custom-react-calendar.css
+++ b/src/features/calendar/styles/custom-react-calendar.css
@@ -179,9 +179,12 @@
 }
 
 .main-calendar-title.react-calendar__tile {
+  position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
+  gap: 4px;
   flex: 0 0 14%; /* flex가 디폴트로 약 14%로 설정되어 있음 (100% 에서 7개의 요일을 나눈 값이 14%) */
   max-width: 100%;
   /* margin: 16px 20px; */
@@ -205,6 +208,11 @@
 .main-calendar-title.react-calendar__decade-view__years__year--neighboringDecade:disabled,
 .main-calendar-title.react-calendar__century-view__decades__decade--neighboringCentury:disabled {
   color: #cdcdcd;
+}
+
+/* 날짜 텍스트 (1 ~ 31) */
+.main-calendar-title.react-calendar__tile abbr {
+  height: 22px;
 }
 
 /* 날짜 호버시 abbr 배경색 변경 */

--- a/src/features/calendar/styles/custom-react-calendar.css
+++ b/src/features/calendar/styles/custom-react-calendar.css
@@ -1,3 +1,8 @@
+/* 컴포넌트 높이 조정 (정해진 높이 안에서 6주 혹은 5주가 표현되도록 높이 조정) */
+.main-calendar {
+  height: calc(100% - 58px);
+}
+
 .main-calendar-title.react-calendar {
   width: 767px;
   max-width: 100%;
@@ -9,6 +14,11 @@
 
 .main-calendar-title.react-calendar--doubleView {
   width: 700px;
+}
+
+/* 컴포넌트 높이 조정 (정해진 높이 안에서 6주 혹은 5주가 표현되도록 높이 조정) */
+.react-calendar__viewContainer {
+  height: 100%;
 }
 
 .main-calendar-title.react-calendar--doubleView .main-calendar-title.react-calendar__viewContainer {
@@ -71,6 +81,17 @@
 /* 달력 사이드 여백 */
 .main-calendar .react-calendar__month-view {
   padding: 12px;
+  height: 100%;
+
+  /* 컴포넌트 높이 조정 (정해진 높이 안에서 6주 혹은 5주가 표현되도록 높이 조정) */
+  > div {
+    align-items: flex-start !important;
+    height: 100%;
+  }
+
+  > div > div {
+    height: 100%;
+  }
 }
 
 /* 요일 간격 */
@@ -83,6 +104,8 @@
 /* 일자별 간격 */
 .main-calendar .react-calendar__month-view__days {
   /* gap: 20px; */
+  /* 컴포넌트 높이 조정 (정해진 높이 안에서 6주 혹은 5주가 표현되도록 높이 조정) */
+  height: calc(100% - 58px) !important;
 }
 
 /* 360px 미만 화면 */
@@ -185,12 +208,11 @@
   align-items: center;
   flex-direction: column;
   gap: 4px;
-  flex: 0 0 14%; /* flex가 디폴트로 약 14%로 설정되어 있음 (100% 에서 7개의 요일을 나눈 값이 14%) */
+  flex: 1; /* 날짜가 정해진 높이 및 너비 안에서 공간을 모두 사용하여 균등하게 분배되도록 설정 */
   max-width: 100%;
   /* margin: 16px 20px; */
   /* gap: 20px; */
   /* padding: 10px 6.6667px; */
-  padding: 12px 0 20px;
   background: none;
   text-align: center;
   line-height: 16px;

--- a/src/features/calendar/styles/custom-react-calendar.css
+++ b/src/features/calendar/styles/custom-react-calendar.css
@@ -1,0 +1,279 @@
+.main-calendar-title.react-calendar {
+  width: 767px;
+  max-width: 100%;
+  background: white;
+  border: 1px solid #a0a096;
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.125em;
+}
+
+.main-calendar-title.react-calendar--doubleView {
+  width: 700px;
+}
+
+.main-calendar-title.react-calendar--doubleView .main-calendar-title.react-calendar__viewContainer {
+  display: flex;
+  margin: -0.5em;
+}
+
+.main-calendar-title.react-calendar--doubleView .main-calendar-title.react-calendar__viewContainer > * {
+  width: 50%;
+  margin: 0.5em;
+}
+
+.main-calendar-title.react-calendar,
+.main-calendar-title.react-calendar *,
+.main-calendar-title.react-calendar *:before,
+.main-calendar-title.react-calendar *:after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.main-calendar-title.react-calendar button {
+  margin: 0;
+  border: 0;
+  outline: none;
+}
+
+.main-calendar-title.react-calendar button:enabled:hover {
+  cursor: pointer;
+}
+
+.main-calendar-title.react-calendar__navigation {
+  display: flex;
+  height: 44px;
+  margin-bottom: 1em;
+}
+
+.main-calendar-title.react-calendar__navigation button {
+  min-width: 44px;
+  background: none;
+}
+
+.main-calendar-title.react-calendar__navigation button:disabled {
+  background-color: #f0f0f0;
+}
+
+.main-calendar-title.react-calendar__navigation button:enabled:hover,
+.main-calendar-title.react-calendar__navigation button:enabled:focus {
+  background-color: #e6e6e6;
+}
+
+.main-calendar-title.react-calendar__month-view__weekdays {
+  text-align: center;
+  font: inherit;
+  font-size: 1.4rem;
+  line-height: 2rem;
+  font-weight: 700;
+}
+
+/* 달력 사이드 여백 */
+.main-calendar .react-calendar__month-view {
+  padding: 12px;
+}
+
+/* 요일 간격 */
+.main-calendar .react-calendar__month-view__weekdays {
+  justify-content: space-between;
+  margin-top: 14px;
+  margin-bottom: 24px;
+}
+
+/* 일자별 간격 */
+.main-calendar .react-calendar__month-view__days {
+  /* gap: 20px; */
+}
+
+/* 360px 미만 화면 */
+@media screen and (max-width: 359px) {
+  /* 달력 사이드 여백 */
+  .main-calendar .react-calendar__month-view {
+    padding: 12px;
+  }
+
+  /* 요일 간격 */
+  .main-calendar .react-calendar__month-view__weekdays {
+    gap: 17px;
+    margin-top: 14px;
+    margin-bottom: 16px;
+  }
+
+  /* 일자별 간격 */
+  .main-calendar .react-calendar__month-view__days {
+    gap: 17px;
+  }
+}
+
+/* 토,일 */
+.main-calendar .react-calendar__month-view__weekdays__weekday.react-calendar__month-view__weekdays__weekday--weekend {
+  flex: 0 0 14% !important; /* 토,일 요일 너비 조정 (100% 에서 7개의 요일을 나눈 값이 14%) */
+  overflow: hidden;
+  margin-inline-end: 0px;
+  width: 22px;
+  height: 22px;
+  margin-right: 0;
+  max-width: 100%;
+  text-align: center;
+  color: var(--Red-300);
+}
+
+/* 토요일 글자색 */
+.main-calendar
+  .react-calendar__month-view__weekdays__weekday.react-calendar__month-view__weekdays__weekday--weekend:nth-child(7) {
+  color: var(--Blue-300);
+}
+
+/* 월~금 */
+.main-calendar .react-calendar__month-view__weekdays__weekday {
+  flex: 0 0 14% !important; /* 월~금 요일 너비 조정 (100% 에서 7개의 요일을 나눈 값이 14%) */
+  overflow: hidden;
+  margin-inline-end: 0px;
+  width: 22px;
+  height: 22px;
+  margin-right: 0;
+  max-width: 100%;
+  text-align: center;
+}
+
+.react-calendar__month-view__weekdays {
+  background: none;
+  abbr {
+    /*월,화,수... 글자 부분*/
+    font-size: 1.4rem;
+    font-weight: 500;
+    text-decoration: none;
+  }
+}
+
+.main-calendar-title.react-calendar__month-view__weekNumbers .react-calendar__tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: inherit;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+
+.main-calendar-title.react-calendar__month-view__days__day--weekend {
+  color: #d10000;
+}
+
+/* 토요일에 해당하는 날짜는 모두 파란색 (다음달로 넘어가는 날짜는 파란색으로 표현되지 않게 예외처리) */
+.main-calendar-title.react-calendar__month-view__days__day--weekend:nth-child(7n):not(
+    .main-calendar-title.react-calendar__month-view__days__day--neighboringMonth
+  ) {
+  color: var(--Blue-300);
+}
+
+.main-calendar-title.react-calendar__month-view__days__day--neighboringMonth,
+.main-calendar-title.react-calendar__decade-view__years__year--neighboringDecade,
+.main-calendar-title.react-calendar__century-view__decades__decade--neighboringCentury {
+  color: #e2e2e2;
+}
+
+.main-calendar-title.react-calendar__year-view .main-calendar-title.react-calendar__tile,
+.main-calendar-title.react-calendar__decade-view .main-calendar-title.react-calendar__tile,
+.main-calendar-title.react-calendar__century-view .main-calendar-title.react-calendar__tile {
+  padding: 2em 0.5em;
+}
+
+.main-calendar-title.react-calendar__tile {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 0 0 14%; /* flex가 디폴트로 약 14%로 설정되어 있음 (100% 에서 7개의 요일을 나눈 값이 14%) */
+  max-width: 100%;
+  /* margin: 16px 20px; */
+  /* gap: 20px; */
+  /* padding: 10px 6.6667px; */
+  padding: 12px 0 20px;
+  background: none;
+  text-align: center;
+  line-height: 16px;
+  font: inherit;
+  font-size: 1.4rem;
+  border-radius: 50%;
+}
+
+.main-calendar-title.react-calendar__tile:disabled {
+  background-color: #f0f0f0;
+  color: #ababab;
+}
+
+.main-calendar-title.react-calendar__month-view__days__day--neighboringMonth:disabled,
+.main-calendar-title.react-calendar__decade-view__years__year--neighboringDecade:disabled,
+.main-calendar-title.react-calendar__century-view__decades__decade--neighboringCentury:disabled {
+  color: #cdcdcd;
+}
+
+/* 날짜 호버시 abbr 배경색 변경 */
+.main-calendar-title.react-calendar__tile:enabled:hover abbr,
+.main-calendar-title.react-calendar__tile:enabled:focus abbr {
+  display: block;
+  background-color: #e6e6e6;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+}
+
+.main-calendar-title.react-calendar__tile--now {
+}
+
+/* 오늘 날짜 배경색을 abbr 태그에 적용 */
+.main-calendar-title.react-calendar__tile--now abbr {
+  display: block;
+  background: #ffff76;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+}
+
+/* 오늘 날짜 호버시 abbr 배경색 변경 */
+.main-calendar-title.react-calendar__tile--now abbr:enabled:hover,
+.main-calendar-title.react-calendar__tile--now abbr:enabled:focus {
+  background: #ffffa9;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+}
+
+.main-calendar-title.react-calendar__tile--hasActive {
+  background: #191616;
+}
+
+.main-calendar-title.react-calendar__tile--hasActive:enabled:hover,
+.main-calendar-title.react-calendar__tile--hasActive:enabled:focus {
+  background: #a9d4ff;
+}
+
+.main-calendar-title.react-calendar__tile--active {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.main-calendar-title.react-calendar__tile--active abbr {
+  display: block;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #191616;
+  color: white;
+}
+
+/* 활성 날짜 호버시 abbr 배경색 변경 */
+.main-calendar-title.react-calendar__tile--active:enabled:hover abbr,
+.main-calendar-title.react-calendar__tile--active:enabled:focus abbr {
+  background: #191616;
+}
+
+.main-calendar-title.react-calendar--selectRange .main-calendar-title.react-calendar__tile--hover {
+  background-color: #e6e6e6;
+}
+/* 
+.react-calendar__tile .react-calendar__month-view__days__day .main-calendar-title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+} */

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -1,18 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import GnbNavLayout from '@src/layouts/GnbNavLayout';
 import MonthlyCalendar from '@src/features/calendar/components/MonthlyCalendar';
 import MeetingSchedule from '@src/features/calendar/components/MeetingSchedule';
 import CirclePlusFilled from '@src/components/icons/CirclePlusFilled';
 import Link from 'next/link';
+import dayjs from 'dayjs';
 
 const Calendar = () => {
+  const [selectDate, setSelectDate] = useState<string>(dayjs().format('YYYY-MM-DD'));
+
+  const handleSelectDate = (date: string) => {
+    setSelectDate(date);
+  };
+
   return (
     <GnbNavLayout>
       {/* 월간 캘린더 */}
-      <MonthlyCalendar />
+      <MonthlyCalendar onSelectDate={handleSelectDate} />
       {/* 캘린더에서 선택한 날짜에 대한 회의 리스트 보는 영역 */}
-      <MeetingSchedule />
+      <MeetingSchedule selectDate={selectDate} />
 
       {/* 예약하기 링크 (플로팅) */}
       <div {...stylex.props(Styles.CreateReservationWrapper)}>


### PR DESCRIPTION
# 작업 내용
- 월간 캘린더 컴포넌트 리팩토링
   - 기존에 캘린더 코드를 직접 작성했었는데 swiper나 슬라이드를 사용해서 캘린더가 넘어가게끔 구현을 하려다보니 코드가 점점 복잡해지고 유지보수하기가 쉽지 않아서, react-calendar 라이브러리를 사용해서 캘린더를 표현함.
   - 원래는 swiper.js를 사용해서 캘린더가 넘어가게 하려고 했는데, month가 중복으로 보여진느 문제가 발생해서 react-slick으로 변경함.
   - 다음 달로 넘기는 건 슬라이드가 넘어가는 효과가 잘 나타는데, 이전 달로 넘기는 건 슬라이드가 넘어가는 효과가 잘 표현되지 않는 문제가 발생함. 일단은 앱을 얼른 출시하는 게 목표이기 때문에 추후에 좀 더 해당 문제를 알아보고 해결하기로 함.
   - 원래는 5주차와 6주차가 표시될 때 높이가 다르게 설정되게 하려고 했는데, 네이버 캘린더를 참고해보니 동일한 높이에 날짜 영역의 높이가 비율로 변경되는 것을 발견했음. 그래서 날짜가 정해진 높이 및 너비 안에서 공간을 모두 사용하여 균등하게 분배되도록 설정해줌.
   
- 회의 캘린더 정보를 불러오는 React-query 훅을 구현하여, 캘린더에서 회의가 있는 날짜 밑에 dot(작은 원)가 표시되게 함.

- 월간 캘린더에서 선택한 날짜에 해당하는 회의 리스트가 표현되도록 API를 연결

# 추가로 해줘야 하는 작업
- 캘린더에 공휴일을 표시해주기