### PR TITLE
Update(4TS-29): 초대 페이지 디자인 변경 및 초대 참여 후 성공, 에러가 발생한 경우에 대한 로직 추가

### DIFF
--- a/public/img/ellipsis.svg
+++ b/public/img/ellipsis.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="4" viewBox="0 0 28 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="2" cy="2" r="2" fill="#444444"/>
+<circle cx="14" cy="2" r="2" fill="#444444"/>
+<circle cx="26" cy="2" r="2" fill="#444444"/>
+</svg>

--- a/src/features/invite/queries/useGetInviteInfoQuery.tsx
+++ b/src/features/invite/queries/useGetInviteInfoQuery.tsx
@@ -2,14 +2,16 @@ import clientInstance from '@src/utils/api/clientInstance';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 
-interface InviteInfo {
-  code: number;
+interface InviteInfoResponse {
   success: boolean;
+  code: number;
   inviteInfo: {
     InviteId: string;
     workspace: {
       WorkspaceId: number;
       workspaceName: string;
+      memberCount: number;
+      memberList: MemberListItem[];
     };
     invitedMember: {
       displayName: string;
@@ -18,7 +20,12 @@ interface InviteInfo {
   };
 }
 
-const getInviteInfoApi = async (InviteId: string): Promise<InviteInfo> => {
+interface MemberListItem {
+  displayName: string;
+  profileImgUrl: null | string;
+}
+
+const getInviteInfoApi = async (InviteId: string): Promise<InviteInfoResponse> => {
   const response = await clientInstance.get(`/v1/workspace/invite/${InviteId}`);
 
   return response.data;

--- a/src/features/invite/queries/usePostWorkspaceJoinQuery.tsx
+++ b/src/features/invite/queries/usePostWorkspaceJoinQuery.tsx
@@ -1,6 +1,9 @@
 import { confirm } from '@src/components/ui/Modal/confirm';
 import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import { hideModal } from '@src/slices/modal';
 import clientInstance from '@src/utils/api/clientInstance';
+import { useRouter } from 'next/router';
+import { useDispatch } from 'react-redux';
 
 interface WorkspaceInfo {
   code: number;
@@ -36,11 +39,30 @@ const postWorkspaceJoinApi = async (data: JoinInfo): Promise<WorkspaceInfo> => {
  *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
  */
 const usePostWorkspaceJoinQuery = () => {
+  const router = useRouter();
+  const dispatch = useDispatch();
+  const asPath = router.asPath;
+
   const mutation = useCustomMutation({
     mutationFn: (data: JoinInfo) => postWorkspaceJoinApi(data),
+    onSuccess: () => {
+      // 가입 성공 시 홈 화면으로 이동
+      router.push('/');
+    },
     onError: (error, variables, context) => {
+      console.log('error', error);
+      if (error?.status === 401) {
+        return confirm({
+          content: '로그인 후 참가하실 수 있습니다. 로그인 페이지로 이동할까요?',
+          onOk: () => router.push(`/login?prev_url=${process.env.NEXT_PUBLIC_FRONTEND_URL}${asPath}`),
+          onCancel: () => dispatch(hideModal()),
+        });
+      }
+
       // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
-      confirm({ content: error?.response.data.message.errMsg });
+      return confirm({
+        content: error?.response.data.message.errMsg || `서버 에러가 발생했습니다. (code: ${error?.status})`,
+      });
     },
   });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,8 +20,8 @@ export async function middleware(request: NextRequest) {
     return null;
   }
 
-  // 로그인을 하지 않은 경우, 로그인 페이지로 이동 (로그인 페이지를 제외한 모든 페이지 접근 불가)
-  if (!isRefreshToken && path !== '/login') {
+  // 로그인을 하지 않은 경우, 로그인 페이지로 이동 (초대 페이지, 로그인 페이지를 제외한 모든 페이지 접근 불가)
+  if (!isRefreshToken && !['/login', '/invite'].includes(path)) {
     return NextResponse.redirect(new URL(`/login?prev_url=${encodeURIComponent(prevUrl)}`, request.url));
   }
 

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -9,13 +9,20 @@ import Button from '@src/components/ui/Button';
 import useGetInviteInfoQuery from '@src/features/invite/queries/useGetInviteInfoQuery';
 import usePostWorkspaceJoinQuery from '@src/features/invite/queries/usePostWorkspaceJoinQuery';
 import { useRouter } from 'next/router';
+import ProfileImg from '@src/components/ui/ProfileImg';
+import EllipsisImg from '@public/img/ellipsis.svg';
 
 const Invite = () => {
   const [displayName, handleChangeDisplayName] = useInput('');
   const { data } = useGetInviteInfoQuery();
   const mutation = usePostWorkspaceJoinQuery();
   const router = useRouter();
-  const letterImgUrl = 'https://roomlet.s3.ap-northeast-2.amazonaws.com/public/images/invite/invite-letter.png';
+  const memberCount = data?.inviteInfo?.workspace?.memberCount;
+  const isMemberCountGreaterThanLimit = (limit: number) => memberCount > limit;
+  const displayedMemberNames = data?.inviteInfo?.workspace?.memberList
+    .slice(0, 2)
+    .map((item) => item.displayName)
+    .join(isMemberCountGreaterThanLimit(1) ? ', ' : '');
 
   const handleClickJoin = () => {
     mutation.mutate({
@@ -36,17 +43,63 @@ const Invite = () => {
             {/* 룸렛 텍스트 로고 */}
             <div className="logo-wrapper" {...stylex.props(Styles.logoWrapper)}>
               <RoomletTextLogo width={164} height={24} />
+              <p {...stylex.props(Typography.SubtitleRegularBold)}>룸렛에서 회의를 함께 준비해 보세요</p>
             </div>
 
             {/* 초대 내용 */}
-            <div {...stylex.props(Typography.M3BodyLarge)}>
-              <img src={letterImgUrl} alt="편지 이미지" {...stylex.props(Styles.letterImg)} />
-              <div {...stylex.props(Styles.contentWrapper, Typography.M3BodyLarge)}>
-                [{data?.inviteInfo?.invitedMember.displayName}]님이 초대했어요.
-                <br />
-                <br />
-                룸렛에서 [{data?.inviteInfo?.workspace?.workspaceName}] 회의를 <br />
-                함께 준비해보세요.
+            <div {...stylex.props(Styles.inviteContentContainer)}>
+              <p {...stylex.props(Typography.TextSmallRegular, Styles.workspaceNameContent)}>
+                {data?.inviteInfo?.workspace?.workspaceName}의 회의를 준비하고
+                <br /> 일정을 관리해보세요.
+              </p>
+
+              {/* 멤버 프로필 이미지 리스트 */}
+              <div {...stylex.props(Styles.memberInfoContainer)}>
+                {isMemberCountGreaterThanLimit(5) ? (
+                  <div {...stylex.props(Styles.greaterThanFiveMemberContainer)}>
+                    <div {...stylex.props(Styles.memberProfileImgGroupContainer)}>
+                      {data?.inviteInfo?.workspace?.memberList.slice(0, 2).map((item) => (
+                        <div {...stylex.props(Styles.memberGroupItemWrapper)}>
+                          <ProfileImg
+                            src={item.profileImgUrl}
+                            alt={`${item.displayName}의 프로필 사진`}
+                            size={60}
+                            borderProperties={{ radius: '1.6rem', color: colors.gray40, width: '1px' }}
+                          />
+                        </div>
+                      ))}
+                    </div>
+
+                    <EllipsisImg />
+                    <div {...stylex.props(Styles.memberGroupItemWrapper)}>
+                      <ProfileImg
+                        src={data?.inviteInfo?.workspace?.memberList?.slice(-1)[0]?.profileImgUrl}
+                        alt="프로필 사진"
+                        size={60}
+                        borderProperties={{ radius: '1.6rem', color: colors.gray40, width: '1px' }}
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  <div {...stylex.props(Styles.memberProfileImgGroupContainer)}>
+                    {data?.inviteInfo?.workspace?.memberList.map((item) => (
+                      <div {...stylex.props(Styles.memberGroupItemWrapper)}>
+                        <ProfileImg
+                          src={item.profileImgUrl}
+                          alt={`${item.displayName}의 프로필 사진`}
+                          size={60}
+                          borderProperties={{ radius: '1.6rem', color: colors.gray40, width: '1px' }}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* 멤버 닉네임 */}
+                <p {...stylex.props(Styles.nicknameContent, Typography.SubTextLargeRegular)}>
+                  {displayedMemberNames}
+                  {isMemberCountGreaterThanLimit(3) ? ` 님 외 ${memberCount - 2}명` : ' 님'}이 이미 함께하고 있어요..
+                </p>
               </div>
             </div>
           </div>
@@ -99,15 +152,43 @@ const Styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
+    flexDirection: 'column',
+    gap: '32px',
     marginBottom: '56px',
   },
-  letterImg: {
-    margin: '0 auto',
-    marginBottom: '52px',
-    width: '220px',
-    height: '189px',
+  inviteContentContainer: {
+    display: 'flex',
+    alignContent: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
   },
-  contentWrapper: {
+  workspaceNameContent: {
+    color: colors.black500,
+    textAlign: 'center',
+    marginBottom: '32px',
+  },
+  memberInfoContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+    gap: '24px',
+  },
+  memberProfileImgGroupContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  memberGroupItemWrapper: {
+    margin: '0 -10px',
+  },
+  greaterThanFiveMemberContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '41px',
+  },
+  nicknameContent: {
     marginBottom: '75px',
     textAlign: 'center',
   },

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -11,6 +11,7 @@ import usePostWorkspaceJoinQuery from '@src/features/invite/queries/usePostWorks
 import { useRouter } from 'next/router';
 import ProfileImg from '@src/components/ui/ProfileImg';
 import EllipsisImg from '@public/img/ellipsis.svg';
+import Link from 'next/link';
 
 const Invite = () => {
   const [displayName, handleChangeDisplayName] = useInput('');
@@ -42,7 +43,9 @@ const Invite = () => {
           <div {...stylex.props(Styles.logoAndInfoContainer)}>
             {/* 룸렛 텍스트 로고 */}
             <div className="logo-wrapper" {...stylex.props(Styles.logoWrapper)}>
-              <RoomletTextLogo width={164} height={24} />
+              <Link href="/">
+                <RoomletTextLogo width={164} height={24} />
+              </Link>
               <p {...stylex.props(Typography.SubtitleRegularBold)}>룸렛에서 회의를 함께 준비해 보세요</p>
             </div>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "paths": {
       "@src/*": ["src/*"],
       "@assets/*": ["src/assets/*"],
-      "@features/*": ["src/features/*"]
+      "@features/*": ["src/features/*"],
+      "@public/*": ["public/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
# 작업 내용
- 초대 페이지 디자인 변경
   - 디자인 수정이 최종적으로 완료되지는 않았지만 확정된 부분까지 퍼블리싱을 진행함.
- 초대 참여 후 성공 및 에러가 발생한 경우, 다음 행동 로직 추가
   - 초대 참여 성공시 홈 화면으로 이동
   - 초대 참여 실패시, 서버 에러 코드에 맞게 에러 메시지를 보여줌.
      - 401에러가 발생한 경우 로그인 페이지로 유도
      - 그 외에는 서버에서 반환하는 에러 메시지를 로드하고, 에러 메시지가 없는 경우에는 에러 코드와 함께 서버에서 에러가 발생했다는 것을 알림.