### PR TITLE
Feat(RT-6): 워크스페이스 정보에서 워크스페이스 프로필 사진 로드 및 정보 수정 API 연결

### DIFF
--- a/src/components/ui/Toast/index.tsx
+++ b/src/components/ui/Toast/index.tsx
@@ -14,7 +14,9 @@ const MessageContent: FC<ToastProps> = (props) => {
 
   return (
     <div {...stylex.props(Styles.Message, Typography.TextSmallMedium)}>
-      <CircleCheckmarkFilled width={24} height={24} />
+      <div {...stylex.props(Styles.IconWrapper)}>
+        <CircleCheckmarkFilled width={24} height={24} />
+      </div>
       <span>{message}</span>
     </div>
   );
@@ -44,5 +46,8 @@ const Styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: '4px',
+  },
+  IconWrapper: {
+    flexShrink: 0,
   },
 });

--- a/src/components/ui/Toast/styles/styles.module.css
+++ b/src/components/ui/Toast/styles/styles.module.css
@@ -1,4 +1,9 @@
 .toast-container {
+  width: fit-content;
+  margin: 16px;
+  padding: 1.6rem;
+  border-radius: 1.2rem;
   background-color: var(--Gray-700);
   color: var(--Base-White);
+  word-break: keep-all;
 }

