### PR TITLE
Update&Feat(3TS-8): 예약 리스트 필터를 라디오 버튼으로 수정 및 참여한 회의가 없는 경우 문구가 표시되게 구현

### DIFF
--- a/src/components/icons/CircleAlertFilled.tsx
+++ b/src/components/icons/CircleAlertFilled.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+const CircleAlertFilled = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg width={width} height={height} viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <g clipPath="url(#clip0_2766_14236)">
+        <path
+          d="M64 32C64 36.0515 63.2471 39.9275 61.8728 43.4953C57.5898 54.6197 47.2719 62.747 34.9304 63.8672C33.9648 63.9555 32.9878 64 31.9997 64C14.3268 64 0 49.6733 0 32C0 14.3267 14.3268 0 31.9997 0C49.6726 0 64 14.3273 64 32Z"
+          fill="#F0E7E7"
+        />
+        <path
+          d="M30.5 21.5C30.5 20.6716 31.1716 20 32 20C32.8284 20 33.5 20.6716 33.5 21.5V35.5C33.5 36.3284 32.8284 37 32 37C31.1716 37 30.5 36.3284 30.5 35.5V21.5Z"
+          fill="#B5312C"
+        />
+        <circle cx="32" cy="41" r="2" fill="#B5312C" />
+      </g>
+      <defs>
+        <clipPath id="clip0_2766_14236">
+          <rect width="64" height="64" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+
+export default CircleAlertFilled;

