### PR TITLE
Update(3TS-28): 예약 가능 시간 데이터를 로드할 때 보여주는 시간 형태 및 예약 데이터에서 startTime 값 전달 오류 수정

### DIFF
--- a/src/features/booking/components/BookingTimePicker/TimeOptionList/index.tsx
+++ b/src/features/booking/components/BookingTimePicker/TimeOptionList/index.tsx
@@ -15,7 +15,7 @@ const TimeOptionList: FC<TimeOptionListProps> = (props) => {
   const { onSelect, data, reserDate } = props;
   const optionList = data?.timeList
     .map((item, idx) => {
-      const displayTime = `${item.time.slice(0, 2)}:${item.time.slice(2, 4)}`;
+      const displayTime = item.time;
 
       // 현재 시간 이후의 시간들만 출력되게 구현
       return (

--- a/src/pages/booking.tsx
+++ b/src/pages/booking.tsx
@@ -89,7 +89,7 @@ const Booking = () => {
       attendMemberList: mappedAttendMemberList,
       CongressCategoryId: Number(data.CongressCategoryId),
       RoomId: Number(data.RoomId),
-      startTime: data.endTime.value,
+      startTime: data.startTime.value,
       endTime: data.endTime.value,
     });
   };


### PR DESCRIPTION
# 작업 내용
- 예약하기 페이지에서 시작 시간 및 종료 시간을 로드할 때, `${item.time.slice(0, 2)}:${item.time.slice(2, 4)}`로 변환해서 사용하고 있었는데 서버에서 시간을 변환해서 주시기로 하셔서 서버에서 전달받은 시간을 그대로 로드하기로 함.
- 예약 정보를 서버로 전달할 때, startTime에 endTime 값을 전달하는 오류가 있어서 수정함.