### PR TITLE
Update(TSK-13): 온보딩 확인 여부 로컬 스토리지에 저장 및 skip 버튼이 잘려보이는 문제 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-redux": "^9.1.0",
         "react-slick": "^0.29.0",
         "react-switch": "^7.0.0",
+        "redux-persist": "^6.0.0",
         "slick-carousel": "^1.8.1"
       },
       "devDependencies": {
@@ -6419,6 +6420,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-redux": "^9.1.0",
     "react-slick": "^0.29.0",
     "react-switch": "^7.0.0",
+    "redux-persist": "^6.0.0",
     "slick-carousel": "^1.8.1"
   },
   "devDependencies": {

--- a/src/features/onboarding/components/OnboardingSlider/index.tsx
+++ b/src/features/onboarding/components/OnboardingSlider/index.tsx
@@ -104,20 +104,21 @@ const OnboardingSlider = () => {
               <div {...stylex.props(SliderStyles.textContent)}>
                 <p {...stylex.props(SliderStyles.title)}>{item.title}</p>
                 <p {...stylex.props(SliderStyles.description)}>{item.description}</p>
+
+                <div {...stylex.props(SliderStyles.buttonContent)}>
+                  <button
+                    {...stylex.props(SliderStyles.button)}
+                    onClick={dotIndex < onboardingList.length - 1 ? handleClickSkip : handleClickRunMeeting}
+                    type="button"
+                  >
+                    {dotIndex < onboardingList.length - 1 ? 'Skip' : '회의 진행하기'}
+                  </button>
+                </div>
               </div>
             </div>
           </div>
         ))}
       </Slider>
-      <div {...stylex.props(SliderStyles.buttonContent)}>
-        <button
-          {...stylex.props(SliderStyles.button)}
-          onClick={dotIndex < onboardingList.length - 1 ? handleClickSkip : handleClickRunMeeting}
-          type="button"
-        >
-          {dotIndex < onboardingList.length - 1 ? 'Skip' : '회의 진행하기'}
-        </button>
-      </div>
     </div>
   );
 };
