### PR TITLE
Feat(TSK-28): 회의실 예약 상세보기의 댓글 수정 및 삭제 API 연결

### DIFF
--- a/src/components/ui/Modal/index.tsx
+++ b/src/components/ui/Modal/index.tsx
@@ -24,9 +24,7 @@ const Modal: FC<ModalProps> = (props) => {
   return (
     isOpen && (
       <Portal>
-        <div {...stylex.props(Styles.container)}>
-          <div className="modal-content">{children}</div>
-        </div>
+        <div {...stylex.props(Styles.container)}>{children}</div>
       </Portal>
     )
   );

--- a/src/features/comment/components/CommentEditModal/index.tsx
+++ b/src/features/comment/components/CommentEditModal/index.tsx
@@ -41,6 +41,7 @@ export default CommentEditModal;
 
 const Styles = stylex.create({
   container: {
+    width: '767px',
     maxWidth: '100%',
     height: '100vh',
     background: colors.white500,

--- a/src/features/comment/components/CommentEditModal/index.tsx
+++ b/src/features/comment/components/CommentEditModal/index.tsx
@@ -7,6 +7,7 @@ import { colors } from '../../../../../public/styles/vars.stylex';
 import { useDispatch } from 'react-redux';
 import { hideModal } from '@src/slices/modal';
 import useTextArea from '@src/hooks/useTextArea';
+import usePatchCongressCommentQuery from '../../queries/usePatchCongressCommentQuery';
 
 interface CommentEditModalProps {
   data: CommentListItem;
@@ -15,10 +16,18 @@ interface CommentEditModalProps {
 const CommentEditModal: FC<CommentEditModalProps> = (props) => {
   const { data } = props;
   const [content, handleChangeContent] = useTextArea(data.content);
+  const mutation = usePatchCongressCommentQuery();
   const dispatch = useDispatch();
 
   const prevOnClick = () => {
     dispatch(hideModal());
+  };
+
+  const handleClickComplete = () => {
+    mutation.mutate({
+      CommentId: data.CommentId,
+      content,
+    });
   };
 
   return (
@@ -27,7 +36,7 @@ const CommentEditModal: FC<CommentEditModalProps> = (props) => {
         <Header
           title="댓글 수정"
           prevOnClick={prevOnClick}
-          rightBtnInfo={{ name: '완료', isActive: true, onClick: () => {} }}
+          rightBtnInfo={{ name: '완료', isActive: true, onClick: handleClickComplete }}
         />
 
         {/* 수정할 댓글 내용 */}

--- a/src/features/comment/components/CommentList/index.tsx
+++ b/src/features/comment/components/CommentList/index.tsx
@@ -13,6 +13,8 @@ import PencilOutlined from '@src/components/icons/PencilOutlined';
 import TrashcanOutlined from '@src/components/icons/TrashcanOutlined';
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import CommentEditModal from '../CommentEditModal';
+import useDeleteCongressCommentQuery from '../../queries/useDeleteCongressCommentQuery';
+import { confirm } from '@src/components/ui/Modal/confirm';
 
 // fromNow를 사용하기 위해 플러그인 사용
 dayjs.extend(relativeTime);
@@ -21,6 +23,7 @@ const CommentList = () => {
   const router = useRouter();
   const { id } = router.query;
   const { data } = useGetWorkspaceCongressCommentQuery({ page: 1, perPage: 5, cgsid: Number(id) });
+  const mutation = useDeleteCongressCommentQuery();
   const { renderModal } = useRenderModal();
 
   const getMenuList = (item: CommentListItem) => {
@@ -39,7 +42,14 @@ const CommentList = () => {
         id: '2',
         label: '삭제하기',
         icon: <TrashcanOutlined width={16} height={16} />,
-        onClick: () => {},
+        onClick: () => {
+          confirm({
+            content: '댓글을 삭제하시겠어요? \n삭제한 댓글은 복구가 불가능해요.',
+            cancelBtnName: '취소',
+            okBtnName: '확인',
+            onOk: () => mutation.mutate({ CommentId: item.CommentId }),
+          });
+        },
       },
     ];
   };
@@ -69,6 +79,7 @@ const CommentList = () => {
                   </div>
 
                   {/* 수정하기 / 삭제하기 */}
+                  {/* [ ] 본인 댓글에만 드롭박스가 나타나게 수정 필요 */}
                   <Dropdown menuList={getMenuList(item)} />
                 </div>
 

--- a/src/features/comment/queries/useDeleteCongressCommentQuery.tsx
+++ b/src/features/comment/queries/useDeleteCongressCommentQuery.tsx
@@ -1,0 +1,60 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import { hideModal } from '@src/slices/modal';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+import { useDispatch } from 'react-redux';
+
+type ResponseData = null;
+
+interface CommentRequestData {
+  CommentId: number;
+}
+
+const deleteCongressCommentApi = async (WorkspaceId, data: CommentRequestData): Promise<ResponseData> => {
+  const { CommentId } = data;
+
+  const response = await clientInstance.delete(`/v1/workspace/@${WorkspaceId}/congress/comment/${CommentId}`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 회의 예약 상세보기의 댓글을 삭제하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 댓글 삭제 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const useDeleteCongressCommentQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+  const dispatch = useDispatch();
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: CommentRequestData) => {
+      return deleteCongressCommentApi(workspaceId, data);
+    },
+    onSuccess: (data, variables) => {
+      // 업데이트 후 댓글 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['congressCommentList'] });
+
+      // 댓글 수정 모달 닫기
+      dispatch(hideModal());
+    },
+    onError: (error, variables, context) => {
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
+  });
+
+  return mutation;
+};
+
+export default useDeleteCongressCommentQuery;

--- a/src/features/comment/queries/usePatchCongressCommentQuery.tsx
+++ b/src/features/comment/queries/usePatchCongressCommentQuery.tsx
@@ -1,0 +1,61 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import { hideModal } from '@src/slices/modal';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+import { useDispatch } from 'react-redux';
+
+type ResponseData = null;
+
+interface CommentRequestData {
+  CommentId: number;
+  content: string;
+}
+
+const patchCongressCommentApi = async (WorkspaceId, data: CommentRequestData): Promise<ResponseData> => {
+  const { CommentId, ...rest } = data;
+
+  const response = await clientInstance.patch(`/v1/workspace/@${WorkspaceId}/congress/comment/${CommentId}`, rest);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 댓글 수정하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 회의실 댓글 수정 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const usePatchCongressCommentQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+  const dispatch = useDispatch();
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: CommentRequestData) => {
+      return patchCongressCommentApi(workspaceId, data);
+    },
+    onSuccess: (data, variables) => {
+      // 업데이트 후 댓글 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['congressCommentList'] });
+
+      // 댓글 수정 모달 닫기
+      dispatch(hideModal());
+    },
+    onError: (error, variables, context) => {
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
+  });
+
+  return mutation;
+};
+
+export default usePatchCongressCommentQuery;


### PR DESCRIPTION
# 작업 내용
- 회의실 예약 상세보기의 댓글 수정 기능 구현
   - 댓글 수정 모달의 너비가 좁게 표현되는 문제가 있어서 767px이라는 고정 너비값을 적용
- 회의실 예약 상세보기의 댓글 삭제 기능 구현