### PR TITLE
Feat(4TS-34): 타인의 프로필 정보를 보는 페이지 구현

### DIFF
--- a/src/features/comment/components/CommentList/index.tsx
+++ b/src/features/comment/components/CommentList/index.tsx
@@ -15,6 +15,7 @@ import useRenderModal from '@src/hooks/ui/useRenderModal';
 import CommentEditModal from '../CommentEditModal';
 import useDeleteCongressCommentQuery from '../../queries/useDeleteCongressCommentQuery';
 import { confirm } from '@src/components/ui/Modal/confirm';
+import Link from 'next/link';
 
 // fromNow를 사용하기 위해 플러그인 사용
 dayjs.extend(relativeTime);
@@ -64,7 +65,9 @@ const CommentList = () => {
           <li key={item.CommentId}>
             <div {...stylex.props(Styles.profileAndCommentInfoContainer)}>
               {/* 프로필 이미지 */}
-              <ProfileImg src={item.member.profileImgUrl} size={32} />
+              <Link href={`/profile/${item.member.MemberId}`}>
+                <ProfileImg src={item.member.profileImgUrl} size={32} />
+              </Link>
 
               <div {...stylex.props(Styles.commentInfoContainer)}>
                 {/* 작성자 정보 및 드롭다운 */}
@@ -72,7 +75,9 @@ const CommentList = () => {
                   {/* 닉네임 및 작성일 */}
                   <div {...stylex.props(Styles.nicknameAndDateContainer)}>
                     {/* 닉네임 */}
-                    <span {...stylex.props(Styles.nickname)}>{item.member.displayName}</span>
+                    <Link href={`/profile/${item.member.MemberId}`} {...stylex.props(Styles.nicknameLink)}>
+                      <span {...stylex.props(Styles.nickname)}>{item.member.displayName}</span>
+                    </Link>
 
                     {/* 작성일 */}
                     <span {...stylex.props(Styles.date)}>{dayjs(item.createdAt).fromNow()}</span>
@@ -153,5 +158,9 @@ const Styles = stylex.create({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  nicknameLink: {
+    width: '100%',
+    textDecoration: 'none',
   },
 });

--- a/src/features/mypage/profile/queries/useDeleteWorkspaceMemberQuery.tsx
+++ b/src/features/mypage/profile/queries/useDeleteWorkspaceMemberQuery.tsx
@@ -1,0 +1,59 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+
+type ResponseData = null;
+
+interface MemberRequestData {
+  MemberId: number;
+}
+
+const deleteWorkspaceMemberApi = async (WorkspaceId, data: MemberRequestData): Promise<ResponseData> => {
+  const { MemberId } = data;
+
+  const response = await clientInstance.delete(`/v1/workspace/@${WorkspaceId}/member/${MemberId}`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 멤버를 내보내는(추방)하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 멤버 추방 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const useDeleteWorkspaceMemberQuery = () => {
+  const router = useRouter();
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: MemberRequestData) => {
+      return deleteWorkspaceMemberApi(workspaceId, data);
+    },
+    onSuccess: (data, variables) => {
+      // 업데이트 후 멤버 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['teamList'] });
+
+      // 이전 화면으로 이동
+      router.back();
+    },
+    onError: (error, variables, context) => {
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
+  });
+
+  return mutation;
+};
+
+export default useDeleteWorkspaceMemberQuery;

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -99,7 +99,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
               data.memberList.map((item, idx) => (
                 <li {...stylex.props(Typography.SubtitleRegularSemiBold)}>
                   <div {...stylex.props(Styles.MemberItemContainer)}>
-                    <Link {...stylex.props(Styles.MemberInfoLink)} href={`/profiles/${item.MemberId}`}>
+                    <Link {...stylex.props(Styles.MemberInfoLink)} href={`/profile/${item.MemberId}`}>
                       <ProfileImg src={item.profileImgUrl} size={42} borderProperties={{ radius: '12px' }} />
                       <span>{item.displayName}</span>
                     </Link>

--- a/src/features/profile/components/ProfilePersonalDataList/index.tsx
+++ b/src/features/profile/components/ProfilePersonalDataList/index.tsx
@@ -8,6 +8,8 @@ import AlertModal from '@src/components/ui/Modal/alert';
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import { hideModal } from '@src/slices/modal';
 import { useDispatch } from 'react-redux';
+import useDeleteWorkspaceMemberQuery from '@src/features/mypage/profile/queries/useDeleteWorkspaceMemberQuery';
+import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
 
 type ProfilePersonalDataListProps = {
   dataList: { id: number; name: string; icon: React.JSX.Element }[];
@@ -15,13 +17,14 @@ type ProfilePersonalDataListProps = {
   isPublicProfile?: boolean;
   memberId?: number;
   isMyProfile?: boolean;
-  isAdmin?: boolean;
 };
 
 const ProfilePersonalDataList: FC<ProfilePersonalDataListProps> = (props) => {
-  const { dataList, isPublicProfile, title, memberId, isMyProfile, isAdmin } = props;
+  const { dataList, isPublicProfile, title, memberId, isMyProfile } = props;
   const { renderModal } = useRenderModal();
   const dispatch = useDispatch();
+  const { data } = useGetMypageInfoQuery();
+  const mutation = useDeleteWorkspaceMemberQuery();
 
   const handleClickRemoveUser = () => {
     if (isMyProfile) {
@@ -34,7 +37,7 @@ const ProfilePersonalDataList: FC<ProfilePersonalDataListProps> = (props) => {
     confirm({
       content: '내보내면 더이상 회의록을 공유할 수 없어요.\n그래도 괜찮으신가요?',
       onOk: () => {
-        console.log('내보내기');
+        mutation.mutate({ MemberId: memberId });
       },
       okBtnName: '내보낼게요',
       cancelBtnName: '같이할래요',
@@ -53,8 +56,8 @@ const ProfilePersonalDataList: FC<ProfilePersonalDataListProps> = (props) => {
           </li>
         ))}
 
-        {/* 내보내기 */}
-        {isPublicProfile && isAdmin && (
+        {/* 내보내기 - 자기 자신에게는 안보임 */}
+        {isPublicProfile && data.myInfo.isAdmin && !isMyProfile && (
           <li {...stylex.props(Styles.Item)}>
             <span>
               <RemoveUserOutlined width={24} height={24} />

--- a/src/features/profile/components/ProfilePersonalDataList/index.tsx
+++ b/src/features/profile/components/ProfilePersonalDataList/index.tsx
@@ -57,7 +57,7 @@ const ProfilePersonalDataList: FC<ProfilePersonalDataListProps> = (props) => {
         ))}
 
         {/* 내보내기 - 자기 자신에게는 안보임 */}
-        {isPublicProfile && data.myInfo.isAdmin && !isMyProfile && (
+        {isPublicProfile && data?.myInfo.isAdmin && !isMyProfile && (
           <li {...stylex.props(Styles.Item)}>
             <span>
               <RemoveUserOutlined width={24} height={24} />

--- a/src/features/reservation/components/ReservationInfo/index.tsx
+++ b/src/features/reservation/components/ReservationInfo/index.tsx
@@ -6,6 +6,7 @@ import ProfileImg from '@src/components/ui/ProfileImg';
 import useGetWorkspaceCongressQuery from '../../queries/useGetWorkspaceCongressQuery';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 const ReservationInfo = () => {
   const router = useRouter();
@@ -50,10 +51,16 @@ const ReservationInfo = () => {
                   <p {...stylex.props(Styles.TeamName)}>{teamItem.teamName}</p>
                   <div {...stylex.props(Styles.MemberListContainer)}>
                     {teamItem.memberList.map((memberItem) => (
-                      <div {...stylex.props(Styles.MemberInfoContainer)}>
-                        <ProfileImg size={20} src={memberItem.profileImgUrl} />
-                        <span {...stylex.props(Typography.TagLargeMedium)}>{memberItem.displayName}</span>
-                      </div>
+                      <Link
+                        href={`/profile/${memberItem.MemberId}`}
+                        key={memberItem.MemberId}
+                        {...stylex.props(Styles.memberLink)}
+                      >
+                        <div {...stylex.props(Styles.MemberInfoContainer)}>
+                          <ProfileImg size={20} src={memberItem.profileImgUrl} />
+                          <span {...stylex.props(Typography.TagLargeMedium)}>{memberItem.displayName}</span>
+                        </div>
+                      </Link>
                     ))}
                   </div>
                 </div>
@@ -92,6 +99,7 @@ const Styles = stylex.create({
     display: 'flex',
     gap: '4px',
     alignContent: 'center',
+    color: colors.black400,
   },
   TeamName: {
     width: '56px',
@@ -146,5 +154,9 @@ const Styles = stylex.create({
     background: colors.gray20,
     fontSize: '1.4rem',
     color: colors.black300,
+  },
+  memberLink: {
+    width: '100%',
+    textDecoration: 'none',
   },
 });

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import stylex from '@stylexjs/stylex';
+import { useRouter } from 'next/router';
+import DataflowOutlined from '@src/components/icons/DataflowOutlined';
+import MailOutlined from '@src/components/icons/MailOutlined';
+import UserSquareOutlined from '@src/components/icons/UserSquareOutlined';
+import BoundaryArea from '@src/components/ui/BoundaryArea';
+import Header from '@src/components/ui/Header';
+import ProfileImg from '@src/components/ui/ProfileImg';
+import ProfilePersonalDataList from '@src/features/profile/components/ProfilePersonalDataList';
+import useGetWorkspaceMemberQuery from '@src/features/profile/queries/useGetWorkspaceMemberQuery';
+import MainLayout from '@src/layouts/MainLayout';
+import { Typography } from '../../../public/styles/vars.stylex';
+import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
+
+const UserProfile = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const { data } = useGetWorkspaceMemberQuery(Number(id));
+
+  const handlePrevOnClick = () => {
+    router.back();
+  };
+
+  const dataList = [
+    { id: 1, name: data?.member?.teamInfo?.teamName, icon: <DataflowOutlined width={24} height={24} /> },
+    { id: 2, name: data?.member?.position || '직책 없음', icon: <UserSquareOutlined width={24} height={24} /> },
+    { id: 3, name: data?.member?.email, icon: <MailOutlined width={24} height={24} /> },
+  ];
+
+  return (
+    <MainLayout>
+      <Header prevOnClick={handlePrevOnClick} />
+
+      {/* 프로필 이미지 */}
+      <div {...stylex.props(Styles.ProfileContainer)}>
+        <ProfileImg size={68} src={data?.member?.profileImgUrl} />
+        <span {...stylex.props(Typography.TitleRegularBold)}>{data?.member?.displayName}</span>
+      </div>
+
+      {/* 경계선 */}
+      <BoundaryArea />
+
+      {/* 개인 정보 */}
+      <ProfilePersonalDataList
+        isPublicProfile
+        title="개인 정보"
+        dataList={dataList}
+        memberId={data?.member?.MemberId}
+        isMyProfile={data?.member.ourself}
+      />
+    </MainLayout>
+  );
+};
+
+export default UserProfile;
+
+const Styles = stylex.create({
+  ProfileContainer: {
+    padding: '24px 0',
+    margin: '0 auto',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '16px',
+  },
+});


### PR DESCRIPTION
# 작업 내용
- 타인의 프로필 정보를 보는 페이지 구현
   - 예약 상세보기 페이지에서 댓글 및 참여자에서 보이는 멤버 정보에 프로필 페이지로 이동하는 링크 연결
   - 관리자는 해당 페이지에서 멤버를 바로 내보낼 수 있도록 멤버 내보내기 기능 구현 (자기 자신과 타인은 내보내기 메뉴가 보이지 않음)