### PR TITLE
Feat(RT-12): SEO를 위한 메타태그를 다루는 컴포넌트 구현 및 React-query SSR 설정

### DIFF
--- a/src/components/ui/SEOHead/index.tsx
+++ b/src/components/ui/SEOHead/index.tsx
@@ -1,0 +1,48 @@
+import React, { FC } from 'react';
+import Head from 'next/head';
+
+interface SEOHeadProps {
+  title?: string;
+  description?: string;
+  image?: string;
+  url?: { pathname: string; query?: any };
+  keyword?: string;
+  isMobileUrl?: boolean;
+  jsonLd?: any;
+}
+
+const SEOHead: FC<SEOHeadProps> = (props) => {
+  const { title, description, image, url, keyword, isMobileUrl = true, jsonLd } = props;
+  const OgImage = `${process.env.NEXT_PUBLIC_S3_URL}/public/images/logo/roomlet_og_image.png`;
+  const commonMetaData = {
+    title: '룸렛',
+    description: '룸렛에서 간편하게 회의를 관리해보세요!',
+    keyword: '회의, 회의예약',
+  };
+
+  return (
+    <Head>
+      <title>{title || commonMetaData.title}</title>
+      <meta name="description" content={description || commonMetaData.description} />
+      <meta property="og:title" content={title || commonMetaData.title} />
+      <meta property="og:description" content={description || commonMetaData.description} />
+      <meta property="og:image" content={image || OgImage} />
+      <meta property="og:site_name" content="룸렛" />
+      <meta
+        property="og:url"
+        content={`${process.env.NEXT_PUBLIC_FRONTEND_URL}${url.pathname}${url.query ? `?${url.query}` : ''}`}
+      />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:keyword" content={keyword || commonMetaData.keyword} />
+
+      <meta name="twitter:title" content={title || commonMetaData.title} />
+      <meta name="twitter:description" content={description || commonMetaData.description} />
+      <meta name="twitter:card" content="summary" />
+
+      {jsonLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />}
+    </Head>
+  );
+};
+
+export default SEOHead;

--- a/src/features/invite/queries/useGetInviteInfoQuery.tsx
+++ b/src/features/invite/queries/useGetInviteInfoQuery.tsx
@@ -25,7 +25,7 @@ interface MemberListItem {
   profileImgUrl: null | string;
 }
 
-const getInviteInfoApi = async (InviteId: string): Promise<InviteInfoResponse> => {
+export const getInviteInfoApi = async (InviteId: string): Promise<InviteInfoResponse> => {
   const response = await clientInstance.get(`/v1/workspace/invite/${InviteId}`);
 
   return response.data;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { AppProps } from 'next/app';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
@@ -5,7 +6,7 @@ import 'dayjs/locale/ko';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 // react-query
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HydrationBoundary, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 // redux
 import { Provider } from 'react-redux';
@@ -21,10 +22,20 @@ import '../features/calendar/styles/custom-react-calendar.css';
 import { ToastContainer } from 'react-toastify';
 // import '../features/calendar/styles/styles.css';
 
-// client 생성
-const queryClient = new QueryClient();
-
 export default function App({ Component, pageProps }: AppProps) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // With SSR, we usually want to set some default staleTime
+            // above 0 to avoid refetching immediately on the client
+            staleTime: 60 * 1000,
+          },
+        },
+      })
+  );
+
   dayjs.extend(utc);
   dayjs.extend(timezone);
 