--- a/src/features/home/queries/useGetWorkspaceMainInfoQuery.tsx
+++ b/src/features/home/queries/useGetWorkspaceMainInfoQuery.tsx
@@ -18,6 +18,7 @@ interface WorkspaceInfo {
   workspace: {
     WorkspaceId: number;
     workspaceName: string;
+    workspaceImgKey: string;
     congressInfo: {
       myCongressCount: number;
       workspaceCongressCount: number;
@@ -61,6 +62,7 @@ const useGetWorkspaceMainInfoQuery = () => {
       workspace: {
         WorkspaceId: null,
         workspaceName: '',
+        workspaceImgKey: '',
         congressInfo: {
           myCongressCount: 0,
           workspaceCongressCount: 0,

--- a/src/features/mypage/compontents/MyPageImgUpload/index.tsx
+++ b/src/features/mypage/compontents/MyPageImgUpload/index.tsx
@@ -16,7 +16,7 @@ const MyPageImgUpload: FC<MyPageImgUploadProps> = (props) => {
   const { onSelect, initialImgUrl } = props;
 
   const [profileImg, setProfileImg] = useState<string>('');
-  const [imgUrl, setImgUrl] = useState<string | null>(initialImgUrl);
+  const [imgUrl, setImgUrl] = useState<string | null>(null);
   const imageUploadRef = useRef(null);
 
   const handleClickImgUpload = () => {
@@ -58,7 +58,7 @@ const MyPageImgUpload: FC<MyPageImgUploadProps> = (props) => {
     <div {...stylex.props(Styles.Container)}>
       <div {...stylex.props(Styles.ImgContainer)}>
         {/* [ ] src 타입 수정하기 */}
-        <ProfileImg src={imgUrl} size={68} />
+        <ProfileImg src={imgUrl || initialImgUrl} size={68} />
         <input
           type="file"
           style={{ display: 'none' }}

--- a/src/features/workspace/queries/usePatchWorkspaceInfoQuery.tsx
+++ b/src/features/workspace/queries/usePatchWorkspaceInfoQuery.tsx
@@ -39,7 +39,7 @@ const usePatchWorkspaceInfoQuery = () => {
   const mutation = useCustomMutation({
     mutationFn: (data: FormData) => patchWorkspaceInfoApi(workspaceId, data),
     onSuccess: () => {
-      Toast({ message: '정보 수정이 완료되었습니다.' });
+      Toast({ message: '워크스페이스 정보 수정이 완료되었습니다.' });
     },
     onError: (error, variables, context) => {
       const errorCode = error?.status;

--- a/src/features/workspace/queries/usePatchWorkspaceInfoQuery.tsx
+++ b/src/features/workspace/queries/usePatchWorkspaceInfoQuery.tsx
@@ -1,0 +1,58 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import Toast from '@src/components/ui/Toast';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+
+interface WorkspaceInfoFormData {
+  code: number;
+  success: boolean;
+  workspaceInfo: {
+    // 텍스트 필드
+    workspaceName: string;
+    // 파일 필드
+    image: File;
+  };
+}
+
+const patchWorkspaceInfoApi = async (WorkspaceId: number, data: FormData): Promise<WorkspaceInfoFormData> => {
+  const response = await clientInstance.patch(`/v1/workspace/@${WorkspaceId}`, data);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 정보를 수정하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 워크페이스 정보를 수정하기 위한 데이터
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const usePatchWorkspaceInfoQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: FormData) => patchWorkspaceInfoApi(workspaceId, data),
+    onSuccess: () => {
+      Toast({ message: '정보 수정이 완료되었습니다.' });
+    },
+    onError: (error, variables, context) => {
+      const errorCode = error?.status;
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({
+        content:
+          error?.response.data.message.errMsg ||
+          `워크스페이스 정보 수정에 실패했습니다.\n(server error code: ${errorCode})`,
+      });
+    },
+  });
+
+  return mutation;
+};
+
+export default usePatchWorkspaceInfoQuery;

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -55,15 +55,23 @@ const WorkspaceHome = () => {
           ? {
               rightBtnInfo: {
                 name: '완료',
-                isActive: !!workspaceImgFile || data?.workspace?.workspaceName !== workspaceName,
-                onClick: () => {
-                  const formData = new FormData();
+                // 이미지 파일이 있거나 워크스페이스 이름이 변경되었을 때 버튼 활성화
+                ...(!!workspaceImgFile || data?.workspace?.workspaceName !== workspaceName
+                  ? {
+                      isActive: true,
+                      onClick: () => {
+                        const formData = new FormData();
 
-                  formData.append('workspaceName', workspaceName);
-                  formData.append('image', workspaceImgFile);
+                        formData.append('workspaceName', workspaceName);
 
-                  mutation.mutate(formData);
-                },
+                        if (workspaceImgFile) {
+                          formData.append('image', workspaceImgFile);
+                        }
+
+                        mutation.mutate(formData);
+                      },
+                    }
+                  : { isActive: false, onClick: null }),
               },
             }
           : {})}

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -18,8 +18,8 @@ import { Typography } from '../../../../public/styles/vars.stylex';
 const WorkspaceHome = () => {
   const { data: myInfoData } = useGetMypageInfoQuery();
   const { data } = useGetWorkspaceMainInfoQuery();
-  const [isEdit, setIsEdit] = useState<boolean>(false);
   const [workspaceName, handleChangeWorkspaceName] = useInput<string>(data?.workspace.workspaceName);
+  const isAdmin = myInfoData?.myInfo.isAdmin;
   const commonUrl = 'mypage/workspace';
   const menuList = [
     {
@@ -37,33 +37,24 @@ const WorkspaceHome = () => {
     },
   ];
 
-  const editBtnProps = {
-    update: {
-      name: '수정',
-      isActive: isEdit,
-      onClick: () => {
-        setIsEdit(true);
-      },
-    },
-    complete: {
-      name: '완료',
-      isActive: isEdit,
-      onClick: () => {
-        setIsEdit(false);
-      },
-    },
-  };
-
   return (
     <MainLayout>
       <Header
         title="워크스페이스 정보"
         prevUrl="/mypage"
-        {...(myInfoData?.myInfo.isAdmin ? { rightBtnInfo: isEdit ? editBtnProps.complete : editBtnProps.update } : {})}
+        {...(isAdmin
+          ? {
+              rightBtnInfo: {
+                name: '완료',
+                isActive: data?.workspace?.workspaceName !== workspaceName,
+                onClick: () => {},
+              },
+            }
+          : {})}
       />
 
       {/* 이미지 업로드 및 이름 입력 */}
-      {isEdit ? (
+      {isAdmin ? (
         <div {...stylex.props(Styles.ProfileContainer)}>
           <MyPageImgUpload onSelect={null} initialImgUrl={null} />
           <MyPageInput label="워크스페이스 이름" value={workspaceName} onChange={handleChangeWorkspaceName} />

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -14,12 +14,17 @@ import useGetWorkspaceMainInfoQuery from '@src/features/home/queries/useGetWorks
 import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
 import ProfileImg from '@src/components/ui/ProfileImg';
 import { Typography } from '../../../../public/styles/vars.stylex';
+import usePatchWorkspaceInfoQuery from '@src/features/workspace/queries/usePatchWorkspaceInfoQuery';
+import Toast from '@src/components/ui/Toast';
 
 const WorkspaceHome = () => {
   const { data: myInfoData } = useGetMypageInfoQuery();
   const { data } = useGetWorkspaceMainInfoQuery();
+  const mutation = usePatchWorkspaceInfoQuery();
   const [workspaceName, handleChangeWorkspaceName] = useInput<string>(data?.workspace.workspaceName);
+  const [workspaceImgFile, setWorkspaceImgFile] = useState<Blob | null>(null);
   const isAdmin = myInfoData?.myInfo.isAdmin;
+  const workspaceImgUrl = `${process.env.NEXT_PUBLIC_S3_URL}/${data?.workspace.workspaceImgKey}`;
   const commonUrl = 'mypage/workspace';
   const menuList = [
     {
@@ -37,6 +42,10 @@ const WorkspaceHome = () => {
     },
   ];
 
+  const handleSelectWorkspaceImg = (file: Blob) => {
+    setWorkspaceImgFile(file);
+  };
+
   return (
     <MainLayout>
       <Header
@@ -46,8 +55,15 @@ const WorkspaceHome = () => {
           ? {
               rightBtnInfo: {
                 name: '완료',
-                isActive: data?.workspace?.workspaceName !== workspaceName,
-                onClick: () => {},
+                isActive: !!workspaceImgFile || data?.workspace?.workspaceName !== workspaceName,
+                onClick: () => {
+                  const formData = new FormData();
+
+                  formData.append('workspaceName', workspaceName);
+                  formData.append('image', workspaceImgFile);
+
+                  mutation.mutate(formData);
+                },
               },
             }
           : {})}
@@ -56,12 +72,12 @@ const WorkspaceHome = () => {
       {/* 이미지 업로드 및 이름 입력 */}
       {isAdmin ? (
         <div {...stylex.props(Styles.ProfileContainer)}>
-          <MyPageImgUpload onSelect={null} initialImgUrl={null} />
+          <MyPageImgUpload onSelect={handleSelectWorkspaceImg} initialImgUrl={workspaceImgUrl} />
           <MyPageInput label="워크스페이스 이름" value={workspaceName} onChange={handleChangeWorkspaceName} />
         </div>
       ) : (
         <div {...stylex.props(Styles.ProfileContainer)}>
-          <ProfileImg src={null} size={68} />
+          <ProfileImg src={workspaceImgUrl} size={68} />
           <p {...stylex.props(Typography.TitleRegularBold)}>{data.workspace.workspaceName}</p>
         </div>
       )}


### PR DESCRIPTION
# 작업 내용
- 기존에는 관리자가 프로필 수정을 눌러야 편집 화면으로 변경이 되었는데, 관리자는 워크스페이스 정보 화면에서 바로 수정 화면을 볼 수 있게하고 그 외 멤버들은 프로필 사진과 워크스페이스 이름만 볼 수 있게 함.
   - 이렇게 변경한 이유는 취소 버튼을 위치 시키는 게 마땅치 않아서 일단 이렇게 수정을 함.
- 서버에서 프로필 이미지에 데이터를 전달받게 되어서 워크스페이스 프로필 이미지 로드
- 워크스페이스 정보 수정 API 연결
- 토스트 메시지 css 수정
   - 모바일 화면에서 토스트 메시지가 PC 화면 크기에서 보던 것과 다르게 나옴
      - 메시지가 컨텐츠 내용에 맞게 너비가 줄어들지 않고, border-radius도 적용되지 않았음. 
      - 그리고 메시지가 모바일 화면 전체 너비를 차지하고 있었음.
   - 그래서 PC 화면과 모바일 화면 모두 동일한 디자인이 사용될 수 있도록 Toast 메시지 디자인을 커스텀해줌.