### PR TITLE
Feat&Fix(TSK-24): 캘린더에서 회의 스케줄이 없는 경우 문구가 표시되게 구현 및 캘린더의 날짜 밑에 dot이 잘못 표현되는 문제 해결

### DIFF
--- a/src/features/calendar/components/MeetingSchedule/index.tsx
+++ b/src/features/calendar/components/MeetingSchedule/index.tsx
@@ -3,6 +3,7 @@ import stylex from '@stylexjs/stylex';
 import useGetWorkspaceCongressListQuery from '@src/queries/workspace/useGetWorkspaceCongressListQuery';
 import dayjs from 'dayjs';
 import router from 'next/router';
+import { colors } from 'public/styles/vars.stylex';
 
 const MeetingSchedule: FC<{ selectDate: string }> = ({ selectDate }) => {
   const { data } = useGetWorkspaceCongressListQuery({
@@ -17,22 +18,33 @@ const MeetingSchedule: FC<{ selectDate: string }> = ({ selectDate }) => {
     <div {...stylex.props(Styles.container)}>
       <h3 {...stylex.props(Styles.selectedDateTitle)}>{dayjs(selectDate).format('D.ddd')}</h3>
       <div {...stylex.props(Styles.meetingListContent)}>
-        {data?.congressList.map((item) => (
-          <div {...stylex.props(Styles.meetingContent)} onClick={() => handleMeetingClick(item.CongressId)}>
-            <div {...stylex.props(Styles.meetingCategoryLine(item.congressCategory.hexcode))} />
+        {data?.congressList.length > 0 ? (
+          data?.congressList.map((item) => (
+            <div {...stylex.props(Styles.meetingContent)} onClick={() => handleMeetingClick(item.CongressId)}>
+              <div {...stylex.props(Styles.meetingCategoryLine(item.congressCategory.hexcode))} />
+              <div {...stylex.props(Styles.detailContent)}>
+                <div {...stylex.props(Styles.infoContent)}>
+                  <p {...stylex.props(Styles.titleText('#333'))}>{item.congressTitle}</p>
+                  <p {...stylex.props(Styles.timeText)}>
+                    {item.startTime} ~ {item.endTime}
+                  </p>
+                </div>
+                <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
+                  {item.congressCategory.categoryName}
+                </div>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div {...stylex.props(Styles.meetingContent)}>
+            <div {...stylex.props(Styles.meetingCategoryLine(colors.gray40))} />
             <div {...stylex.props(Styles.detailContent)}>
               <div {...stylex.props(Styles.infoContent)}>
-                <p {...stylex.props(Styles.titleText)}>{item.congressTitle}</p>
-                <p {...stylex.props(Styles.timeText)}>
-                  {item.startTime} ~ {item.endTime}
-                </p>
-              </div>
-              <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
-                {item.congressCategory.categoryName}
+                <p {...stylex.props(Styles.titleText('#7D7F85'))}>회의가 없습니다</p>
               </div>
             </div>
           </div>
-        ))}
+        )}
       </div>
     </div>
   );
@@ -73,7 +85,7 @@ const Styles = stylex.create({
   }),
   detailContent: { width: '100%', display: 'flex', justifyContent: 'space-between' },
   infoContent: { display: 'flex', flexDirection: 'column', gap: '8px' },
-  titleText: { fontSize: '1.6rem', fontWeight: '500', lineHeight: '2.4rem' },
+  titleText: (color) => ({ fontSize: '1.6rem', fontWeight: '500', lineHeight: '2.4rem', color }),
   timeText: { fontSize: '1.4rem', fontWeight: '400', lineHeight: '2rem', color: 'var(--Gray-10)' },
   categoryTag: (hexcode) => ({
     padding: '4px 8px',

--- a/src/features/calendar/components/MonthlyCalendar/index.tsx
+++ b/src/features/calendar/components/MonthlyCalendar/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { FC, useState } from 'react';
 import Slider from 'react-slick';
 
 import Calendar from 'react-calendar';
@@ -74,8 +74,6 @@ const MonthlyCalendar: FC<MonthlyCalendarProps> = ({ onSelectDate }) => {
     },
   };
 
-  console.log('data', data);
-
   return (
     <>
       <div {...stylex.props(Styles.SliderWrapper)}>
@@ -100,7 +98,7 @@ const MonthlyCalendar: FC<MonthlyCalendarProps> = ({ onSelectDate }) => {
                   tileContent={({ activeStartDate, date, view }) => {
                     // 날짜 밑에 dot로 회의 표시
                     const congressHexcode = data?.congressCountByDayList.filter(
-                      (congressDateItem) => congressDateItem.day === dayjs(date).format('DD')
+                      (congressDateItem) => congressDateItem.date === dayjs(date).format('YYYY-MM-DD')
                     )[0]?.hexcodeList;
 
                     return congressHexcode?.length > 0 && !isLoading ? (


### PR DESCRIPTION
# 작업 내용
- 캘린더에서 회의가 없는 날짜를 눌렀을 때, 회의 스케줄이 보여지는 영역에 `회의가 없습니다` 문구가 표시되게 구현
- 캘린더 날짜 밑에 dot이 잘못 표현되는 문제 해결
   - 현재 dot을 표현하기 위해 사용한 filter의 조건문에서 날짜를 비교할 때 단순 '3'과 '03'을 비교해서 dot이 표현되지 않는 문제가 발생함.
   - 그래서 동일하게 0이 붙지 않은 3으로만 값을 비교하게 했음.
   - 그러면 현재 달이 보일 때 이전 달과 다음 달의 일부도 함께 보이게 되는데, 이 때 3월 3일에 dot이 표현되었다고 가정하고, 현재 달이 4월 3일까지 표시된다고 했을 때 4월 3일에도 dot이 표현되는 문제가 있었음.
   - 그래서 날짜 전체(YYYY-MM-DD)를 비교해서 dot을 표현하는 조건식으로 수정하니 문제가 해결됨.