@@ -36,10 +47,12 @@ export default function App({ Component, pageProps }: AppProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Provider store={store}>
-        <ToastContainer />
-        <Component {...pageProps} />
-      </Provider>
+      <HydrationBoundary state={pageProps.dehydratedState}>
+        <Provider store={store}>
+          <ToastContainer />
+          <Component {...pageProps} />
+        </Provider>
+      </HydrationBoundary>
 
       {/* react-query devtools - devtools 폰트 사이즈가 너무 작아서 16px로 설정 */}
       <div className="react-query-devtools" style={{ fontSize: '16px' }}>

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -6,12 +6,15 @@ import { colors, Typography } from '../../public/styles/vars.stylex';
 import Input from '@src/components/ui/Input';
 import useInput from '@src/hooks/useInput';
 import Button from '@src/components/ui/Button';
-import useGetInviteInfoQuery from '@src/features/invite/queries/useGetInviteInfoQuery';
+import useGetInviteInfoQuery, { getInviteInfoApi } from '@src/features/invite/queries/useGetInviteInfoQuery';
 import usePostWorkspaceJoinQuery from '@src/features/invite/queries/usePostWorkspaceJoinQuery';
 import { useRouter } from 'next/router';
 import ProfileImg from '@src/components/ui/ProfileImg';
 import EllipsisImg from '@public/img/ellipsis.svg';
 import Link from 'next/link';
+import SEOHead from '@src/components/ui/SEOHead';
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import { dehydrate, QueryClient } from '@tanstack/react-query';
 
 const Invite = () => {
   const [displayName, handleChangeDisplayName] = useInput('');
@@ -38,6 +41,12 @@ const Invite = () => {
 
   return (
     <MainLayout isScroll>
+      <SEOHead
+        title={`💌 ${data?.inviteInfo?.workspace?.workspaceName}에서 초대장이 도착했어요 | 룸렛`}
+        description="룸렛에서 회의를 함께 준비해 보세요"
+        url={{ pathname: '/invite' }}
+      />
+
       <div {...stylex.props(Styles.Container)}>
         <div {...stylex.props(Styles.logoAndInfoWrapper)}>
           <div {...stylex.props(Styles.logoAndInfoContainer)}>
@@ -130,6 +139,28 @@ const Invite = () => {
 };
 
 export default Invite;
+
+export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+  const InviteId = context.query.InviteId as string;
+
+  await queryClient.prefetchQuery({
+    queryKey: ['inviteInfo', InviteId],
+    queryFn: () => getInviteInfoApi(InviteId),
+  });
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
+};
 
 const Styles = stylex.create({
   Container: {

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import stylex from '@stylexjs/stylex';
 import { useSelector } from 'react-redux';
@@ -8,7 +9,7 @@ import RoomletTextLogo from '@assets/logo_text_roomlet.svg';
 import GoogleLogo from '@features/authentication/assets/google_logo.svg';
 import MainLayout from '@src/layouts/MainLayout';
 // import OnboardingSlider from '@src/features/onboarding/components/OnboardingSlider';
-import { useRouter } from 'next/router';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const OnboardingSlider = dynamic(() => import('@src/features/onboarding/components/OnboardingSlider'), {
   ssr: false,
@@ -42,6 +43,8 @@ const Login = () => {
 
   return (
     <MainLayout>
+      <SEOHead title="로그인 | 룸렛" description="룸렛 로그인 페이지 입니다." url={{ pathname: '/login' }} />
+
       {/* 로그인 페이지를 새로 고침할 때마다 온보딩 화면이 보임 */}
       {isHidden ? (
         <>

--- a/src/utils/api/clientInstance.ts
+++ b/src/utils/api/clientInstance.ts
@@ -5,7 +5,7 @@ const setInterceptors = (instance: AxiosInstance) => {
   // 요청 인터셉트
   instance.interceptors.request.use(
     async (config) => {
-      const result = await axios.get('/api/auth');
+      const result = await axios.get(`${process.env.NEXT_PUBLIC_FRONTEND_URL}/api/auth`);
       const token = result.headers.authorization;
 
       // Authorization에 access token 저장


### PR DESCRIPTION
# 작업 내용
- SEO를 위해 title 및 각종 메타태그를 설정할 수 있는 SEOHead 컴포넌트 구현
   - 로그인 및 초대 페이지에 SEOHead 컴포넌트 추가
- React-query를 ssr에서 사용할 수 있도록 설정
   - 초대 페이지의 타이틀에 워크스페이스 명을 추가하려고 하는데, CSR로 데이터를 로드하니 undefined 후 워크스페이스명이 로드되는 문제가 있었음. 
   - 그래서 SSR에서 리액트 쿼리를 사용하여 초대 정보 데이터를 로드하게 되었고, 페이지 title도 undefined 없이 바로 데이터가 삽입됨.