@@ -150,7 +151,7 @@ const SliderStyles = stylex.create({
   }),
   slideContent: {
     width: '100%',
-    height: '100vh',
+    height: 'calc(100vh - 48px)',
     position: 'relative',
     display: 'flex',
     flexDirection: 'column',
@@ -172,7 +173,7 @@ const SliderStyles = stylex.create({
   },
   textContent: {
     width: '100%',
-    padding: '46px 35px 140px',
+    padding: '46px 0 140px',
     background: 'var( --Base-White)',
     borderRadius: '16px 16px  0 0',
   },

--- a/src/features/onboarding/components/OnboardingSlider/index.tsx
+++ b/src/features/onboarding/components/OnboardingSlider/index.tsx
@@ -3,7 +3,7 @@ import stylex from '@stylexjs/stylex';
 import { useRouter } from 'next/router';
 import Slider from 'react-slick';
 import { useDispatch } from 'react-redux';
-import { changeHiddenStatus } from '../../slices/onboarding';
+import onboarding, { changeHiddenStatus } from '../../slices/onboarding';
 
 const OnboardingSlider = () => {
   const router = useRouter();
@@ -26,7 +26,7 @@ const OnboardingSlider = () => {
   const onboardingList = [
     {
       id: 1,
-      imgUrl: 'https://roomlet-front.s3.ap-northeast-2.amazonaws.com/public/images/onboarding/CALENDAR.png',
+      imgUrl: `${process.env.NEXT_PUBLIC_S3_URL}/public/images/onboarding/CALENDAR.png`,
       name: 'onboarding_01',
       title: '실시간 회의실 예약',
       description: (
@@ -41,7 +41,7 @@ const OnboardingSlider = () => {
     },
     {
       id: 2,
-      imgUrl: 'https://roomlet-front.s3.ap-northeast-2.amazonaws.com/public/images/onboarding/PICTURES.png',
+      imgUrl: `${process.env.NEXT_PUBLIC_S3_URL}/public/images/onboarding/FOLDER.png`,
       name: 'onboarding_02',
       title: '스케쥴 관리 간소화',
       description: (
@@ -56,7 +56,7 @@ const OnboardingSlider = () => {
     },
     {
       id: 3,
-      imgUrl: 'https://roomlet-front.s3.ap-northeast-2.amazonaws.com/public/images/onboarding/CLOCK.png',
+      imgUrl: `${process.env.NEXT_PUBLIC_S3_URL}/public/images/onboarding/CLOCK.png`,
       name: 'onboarding_03',
       title: '효율적인 회의 관리',
       description: (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,6 +10,11 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 // redux
 import { Provider } from 'react-redux';
 import { store } from '../store';
+// redux-persist
+import { persistStore } from 'redux-persist';
+import { PersistGate } from 'redux-persist/integration/react';
+export const persistor = persistStore(store);
+
 // etc
 import '@assets/global.css';
 import '@assets/reset.css';
@@ -36,7 +41,9 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <Provider store={store}>
-        <Component {...pageProps} />
+        <PersistGate loading={null} persistor={persistor}>
+          <Component {...pageProps} />
+        </PersistGate>
       </Provider>
 
       {/* react-query devtools - devtools 폰트 사이즈가 너무 작아서 16px로 설정 */}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,6 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import storage from 'redux-persist/lib/storage';
+import { persistReducer } from 'redux-persist';
 import onboardingReducer from '@features/onboarding/slices/onboarding';
 import bookingReducer from '@features/booking/slices/booking';
 import congressRoomReducer from '@features/mypage/workspace/congress-room/slice/congressRoom';
@@ -7,16 +9,26 @@ import memberReducer from '@features/mypage/workspace/member/slices/member';
 import categoryReducer from '@features/mypage/workspace/category/slices/category';
 import workspaceReducer from '@src/slices/workspace';
 
+const reducers = combineReducers({
+  onboarding: onboardingReducer,
+  booking: bookingReducer,
+  congressRoom: congressRoomReducer,
+  modal: modalReducer,
+  member: memberReducer,
+  category: categoryReducer,
+  workspace: workspaceReducer,
+});
+
+const persistConfig = {
+  key: 'root',
+  storage, // 로컬 스토리지에 저장
+  whitelist: ['onboarding'], // 로컬 스토리지에 저장할 리듀서
+};
+
+const persistedReducer = persistReducer(persistConfig, reducers);
+
 export const store = configureStore({
-  reducer: {
-    onboarding: onboardingReducer,
-    booking: bookingReducer,
-    congressRoom: congressRoomReducer,
-    modal: modalReducer,
-    member: memberReducer,
-    category: categoryReducer,
-    workspace: workspaceReducer,
-  },
+  reducer: persistedReducer,
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself


### PR DESCRIPTION
# 작업 내용
- 모바일 기기에서 온보딩 화면의 skip 및 회의 진행하기 버튼이 잘려보이는 문제 해결
   - 특정 모바일 웹 브라우저(크롬, 사파리)에서 나타난 문제인데 주소 입력창 부분으로 인해 화면이 밀려서 버튼이 잘려보인느 것 같았음.
   - 그래서 높이를 수정하여 잘려보이지 않게 함. 대신에 크롬 사파리에서는 skip 버튼 밑의 여백이 적절하게 보이나, 네이버나 카카오톡 웹뷰 페이지에서는 여백이 많게 보이는 문제가 있음.
   - 모든 곳에서 동일한 디자인으로 보이게 하려면 기획 수정이 필요(ex. skip 위치 이동, '다음' 버튼 추가하고 slide 컴포넌트 안에 텍스트 영역을 포함시키지 않게 하기)해서 일단은 버튼이 잘려보이지 않게 하는 것에 초점을 맞춰서 이슈를 해결함.
   - 기기당 일회성으로 보여지는 화면이기 때문에 크게 신경을 많이 쓰지 않고 다른 이슈에 좀 더 집중해서 해결하고 시간이 남으면 더 얘기해보는 방향이 좋다고 생각함.

- 온보딩 화면이 기기당 한번씩만 보이게 수정
   - 원래 로그인이 되어있지 않은 상태에서 로그인 화면에 접근하기 전에는 온보딩 화면이 항상 보이게 했는데 기획상 기기당 한번만 보이기로 정했기 때문에 로컬 스토리지에 온보딩 화면 확인 여부 값을 저장해두고 본 적이 있으면 더이상 나타나지 않도록 함.
   - 로컬 스토리지에 저장하는 방식은 redux-persist를 사용하여 구현함.

- 온보딩 이미지 url 변경
   - 스케쥴 관리 간소화 부분의 이미지는 FOLDER라는 이미지로 변경해줌.