### PR TITLE
Feat(3TS-12): 캘린더 페이지에서 사용하는 캘린더 css를 _app.jsx에 추가

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -17,6 +17,8 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '../features/authentication/assets/onboarding-slider.css';
 import '../features/booking/assets/custom-react-calendar.css';
+import '../features/calendar/styles/custom-react-calendar.css';
+// import '../features/calendar/styles/styles.css';
 
 // client 생성
 const queryClient = new QueryClient();


### PR DESCRIPTION
# 작업 내용
- 캘린더 페이지에서 사용하는 캘린더에 custom한 css를 적용해야하는데, _app에 적용하지 않아서 아래 화면과 같이 달력이 보이는 문제가 있었음.
   <img width="798" alt="image" src="https://github.com/user-attachments/assets/7fa6859b-0ec7-4f0d-bfce-1224f2ca4300" />
- _app.jsx에 아래 코드를 추가하여 캘린더가 정상적으로 보이게 함.
   ```
    import '../features/calendar/styles/custom-react-calendar.css';
   ```
