### PR TITLE
Update(RT-8): 일부 api 요청시 타임존 파라미터 전달 및 예약 시간 로드 코드 수정

### DIFF
--- a/src/features/booking/components/BookingTimePicker/TimeOptionList/index.tsx
+++ b/src/features/booking/components/BookingTimePicker/TimeOptionList/index.tsx
@@ -15,13 +15,13 @@ const TimeOptionList: FC<TimeOptionListProps> = (props) => {
   const { onSelect, data, reserDate } = props;
   const optionList = data?.timeList
     .map((item, idx) => {
-      const displayTime = item.time;
+      const displayTime = item.dateTime;
 
       // 현재 시간 이후의 시간들만 출력되게 구현
       return (
         item.isValid &&
-        dayjs().isBefore(dayjs(`${reserDate} ${displayTime}`).format('YYYY-MM-DD HH:mm')) && {
-          name: `${Number(item.time.slice(0, 2)) < 12 ? '오전' : '오후'} ${displayTime}`, // 오전, 오후를 시간과 함께 나타냄
+        dayjs().isBefore(dayjs(displayTime)) && {
+          name: `${dayjs(displayTime).format('A HH:mm')}`, // 오전, 오후를 시간과 함께 나타냄
           value: displayTime,
         }
       );
@@ -35,12 +35,23 @@ const TimeOptionList: FC<TimeOptionListProps> = (props) => {
   return (
     <div {...stylex.props(Styles.TimeListWrapper)}>
       <ul {...stylex.props(Styles.TimeList)}>
-        {React.Children.toArray(
-          optionList?.map((item) => (
-            <li {...stylex.props(Styles.TimeItem, Typography.SubTextLargeMedium)} onClick={() => handleClickTime(item)}>
-              {item.name}
-            </li>
-          ))
+        {optionList?.length > 0 ? (
+          React.Children.toArray(
+            optionList?.map((item) => (
+              <li
+                {...stylex.props(Styles.TimeItem, Typography.SubTextLargeMedium)}
+                onClick={() => handleClickTime(item)}
+              >
+                {item.name}
+              </li>
+            ))
+          )
+        ) : (
+          <li {...stylex.props(Styles.TimeItem, Styles.NoTime, Typography.SubTextLargeMedium)}>
+            예약 가능한
+            <br />
+            시간이 없어요.
+          </li>
         )}
       </ul>
     </div>
@@ -74,5 +85,9 @@ const Styles = stylex.create({
     outline: 'none',
     color: colors.gray900,
     cursor: 'pointer',
+  },
+  NoTime: {
+    textAlign: 'center',
+    color: colors.gray50,
   },
 });

--- a/src/features/booking/components/BookingTimePicker/index.tsx
+++ b/src/features/booking/components/BookingTimePicker/index.tsx
@@ -5,24 +5,25 @@ import { Typography, colors } from '../../../../../public/styles/vars.stylex';
 import TimeOptionList from './TimeOptionList';
 import type { TimeItemType } from '../../types';
 import useGetWorkspaceCongressRoomTimQuery from '../../queries/useGetMemberListQuery copy';
+import dayjs from 'dayjs';
 
 type BookingTimePickerProps = {
   placeholder: string;
   roomId: number;
   reserDate: string;
-  startTime?: TimeItemType;
+  startDt?: TimeItemType;
   onSelect: (value: TimeItemType) => void;
 };
 
 const BookingTimePicker: FC<BookingTimePickerProps> = (props) => {
-  const { placeholder, onSelect, roomId, reserDate, startTime } = props;
+  const { placeholder, onSelect, roomId, reserDate, startDt } = props;
   const [isTimeOptionOpen, setIsTimeOptionOpen] = useState<boolean>(false);
   const [selectTime, setSelectTime] = useState<TimeItemType>(null);
   const timeRef = useRef<HTMLDivElement>(null);
   const reserDateWithoutHyphens = reserDate?.split('-').join('');
 
   const { data } = useGetWorkspaceCongressRoomTimQuery(roomId, reserDateWithoutHyphens, {
-    ...(startTime ? { startTime: startTime.value } : {}),
+    ...(startDt ? { startDtNumber: dayjs(startDt.value).valueOf() } : {}),
   });
 
   const handleClickTime = () => {
@@ -47,6 +48,13 @@ const BookingTimePicker: FC<BookingTimePickerProps> = (props) => {
       window.removeEventListener('click', handleClickOutside);
     };
   }, []);
+
+  useEffect(() => {
+    // 예약 시간 날짜가 변경되면 선택된 시간 초기화
+    if (reserDate) {
+      setSelectTime(null);
+    }
+  }, [reserDate]);
 
   return (
     <div {...stylex.props(BookingStyles.formItemInputWrapper, Styles.Wrapper)} ref={timeRef}>

--- a/src/features/booking/queries/useGetMemberListQuery copy.tsx
+++ b/src/features/booking/queries/useGetMemberListQuery copy.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import clientInstance from '@src/utils/api/clientInstance';
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import getUserTimeZone from '@src/utils/timezone/getUserTimeZone';
 
 export interface CongressRoomTimeList {
   success: boolean;
@@ -24,7 +25,7 @@ const getWorkspaceCongressRoomTimeApi = async (
   params: Params
 ): Promise<CongressRoomTimeList> => {
   const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/congress/room/${RoomId}/${date}/time`, {
-    params,
+    params: { ...params, timezone: getUserTimeZone() },
   });
 
   return response.data;

--- a/src/features/booking/queries/useGetMemberListQuery copy.tsx
+++ b/src/features/booking/queries/useGetMemberListQuery copy.tsx
@@ -10,12 +10,12 @@ export interface CongressRoomTimeList {
 }
 
 export interface CongressRoomTimeItem {
-  time: string;
+  dateTime: string;
   isValid: boolean;
 }
 
 interface Params {
-  startTime?: string;
+  startDtNumber?: number;
 }
 
 const getWorkspaceCongressRoomTimeApi = async (
@@ -48,7 +48,7 @@ const useGetWorkspaceCongressRoomTimQuery = (RoomId, date, params: Params) => {
   const WorkspaceId = data?.workspaceList[0].WorkspaceId;
 
   const result = useQuery({
-    queryKey: ['workspaceCongressRoomTime', ...Object.values(params)],
+    queryKey: ['workspaceCongressRoomTime', RoomId, date, ...Object.values(params)],
     queryFn: () => getWorkspaceCongressRoomTimeApi(WorkspaceId, RoomId, date, params),
     enabled: Boolean(WorkspaceId) && Boolean(date) && Boolean(RoomId), // WorkspaceId가 정의되어 있지 않은 경우, 첫 렌더링시 요청이 이뤄지지 않게 함.
   });

--- a/src/features/calendar/components/MeetingSchedule/index.tsx
+++ b/src/features/calendar/components/MeetingSchedule/index.tsx
@@ -26,7 +26,7 @@ const MeetingSchedule: FC<{ selectDate: string }> = ({ selectDate }) => {
                 <div {...stylex.props(Styles.infoContent)}>
                   <p {...stylex.props(Styles.titleText('#333'))}>{item.congressTitle}</p>
                   <p {...stylex.props(Styles.timeText)}>
-                    {item.startTime} ~ {item.endTime}
+                    {dayjs(item.startDt).format('HH:mm')} ~ {dayjs(item.endDt).format('HH:mm')}
                   </p>
                 </div>
                 <div {...stylex.props(Styles.categoryTag(item.congressCategory.hexcode))}>

--- a/src/features/calendar/queries/useGetWorkspaceCongressCalendarQuery.tsx
+++ b/src/features/calendar/queries/useGetWorkspaceCongressCalendarQuery.tsx
@@ -1,5 +1,6 @@
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 import clientInstance from '@src/utils/api/clientInstance';
+import getUserTimeZone from '@src/utils/timezone/getUserTimeZone';
 import { useQuery } from '@tanstack/react-query';
 
 interface CongressCalendarInfo {
@@ -28,6 +29,7 @@ const getWorkspaceCongressCalendarApi = async (WorkspaceId: number, params: Para
   const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/congress/calender`, {
     params: {
       ym,
+      timezone: getUserTimeZone(),
     },
   });
 

--- a/src/features/home/components/TimeLine/index.tsx
+++ b/src/features/home/components/TimeLine/index.tsx
@@ -16,7 +16,6 @@ const TimeLine = () => {
   const { isWorkspace } = useSelector((state: RootState) => state.workspace);
   const [isMyMeeting, setIsMyMeeting] = useState<boolean>(false);
   const { data } = useGetWorkspaceCongressListQuery({
-    date: dayjs().format('YYYY-MM-DD'),
     ...(isMyMeeting ? { my: 1 } : {}),
   });
 

--- a/src/features/home/queries/useGetWorkspaceMainInfoQuery.tsx
+++ b/src/features/home/queries/useGetWorkspaceMainInfoQuery.tsx
@@ -1,5 +1,6 @@
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 import clientInstance from '@src/utils/api/clientInstance';
+import getUserTimeZone from '@src/utils/timezone/getUserTimeZone';
 import { useQuery } from '@tanstack/react-query';
 
 interface WorkspaceInfo {
@@ -25,7 +26,9 @@ interface WorkspaceInfo {
 }
 
 const getWorkspaceInfoApi = async (WorkspaceId: number): Promise<WorkspaceInfo> => {
-  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}`);
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}`, {
+    params: { timezone: getUserTimeZone() },
+  });
 
   return response.data;
 };

--- a/src/pages/booking.tsx
+++ b/src/pages/booking.tsx
@@ -38,8 +38,8 @@ const BookingDatePicker = dynamic(() => import('@src/features/booking/components
 type BookingForm = {
   date: string;
   RoomId: number;
-  startTime: TimeItemType;
-  endTime: TimeItemType;
+  startDt: TimeItemType;
+  endDt: TimeItemType;
   attendMemberList: string[];
   CongressCategoryId: number;
   congressTitle: string;
@@ -58,14 +58,14 @@ const Booking = () => {
   const { data: congressRoomData } = useGetCongressRoomListQuery();
   const { data: categoryData } = useGetCategoryListQuery();
   const mutation = usePostWorkspaceCongressQuery();
-  // 시간 선택시 roomId, date, startTime 값이 필요해서 해당 값들은 실시간 추적이 가능하도록 함.
+  // 시간 선택시 roomId, date, startDt 값이 필요해서 해당 값들은 실시간 추적이 가능하도록 함.
   const RoomId = useWatch({ control, name: 'RoomId' });
   const date = useWatch({ control, name: 'date' });
-  const startTime = useWatch({ control, name: 'startTime' });
+  const startDt = useWatch({ control, name: 'startDt' });
   // selectBookingDate 설정시 값이 초기화 되는 문제가 있어서 제목, 카테고리, 종료 시간, 참석자, 상세 내용도 추적이 가능하게 함
   const congressTitle = useWatch({ control, name: 'congressTitle' });
   const CongressCategoryId = useWatch({ control, name: 'CongressCategoryId' });
-  const endTime = useWatch({ control, name: 'endTime' });
+  const endDt = useWatch({ control, name: 'endDt' });
   const congressDescription = useWatch({ control, name: 'congressDescription' });
   const attendMemberList = useWatch({ control, name: 'attendMemberList' });
 
@@ -89,21 +89,22 @@ const Booking = () => {
       attendMemberList: mappedAttendMemberList,
       CongressCategoryId: Number(data.CongressCategoryId),
       RoomId: Number(data.RoomId),
-      startTime: data.startTime.value,
-      endTime: data.endTime.value,
+      startDt: data.startDt.value,
+      endDt: data.endDt.value,
     });
   };
 
   // Redux 상태 변경 시 React Hook Form의 값 동기화
   useEffect(() => {
     if (selectBookingDate) {
+      // 예약 날짜가 변경되면 예약 시간 초기화
       reset({
         date: selectBookingDate,
         RoomId,
-        startTime,
+        startDt: null,
         congressTitle,
         CongressCategoryId,
-        endTime,
+        endDt: null,
         congressDescription,
         attendMemberList,
       });
@@ -199,7 +200,7 @@ const Booking = () => {
           <BookingFormItem label="시간 선택" required>
             <div {...stylex.props(Styles.TimePickerContainer)}>
               <Controller
-                name="startTime"
+                name="startDt"
                 control={control}
                 defaultValue={null}
                 rules={{ required: '시작 시간을 선택해주세요' }}
@@ -214,7 +215,7 @@ const Booking = () => {
               />
               <span {...stylex.props(Styles.Hyphen)} />
               <Controller
-                name="endTime"
+                name="endDt"
                 control={control}
                 defaultValue={null}
                 rules={{ required: '종료 시간을 선택해주세요' }}
@@ -224,7 +225,7 @@ const Booking = () => {
                     onSelect={field.onChange}
                     roomId={RoomId}
                     reserDate={date}
-                    startTime={startTime}
+                    startDt={startDt}
                   />
                 )}
               />

--- a/src/queries/workspace/useGetWorkspaceCongressListQuery.tsx
+++ b/src/queries/workspace/useGetWorkspaceCongressListQuery.tsx
@@ -12,8 +12,8 @@ export interface CongressListResponse {
 }
 
 interface CongressListItem {
-  startTime: string;
-  endTime: string;
+  startDt: string;
+  endDt: string;
   date: string;
   CongressId: number;
   congressTitle: string;

--- a/src/queries/workspace/useGetWorkspaceCongressListQuery.tsx
+++ b/src/queries/workspace/useGetWorkspaceCongressListQuery.tsx
@@ -1,5 +1,6 @@
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 import clientInstance from '@src/utils/api/clientInstance';
+import getUserTimeZone from '@src/utils/timezone/getUserTimeZone';
 import { useQuery } from '@tanstack/react-query';
 
 export interface CongressListResponse {
@@ -53,7 +54,9 @@ interface Params {
 }
 
 const getWorkspaceCongressListApi = async (WorkspaceId: number, params: Params): Promise<CongressListResponse> => {
-  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/congress/list`, { params });
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/congress/list`, {
+    params: { ...params, timezone: getUserTimeZone() },
+  });
 
   return response.data;
 };

--- a/src/utils/timezone/getUserTimeZone.ts
+++ b/src/utils/timezone/getUserTimeZone.ts
@@ -1,0 +1,14 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+/**
+ * 사용자의 현재 타임존을 반환하는 함수
+ * @returns 사용자의 현재 타임존
+ */
+const getUserTimeZone = () => dayjs.tz.guess();
+
+export default getUserTimeZone;


### PR DESCRIPTION
# 작업 내용
- 사용자의 현재 타임존을 일부 api에 파라미터로 전달해야하는 코드 추가
   - 사용자의 현재 타임존을 가져오는 함수를 구현해줌.
- 예약 시간을 반환하는 api의 반환 데이터 변경에 따라 코드 수정
   - startTime, endTime이 startDt, endDt로 변경됨. 변경된 이름으로 데이터를 불러올 수 있도록 수정해줌.
   - 서버에서 전달받는 모든 시간이 utc이고, 서버에 전달해야하는 시간 데이터도 utc로 변경됨에 따라 더이상 startTime, endTime으로 시간 값만 전달받을 수 없게 됨.
   - 시간만 전달받거나 프론트에서 전달한 시간 값만으로 서버에서 utc 시간으로 계산하는 작업을 한다고 가정할 때, 구체적인 날짜와 사용자의 타임존을 제대로 알지 못한 채로 utc 변환 과정을 거치게 되기 때문에 오류가 생길수가 있음. 그래서 날짜를 포함한 utc 시간으로 예약 시간을 전달받게 됨.
   - 이 외에 회의 생성할 때 전달하는 데이터 key도 startDt, endDt로 변경됨.