--- a/src/components/ui/Radio/index.tsx
+++ b/src/components/ui/Radio/index.tsx
@@ -4,15 +4,16 @@ import styles from './styles/styles.module.css';
 interface RadioProps extends React.InputHTMLAttributes<HTMLInputElement> {
   key?: React.Key;
   label: string;
+  theme?: 'red500' | 'white';
 }
 
 const Radio: FC<RadioProps> = (props) => {
-  const { id, label, type, ...anotherProps } = props;
+  const { id, label, type, theme = 'red500', ...anotherProps } = props;
 
   return (
     <>
-      <label className={styles['common-radio-label']} htmlFor={id}>
-        <input className={styles['common-radio-input']} type="radio" id={id} {...anotherProps} />
+      <label className={`${styles['common-radio-label']} ${styles[theme]}`} htmlFor={id}>
+        <input className={`${styles['common-radio-input']} ${styles[theme]}`} type="radio" id={id} {...anotherProps} />
         {label}
       </label>
     </>

--- a/src/components/ui/Radio/styles/styles.module.css
+++ b/src/components/ui/Radio/styles/styles.module.css
@@ -17,8 +17,15 @@
   display: none;
 }
 
-.common-radio-label:has(.common-radio-input[type='radio']:checked) {
+.common-radio-label.red500:has(.common-radio-input[type='radio']:checked) {
   box-shadow: none;
   background-color: #b5312c;
   color: #ffffff;
+}
+
+.common-radio-label.white:has(.common-radio-input[type='radio']:checked) {
+  box-shadow: none;
+  border: 1px solid #b5312c;
+  color: #b5312c;
+  background-color: #ffffff;
 }

--- a/src/features/calendar/components/DateWheelPicker/index.tsx
+++ b/src/features/calendar/components/DateWheelPicker/index.tsx
@@ -119,7 +119,7 @@ const Styles = stylex.create({
     textAlign: 'center',
   },
   pickerContainer: {
-    width: '181px',
+    width: '192px',
     margin: '0 auto',
     padding: '0 32px',
     gap: '8px',

--- a/src/features/reservation/components/ReservationFilter/index.tsx
+++ b/src/features/reservation/components/ReservationFilter/index.tsx
@@ -6,8 +6,8 @@ import { hideModal } from '@src/slices/modal';
 import stylex from '@stylexjs/stylex';
 import { colors, Typography } from '../../../../../public/styles/vars.stylex';
 import useGetCongressRoomListQuery from '@src/queries/congress/useGetCongressRoomListQuery';
-import RoundCheckbox from '@src/components/ui/RoundCheckbox';
 import useGetCategoryListQuery from '@src/queries/category/useGetCategoryListQuery';
+import Radio from '@src/components/ui/Radio';
 
 const MEETING_TYPE: { id: string; label: string; value: 0 | 1 }[] = [
   {
@@ -42,7 +42,7 @@ const ReservationFilter = () => {
     if (selectedRoomIdList.includes(value)) {
       setSelectedRoomIdList((prevState) => prevState.filter((item) => item !== value));
     } else {
-      setSelectedRoomIdList((prevState) => [...prevState, value]);
+      setSelectedRoomIdList((prevState) => [value]);
     }
   };
 
@@ -50,7 +50,7 @@ const ReservationFilter = () => {
     if (selectedCategoryIdList.includes(value)) {
       setSelectedCategoryIdList((prevState) => prevState.filter((item) => item !== value));
     } else {
-      setSelectedCategoryIdList((prevState) => [...prevState, value]);
+      setSelectedCategoryIdList((prevState) => [value]);
     }
   };
 
@@ -94,16 +94,16 @@ const ReservationFilter = () => {
         <p {...stylex.props(Typography.SubTextLargeSemiBold, Styles.Title)}>필터</p>
         <div {...stylex.props(Styles.RadioContainer)}>
           {MEETING_TYPE.map((item) => (
-            <RoundCheckbox
+            <Radio
               name="meetingType"
               id={`meetingType${item.id}`}
               // label={item.roomName}
+              theme="white"
+              label={item.label}
               value={item.value}
               checked={isOnlyMy ? item.value === 1 : item.value === 0}
               onChange={() => handleChangeMeetingType(item.value)}
-            >
-              {item.label}
-            </RoundCheckbox>
+            />
           ))}
         </div>
 
@@ -111,16 +111,15 @@ const ReservationFilter = () => {
         <p {...stylex.props(Typography.SubTextLargeSemiBold, Styles.Title)}>회의실</p>
         <div {...stylex.props(Styles.RadioContainer)}>
           {congressRoomData?.congressRoomList?.map((item) => (
-            <RoundCheckbox
+            <Radio
               name="congressRoom"
               id={`congressRoom${item.RoomId}`}
-              // label={item.roomName}
+              theme="white"
+              label={item.roomName}
               value={item.RoomId}
               checked={selectedRoomIdList?.includes(item.RoomId)}
               onChange={() => handleChangeMeetingRoom(item.RoomId)}
-            >
-              {item.roomName}
-            </RoundCheckbox>
+            />
           ))}
         </div>
 
@@ -128,16 +127,15 @@ const ReservationFilter = () => {
         <p {...stylex.props(Typography.SubTextLargeSemiBold, Styles.Title)}>카테고리</p>
         <div {...stylex.props(Styles.RadioContainer)}>
           {congressCategoryData?.congressCategoryList?.map((item) => (
-            <RoundCheckbox
+            <Radio
               name="category"
               id={`category${item.CongressCategoryId}`}
-              // label={item.roomName}
+              theme="white"
+              label={item.categoryName}
               value={item.CongressCategoryId}
               checked={selectedCategoryIdList?.includes(item.CongressCategoryId)}
               onChange={() => handleChangeCategory(item.CongressCategoryId)}
-            >
-              {item.categoryName}
-            </RoundCheckbox>
+            />
           ))}
         </div>
 

--- a/src/features/reservation/components/ReservationList/index.tsx
+++ b/src/features/reservation/components/ReservationList/index.tsx
@@ -5,6 +5,8 @@ import { CongressListResponse } from '@src/queries/workspace/useGetWorkspaceCong
 import { useRouter } from 'next/router';
 import MarkerPinFilled from '@src/components/icons/MarkerPinFilled';
 import ClockFilled from '@src/components/icons/ClockFilled';
+import CircleAlertFilled from '@src/components/icons/CircleAlertFilled';
+import { Typography } from '../../../../../public/styles/vars.stylex';
 
 interface ReservationListProps {
   data: CongressListResponse;
@@ -17,47 +19,58 @@ const ReservationList: FC<ReservationListProps> = (props) => {
   return (
     <section {...stylex.props(Styles.wrapper)}>
       <div {...stylex.props(Styles.meetingListContent)}>
-        {data?.congressList.map((item) => (
-          <div
-            {...stylex.props(Styles.meetingContent(item.congressCategory.hexcode))}
-            onClick={() => router.push(`/reservations/${item.CongressId}`)}
-          >
-            <div {...stylex.props(Styles.detailContent)}>
-              <div {...stylex.props(Styles.infoContent)}>
-                <p {...stylex.props(Styles.titleText)}>{item.congressTitle}</p>
+        {data?.congressList.length > 0 ? (
+          data?.congressList.map((item) => (
+            <div
+              {...stylex.props(Styles.meetingContent(item.congressCategory.hexcode))}
+              onClick={() => router.push(`/reservations/${item.CongressId}`)}
+            >
+              <div {...stylex.props(Styles.detailContent)}>
+                <div {...stylex.props(Styles.infoContent)}>
+                  <p {...stylex.props(Styles.titleText)}>{item.congressTitle}</p>
 
-                {/* 시간 */}
-                <div {...stylex.props(Styles.textContainer)}>
-                  <ClockFilled width={14} height={14} />
-                  <p {...stylex.props(Styles.timeText)}>
-                    {item.startTime} ~ {item.endTime}
-                  </p>
-                </div>
+                  {/* 시간 */}
+                  <div {...stylex.props(Styles.textContainer)}>
+                    <ClockFilled width={14} height={14} />
+                    <p {...stylex.props(Styles.timeText)}>
+                      {item.startTime} ~ {item.endTime}
+                    </p>
+                  </div>
 
-                {/* 회의실 */}
-                <div {...stylex.props(Styles.textContainer)}>
-                  <MarkerPinFilled width={14} height={14} />
-                  <p {...stylex.props(Styles.placeText)}>{item.congressRoom.roomName}</p>
+                  {/* 회의실 */}
+                  <div {...stylex.props(Styles.textContainer)}>
+                    <MarkerPinFilled width={14} height={14} />
+                    <p {...stylex.props(Styles.placeText)}>{item.congressRoom.roomName}</p>
+                  </div>
+                  <div {...stylex.props(Styles.profileListContent)}>
+                    {/* {console.log(item.attendMemberList)} */}
+                    {item.attendMemberList.map((item) => (
+                      <div {...stylex.props(Styles.profileContent)}>
+                        <ProfileImg
+                          src={item?.profileImgUrl}
+                          size={34}
+                          borderProperties={{ color: '#D9D9D9', width: '1px', radius: '50%' }}
+                        />
+                      </div>
+                    ))}
+                  </div>
                 </div>
-                <div {...stylex.props(Styles.profileListContent)}>
-                  {/* {console.log(item.attendMemberList)} */}
-                  {item.attendMemberList.map((item) => (
-                    <div {...stylex.props(Styles.profileContent)}>
-                      <ProfileImg
-                        src={item?.profileImgUrl}
-                        size={34}
-                        borderProperties={{ color: '#D9D9D9', width: '1px', radius: '50%' }}
-                      />
-                    </div>
-                  ))}
+                <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
+                  {item.congressCategory.categoryName}
                 </div>
-              </div>
-              <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>
-                {item.congressCategory.categoryName}
               </div>
             </div>
+          ))
+        ) : (
+          <div {...stylex.props(Styles.emptyContentContainer)}>
+            <CircleAlertFilled width={64} height={64} />
+            <p {...stylex.props(Typography.TextSmallRegular)}>
+              참여한 회의가 없습니다.
+              <br />
+              워크스페이스를 생성하여 회의를 만들어주세요!
+            </p>
           </div>
-        ))}
+        )}
       </div>
     </section>
   );
@@ -148,5 +161,14 @@ const Styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: '8px',
+  },
+  emptyContentContainer: {
+    marginTop: '124px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '22px',
+    textAlign: 'center',
   },
 });


### PR DESCRIPTION
# 작업 내용
- DateWheel모달 클릭했을 때, 년도가 일부 잘려서 보여지는 문제로 인해 pickerContainer 너비를 수정함.

- 필터를 체크박스에서 라디오 버튼으로 변경함.
   - 라디오 버튼으로 변경하면 체크 박스처럼 해제를 할 수 있는 게 아니기 때문에 전체 회의에서 특정 카테고리만 커스텀해서 보고 싶은데 이미 회의실이 선택되어져 있는 상태라면 초기화 버튼을 누르고 내가 원하는 작업을 해야함. 이러한 과정이 번거롭기 때문에 체크박스로 변경하거나 라디오 버튼을 사용한 항목에 전체라는 항목을 추가해주는 방향을 논의해보면 좋을 것 같음.

- 예약 리스트에서 회의가 하나도 없는 걍우 문구를 표시하도록 구현함.
   - **커밋 내역 정정:**`예약 리스트에서 참여한 회의가 없는 경우 문구를 표시하도록 구현` 라고 되어있는데 참여한 회의가 없는 경우가 아니라 회의가 하나도 존재하지 않을 때 표시하는 것이라고 내용을 정정함.