### PR TITLE
Feat(RT-25): 공통 마이페이지 프로필 수정 API 연결

### DIFF
--- a/src/features/mypage/profile/queries/usePatchMypageInfoQuery.tsx
+++ b/src/features/mypage/profile/queries/usePatchMypageInfoQuery.tsx
@@ -3,17 +3,13 @@ import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 import clientInstance from '@src/utils/api/clientInstance';
 
-interface WorkspaceInfo {
+interface MyPageInfo {
   code: number;
   success: boolean;
-  workspaceInfo: {
-    WorkspaceId: number;
-    workspaceName: string;
-  };
 }
 
 // [ ] formData에 특정 키를 지정해서 해당 키 값만 받을 수 있게하는 타입스크립트를 선언한 코드 추가 필요
-const patchMypageInfoApi = async (WorkspaceId: number, data: FormData): Promise<WorkspaceInfo> => {
+const patchMypageInfoApi = async (WorkspaceId: number, data: FormData): Promise<MyPageInfo> => {
   const response = await clientInstance.patch(`/v1/workspace/@${WorkspaceId}/mypage/info`, data);
 
   return response.data;

--- a/src/features/mypage/profile/queries/usePatchMypageInfoQuery.tsx
+++ b/src/features/mypage/profile/queries/usePatchMypageInfoQuery.tsx
@@ -3,13 +3,8 @@ import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 import clientInstance from '@src/utils/api/clientInstance';
 
-interface MyPageInfo {
-  code: number;
-  success: boolean;
-}
-
 // [ ] formData에 특정 키를 지정해서 해당 키 값만 받을 수 있게하는 타입스크립트를 선언한 코드 추가 필요
-const patchMypageInfoApi = async (WorkspaceId: number, data: FormData): Promise<MyPageInfo> => {
+const patchMypageInfoApi = async (WorkspaceId: number, data: FormData) => {
   const response = await clientInstance.patch(`/v1/workspace/@${WorkspaceId}/mypage/info`, data);
 
   return response.data;

--- a/src/features/mypage/profile/queries/usePatchMypageProfileQuery.tsx
+++ b/src/features/mypage/profile/queries/usePatchMypageProfileQuery.tsx
@@ -1,0 +1,44 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import clientInstance from '@src/utils/api/clientInstance';
+
+interface WorkspaceInfo {
+  code: number;
+  success: boolean;
+  workspaceInfo: {
+    WorkspaceId: number;
+    workspaceName: string;
+  };
+}
+
+// [ ] formData에 특정 키를 지정해서 해당 키 값만 받을 수 있게하는 타입스크립트를 선언한 코드 추가 필요
+const patchMypageProfileApi = async (data: FormData): Promise<WorkspaceInfo> => {
+  const response = await clientInstance.patch(`/v1/mypage/profile`, data);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 공통 마이페이지 프로필을 수정하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 공통 마이페이지 프로필을 수정하기 위한 데이터
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const usePatchMypageProfileQuery = () => {
+  const mutation = useCustomMutation({
+    mutationFn: (data: FormData) => patchMypageProfileApi(data),
+    onError: (error, variables, context) => {
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
+  });
+
+  return mutation;
+};
+
+export default usePatchMypageProfileQuery;

--- a/src/pages/mypage/profile.tsx
+++ b/src/pages/mypage/profile.tsx
@@ -7,7 +7,6 @@ import { colors } from '../../../public/styles/vars.stylex';
 import BoundaryArea from '@src/components/ui/BoundaryArea';
 import ProfilePersonalDataList from '@src/features/profile/components/ProfilePersonalDataList';
 import DataflowOutlined from '@src/components/icons/DataflowOutlined';
-import UserSquareOutlined from '@src/components/icons/UserSquareOutlined';
 import MailOutlined from '@src/components/icons/MailOutlined';
 import MyPageImgUpload from '@src/features/mypage/compontents/MyPageImgUpload';
 import MyPageInput from '@src/features/mypage/compontents/MyPageInput';
@@ -16,12 +15,14 @@ import usePatchMypageInfoQuery from '@src/features/mypage/profile/queries/usePat
 import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
 import { RootState } from '@src/store';
 import useGetMyPageProfileQuery from '@src/features/mypage/profile/queries/useGetMyPageProfileQuery';
+import usePatchMypageProfileQuery from '@src/features/mypage/profile/queries/usePatchMypageProfileQuery';
 
 const MyPageProfile = () => {
   const { isWorkspace } = useSelector((state: RootState) => state.workspace);
   const { data } = useGetMypageInfoQuery();
   const { data: profileData } = useGetMyPageProfileQuery();
-  const mutation = usePatchMypageInfoQuery();
+  const myPageInfoMutation = usePatchMypageInfoQuery();
+  const myPageProfileMutation = usePatchMypageProfileQuery();
   const [displayName, handleChangeDisplayName] = useInput<string>(
     isWorkspace ? data?.myInfo?.displayName : profileData?.profile.displayName
   );
@@ -48,7 +49,7 @@ const MyPageProfile = () => {
       formData.append('displayName', displayName);
       formData.append('image', imageFile);
 
-      mutation.mutate(formData);
+      myPageInfoMutation.mutate(formData);
     },
   };
   const profileCompleteBtnProps = {
@@ -60,7 +61,7 @@ const MyPageProfile = () => {
       formData.append('displayName', displayName);
       formData.append('image', imageFile);
 
-      // [ ] 공통 프로필 수정 요청 추가
+      myPageProfileMutation.mutate(formData);
     },
   };
 
@@ -76,7 +77,11 @@ const MyPageProfile = () => {
       <div {...stylex.props(Styles.SettingContainer)}>
         <MyPageImgUpload
           onSelect={handleSelectImg}
-          initialImgUrl={isWorkspace ? data?.myInfo?.profileImgUrl : profileData?.profile.profileImgUrl}
+          initialImgUrl={
+            isWorkspace
+              ? `${process.env.NEXT_PUBLIC_S3_URL}/${data?.myInfo?.profileImgUrl}`
+              : `${process.env.NEXT_PUBLIC_S3_URL}/${profileData?.profile.profileImgUrl}`
+          }
         />
         <MyPageInput label="닉네임" value={displayName} onChange={handleChangeDisplayName} />
       </div>

--- a/src/pages/mypage/profile.tsx
+++ b/src/pages/mypage/profile.tsx
@@ -12,7 +12,7 @@ import MailOutlined from '@src/components/icons/MailOutlined';
 import MyPageImgUpload from '@src/features/mypage/compontents/MyPageImgUpload';
 import MyPageInput from '@src/features/mypage/compontents/MyPageInput';
 import useInput from '@src/hooks/useInput';
-import usePatchMypageInfoQuery from '@src/features/mypage/profile/queries/usePostWorkspaceJoinQuery';
+import usePatchMypageInfoQuery from '@src/features/mypage/profile/queries/usePatchMypageInfoQuery';
 import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
 import { RootState } from '@src/store';
 import useGetMyPageProfileQuery from '@src/features/mypage/profile/queries/useGetMyPageProfileQuery';


### PR DESCRIPTION
# 작업 내용
- 워크스페이스에 가입되어 있지 않은 회원인 경우에 보이는 마이페이지에서 프로필 수정이 가능하도록 수정 API를 연결함.
- 워크스페이스가 있는 회원의 마이페이지 프로필 수정 react-query의 파일 이름과 응답 타입을 수정함.