### PR TITLE
Feat(TSK-22): 메인 홈 타임라인에 나의 회의만 보기 구현 및 회의와 워크페이스가 존재하지 않는 회원에게 보여지는 문구 추가

### DIFF
--- a/src/components/ui/Toggle/index.tsx
+++ b/src/components/ui/Toggle/index.tsx
@@ -3,12 +3,13 @@ import styles from './styles/styles.module.css';
 
 type ToggleProps = {
   onChange: (e: React.ChangeEvent) => void;
+  theme?: 'red500' | 'black400';
 };
 
 const Toggle: FC<ToggleProps> = (props) => {
-  const { onChange } = props;
+  const { onChange, theme = 'red500' } = props;
 
-  return <input className={styles['common-toggle']} type="checkbox" onChange={onChange} />;
+  return <input className={`${styles['common-toggle']} ${styles[theme]}`} type="checkbox" onChange={onChange} />;
 };
 
 export default Toggle;

--- a/src/components/ui/Toggle/styles/styles.module.css
+++ b/src/components/ui/Toggle/styles/styles.module.css
@@ -25,8 +25,12 @@
   transition: left 0.3s;
 }
 
-.common-toggle:checked {
+.red500:checked {
   background-color: #b5312c;
+}
+
+.black400:checked {
+  background-color: #242c33;
 }
 
 .common-toggle:checked::after {

--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -19,7 +19,7 @@ const TimeLine = () => {
     <div {...stylex.props(Styles.container)}>
       <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
       <div {...stylex.props(Styles.scrollContainer)}>
-        {data.congressList.map((item) => (
+        {data?.congressList.map((item) => (
           <div {...stylex.props(Styles.timeAndMeetingContent)}>
             <div {...stylex.props(Styles.timeContent)}>
               <span {...stylex.props(Styles.timeText)}>{item.startTime}</span>

--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -5,7 +5,7 @@ import { RootState } from '@src/store';
 import useGetWorkspaceCongressListQuery from '@src/queries/workspace/useGetWorkspaceCongressListQuery';
 import dayjs from 'dayjs';
 import Link from 'next/link';
-import { Typography } from 'public/styles/vars.stylex';
+import { colors, Typography } from '../../../../../public/styles/vars.stylex';
 import Toggle from '@src/components/ui/Toggle';
 
 /**
@@ -62,23 +62,10 @@ const TimeLine = () => {
       ) : (
         // 워크스페이스가 존재하지 않을 때 보여지는 타임라인 (시간만 보여주고 스케줄 상세 설명 영역은 비어있음)
         <div {...stylex.props(Styles.NoScheduleContainer)}>
-          <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
-          <div {...stylex.props(Styles.NoContentScrollContainer)}>
-            <div {...stylex.props(Styles.timeAndMeetingContent)}>
-              <div {...stylex.props(Styles.timeContent)}>
-                <span {...stylex.props(Styles.timeText)}>09:00</span>
-                <div {...stylex.props(Styles.timeDot)} />
-              </div>
-              <div {...stylex.props(Styles.NoMeetingContent)} />
-            </div>
-            <div {...stylex.props(Styles.timeAndMeetingContent)}>
-              <div {...stylex.props(Styles.timeContent)}>
-                <span {...stylex.props(Styles.timeText)}>10:00</span>
-                <div {...stylex.props(Styles.timeDot)} />
-              </div>
-              <div {...stylex.props(Styles.NoMeetingContent)} />
-            </div>
-          </div>
+          <p {...stylex.props(Typography.SubTextLargeRegular)}>
+            오늘 예정된 회의가 없어요. <br />
+            새로운 회의를 생성해보세요
+          </p>
         </div>
       )}
     </>
@@ -193,22 +180,17 @@ const Styles = stylex.create({
   }),
   NoScheduleContainer: {
     width: '100%',
-    height: '176px',
+    height: 'calc(100vh - 374px)',
     display: 'flex',
-    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
     gap: '24px',
+    color: colors.gray900,
     backgroundColor: '#FAFAFA',
     position: 'relative',
     borderTop: '1px solid #F2F2F2',
     borderBottom: '1px solid #F2F2F2',
-  },
-  NoMeetingContent: {
-    height: '52px',
-  },
-  NoContentScrollContainer: {
-    paddingTop: '30px',
-    height: '176px',
-    overflowY: 'auto',
+    textAlign: 'center',
   },
   meetingLink: {
     width: '100%',

--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -36,31 +36,44 @@ const TimeLine = () => {
       {isWorkspace ? (
         // 워크스페이스가 존재할 때 보여지는 타임 라인
         <div {...stylex.props(Styles.container)}>
-          <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
-          <div {...stylex.props(Styles.scrollContainer)}>
-            {data?.congressList.map((item) => (
-              <div {...stylex.props(Styles.timeAndMeetingContent)}>
-                <div {...stylex.props(Styles.timeContent)}>
-                  <span {...stylex.props(Styles.timeText)}>{item.startTime}</span>
-                  <div {...stylex.props(Styles.timeDot)} />
-                </div>
+          {/* 회의가 있는 경우에만 타임라인 구분선 표시 */}
+          {data?.congressList.length > 0 && <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />}
 
-                <Link href={`/reservations/${item.CongressId}`} {...stylex.props(Styles.meetingLink)}>
-                  <div {...stylex.props(Styles.meetingContent)}>
-                    <div {...stylex.props(Styles.detailContent(item.congressCategory.hexcode))}>
-                      <p {...stylex.props(Styles.titleText)}>{item.congressTitle}</p>
-                      <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
-                        {item.congressCategory.categoryName}
+          <div {...stylex.props(Styles.scrollContainer)}>
+            {/* 회의가 있는 경우에만 타임라인 내용 표시 */}
+            {data?.congressList.length > 0 ? (
+              data?.congressList.map((item) => (
+                <div {...stylex.props(Styles.timeAndMeetingContent)}>
+                  <div {...stylex.props(Styles.timeContent)}>
+                    <span {...stylex.props(Styles.timeText)}>{item.startTime}</span>
+                    <div {...stylex.props(Styles.timeDot)} />
+                  </div>
+
+                  <Link href={`/reservations/${item.CongressId}`} {...stylex.props(Styles.meetingLink)}>
+                    <div {...stylex.props(Styles.meetingContent)}>
+                      <div {...stylex.props(Styles.detailContent(item.congressCategory.hexcode))}>
+                        <p {...stylex.props(Styles.titleText)}>{item.congressTitle}</p>
+                        <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
+                          {item.congressCategory.categoryName}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </Link>
+                  </Link>
+                </div>
+              ))
+            ) : (
+              // 회의가 존재하지 않을 때 보여지는 문구
+              <div {...stylex.props(Styles.NoScheduleContainer)}>
+                <p {...stylex.props(Typography.SubTextLargeRegular)}>
+                  오늘 예정된 회의가 없어요. <br />
+                  새로운 회의를 생성해보세요
+                </p>
               </div>
-            ))}
+            )}
           </div>
         </div>
       ) : (
-        // 워크스페이스가 존재하지 않을 때 보여지는 타임라인 (시간만 보여주고 스케줄 상세 설명 영역은 비어있음)
+        // 워크스페이스가 존재하지 않을 때 보여지는 문구
         <div {...stylex.props(Styles.NoScheduleContainer)}>
           <p {...stylex.props(Typography.SubTextLargeRegular)}>
             오늘 예정된 회의가 없어요. <br />

--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import { useSelector } from 'react-redux';
 import { RootState } from '@src/store';
 import useGetWorkspaceCongressListQuery from '@src/queries/workspace/useGetWorkspaceCongressListQuery';
 import dayjs from 'dayjs';
 import Link from 'next/link';
+import { Typography } from 'public/styles/vars.stylex';
+import Toggle from '@src/components/ui/Toggle';
 
 /**
  * 홈 화면의 타임라인을 나타내는 컴포넌트
@@ -12,61 +14,96 @@ import Link from 'next/link';
  */
 const TimeLine = () => {
   const { isWorkspace } = useSelector((state: RootState) => state.workspace);
-  const { data } = useGetWorkspaceCongressListQuery({ date: dayjs().format('YYYY-MM-DD') });
+  const [isMyMeeting, setIsMyMeeting] = useState<boolean>(false);
+  const { data } = useGetWorkspaceCongressListQuery({
+    date: dayjs().format('YYYY-MM-DD'),
+    ...(isMyMeeting ? { my: 1 } : {}),
+  });
 
-  return isWorkspace ? (
-    // 워크스페이스가 존재할 때 보여지는 타임 라인
-    <div {...stylex.props(Styles.container)}>
-      <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
-      <div {...stylex.props(Styles.scrollContainer)}>
-        {data?.congressList.map((item) => (
-          <div {...stylex.props(Styles.timeAndMeetingContent)}>
-            <div {...stylex.props(Styles.timeContent)}>
-              <span {...stylex.props(Styles.timeText)}>{item.startTime}</span>
-              <div {...stylex.props(Styles.timeDot)} />
-            </div>
+  const handleChangeToggle = () => {
+    setIsMyMeeting(!isMyMeeting);
+  };
 
-            <Link href={`/reservations/${item.CongressId}`} {...stylex.props(Styles.meetingLink)}>
-              <div {...stylex.props(Styles.meetingContent)}>
-                <div {...stylex.props(Styles.detailContent(item.congressCategory.hexcode))}>
-                  <p {...stylex.props(Styles.titleText)}>{item.congressTitle}</p>
-                  <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
-                    {item.congressCategory.categoryName}
-                  </div>
+  return (
+    <>
+      <div {...stylex.props(Styles.timeLineSectionHeader)}>
+        <h2 {...stylex.props(Typography.SubtitleRegularSemiBold, Styles.sectionTitle)}>타임라인</h2>
+        <div {...stylex.props(Typography.SubTextLargeMedium, Styles.timeLineSectionToggle)}>
+          <span>나의 회의만 보기</span>
+          <Toggle theme="black400" onChange={handleChangeToggle} />
+        </div>
+      </div>
+      {isWorkspace ? (
+        // 워크스페이스가 존재할 때 보여지는 타임 라인
+        <div {...stylex.props(Styles.container)}>
+          <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
+          <div {...stylex.props(Styles.scrollContainer)}>
+            {data?.congressList.map((item) => (
+              <div {...stylex.props(Styles.timeAndMeetingContent)}>
+                <div {...stylex.props(Styles.timeContent)}>
+                  <span {...stylex.props(Styles.timeText)}>{item.startTime}</span>
+                  <div {...stylex.props(Styles.timeDot)} />
                 </div>
+
+                <Link href={`/reservations/${item.CongressId}`} {...stylex.props(Styles.meetingLink)}>
+                  <div {...stylex.props(Styles.meetingContent)}>
+                    <div {...stylex.props(Styles.detailContent(item.congressCategory.hexcode))}>
+                      <p {...stylex.props(Styles.titleText)}>{item.congressTitle}</p>
+                      <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
+                        {item.congressCategory.categoryName}
+                      </div>
+                    </div>
+                  </div>
+                </Link>
               </div>
-            </Link>
+            ))}
           </div>
-        ))}
-      </div>
-    </div>
-  ) : (
-    // 워크스페이스가 존재하지 않을 때 보여지는 타임라인 (시간만 보여주고 스케줄 상세 설명 영역은 비어있음)
-    <div {...stylex.props(Styles.NoScheduleContainer)}>
-      <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
-      <div {...stylex.props(Styles.NoContentScrollContainer)}>
-        <div {...stylex.props(Styles.timeAndMeetingContent)}>
-          <div {...stylex.props(Styles.timeContent)}>
-            <span {...stylex.props(Styles.timeText)}>09:00</span>
-            <div {...stylex.props(Styles.timeDot)} />
-          </div>
-          <div {...stylex.props(Styles.NoMeetingContent)} />
         </div>
-        <div {...stylex.props(Styles.timeAndMeetingContent)}>
-          <div {...stylex.props(Styles.timeContent)}>
-            <span {...stylex.props(Styles.timeText)}>10:00</span>
-            <div {...stylex.props(Styles.timeDot)} />
+      ) : (
+        // 워크스페이스가 존재하지 않을 때 보여지는 타임라인 (시간만 보여주고 스케줄 상세 설명 영역은 비어있음)
+        <div {...stylex.props(Styles.NoScheduleContainer)}>
+          <div {...stylex.props(Styles.timeAndMeetingDivider(isWorkspace))} />
+          <div {...stylex.props(Styles.NoContentScrollContainer)}>
+            <div {...stylex.props(Styles.timeAndMeetingContent)}>
+              <div {...stylex.props(Styles.timeContent)}>
+                <span {...stylex.props(Styles.timeText)}>09:00</span>
+                <div {...stylex.props(Styles.timeDot)} />
+              </div>
+              <div {...stylex.props(Styles.NoMeetingContent)} />
+            </div>
+            <div {...stylex.props(Styles.timeAndMeetingContent)}>
+              <div {...stylex.props(Styles.timeContent)}>
+                <span {...stylex.props(Styles.timeText)}>10:00</span>
+                <div {...stylex.props(Styles.timeDot)} />
+              </div>
+              <div {...stylex.props(Styles.NoMeetingContent)} />
+            </div>
           </div>
-          <div {...stylex.props(Styles.NoMeetingContent)} />
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 };
 
 export default TimeLine;
 
 const Styles = stylex.create({
+  timeLineSectionHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: '16px',
+    padding: '2px 16px',
+  },
+  timeLineSectionToggle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    color: '#818181',
+  },
+  sectionTitle: {
+    color: '#616161',
+  },
   container: {
     width: '100%',
     height: '100%',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import GnbNavLayout from '@src/layouts/GnbNavLayout';
 import WorkspaceUserGreeting from '@src/features/home/components/UserGreeting/workspaceUser';
@@ -27,7 +27,6 @@ const Home = () => {
       </section>
       {/* 타임 라인 섹션 */}
       <section {...stylex.props(Styles.timeLineSection)}>
-        <h2 {...stylex.props(Styles.sectionTitle, Styles.timeLineSectionTitle)}>타임라인</h2>
         <TimeLine />
       </section>
 
@@ -71,9 +70,6 @@ const Styles = stylex.create({
     fontWeight: '600',
     lineHeight: '2.4rem',
     color: '#616161',
-  },
-  timeLineSectionTitle: {
-    padding: '0 16px',
   },
   CreateWorkspaceBtnWrapper: {
     position: 'relative',


### PR DESCRIPTION
# 작업 내용
- 공통 토글 컴포넌트에 theme 추가
   - 나의 회의만 보기 토글 색상이 기존에 사용하던 색상과 달라서 추가함
- 메인 홈 타임라인 타이틀 옆에 나의 회의만 보기 토글 구현
   - 메인 홈 페이지 파일에 있는 타임라인 타이틀 옆에 나의 회의만 보기 토글을 구현했었는데, 내 회의 필터를 위해 메인 홈 페이지에서 api 요청한 data 결과를 타임라인에 넘겨주는 게 애매해졌음. 
   - 기존에 타임라인 컴포넌트 안에서 데이터를 요청하고 있었기 때문에, 기존 코드 방식을 유지하면서 나의 회의만 보기 필터 기능을 타임라인 컴포넌트 안에서 구현이 되도록 코드를 이동시킴.
   - 추후에 app 라우터로 바꾸면서 이 부분은 서버 컴포넌트로 바꾸면 좋을 것 같음.

- 워크스페이스 및 회의가 존재하지 않는 회원에게 '오늘 예정된 회의가 없어요. 새로운 회의를 생성해보세요' 추가
   - 기존에 워크스페이스가 존재하지 않을 때는 타임라인에 스케쥴 내용은 없고 시간만 표시했었는데, 뭔가 오류처럼 보이는 느낌이 들어서 문구를 표시하는 것으로 수정하게 됨.
   - 회의가 존재하지 않을 때는 타임라인에 아무것도 표시하지 않았는데 이 때도 문구를 표시해서 명확하게 사용자가 회의가 없다는 것을 인지할 수 있게 함.