### PR TITLE
Update(RT-13): 알림 수신 설정 항목 변경 및 알림 해지시 안내 팝업이 나타나도록 구현

### DIFF
--- a/src/components/ui/Toggle/index.tsx
+++ b/src/components/ui/Toggle/index.tsx
@@ -3,13 +3,21 @@ import styles from './styles/styles.module.css';
 
 type ToggleProps = {
   onChange: (e: React.ChangeEvent) => void;
+  checked?: boolean;
   theme?: 'red500' | 'black400';
 };
 
 const Toggle: FC<ToggleProps> = (props) => {
-  const { onChange, theme = 'red500' } = props;
+  const { onChange, theme = 'red500', checked } = props;
 
-  return <input className={`${styles['common-toggle']} ${styles[theme]}`} type="checkbox" onChange={onChange} />;
+  return (
+    <input
+      className={`${styles['common-toggle']} ${styles[theme]}`}
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+    />
+  );
 };
 
 export default Toggle;

--- a/src/features/mypage/compontents/MyPageAlarmToggle/index.tsx
+++ b/src/features/mypage/compontents/MyPageAlarmToggle/index.tsx
@@ -2,6 +2,7 @@ import React, { FC, useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import Toggle from '@src/components/ui/Toggle';
 import { Typography, colors } from '../.././../../../public/styles/vars.stylex';
+import { confirm } from '@src/components/ui/Modal/confirm';
 
 type MyPageAlarmToggleProps = {
   key: string | number;
@@ -15,7 +16,20 @@ const MyPageAlarmToggle: FC<MyPageAlarmToggleProps> = (props) => {
   const [isInviteMeeting, setIsInviteMeeting] = useState<boolean>(false);
 
   const handleChangeAlarm = (e) => {
-    setIsInviteMeeting(e.target.checked);
+    const { checked } = e.target;
+
+    if (isInviteMeeting) {
+      confirm({
+        content: '중요한 알림을 놓칠 수 있어요.\n그래도 괜찮으신가요?',
+        onOk: () => {
+          setIsInviteMeeting(checked);
+        },
+        okBtnName: '그만 받을래요',
+        cancelBtnName: '계속 받을래요',
+      });
+    } else {
+      setIsInviteMeeting(checked);
+    }
   };
 
   return (
@@ -24,7 +38,7 @@ const MyPageAlarmToggle: FC<MyPageAlarmToggleProps> = (props) => {
         <p {...stylex.props(Typography.TextSmallMedium, Styles.Label)}>{label}</p>
         <p {...stylex.props(Typography.CaptionLargeRegular, Styles.Caption)}>{caption}</p>
       </div>
-      <Toggle onChange={handleChangeAlarm} />
+      <Toggle onChange={handleChangeAlarm} checked={isInviteMeeting} />
     </div>
   );
 };

--- a/src/pages/mypage/alarm.tsx
+++ b/src/pages/mypage/alarm.tsx
@@ -8,20 +8,8 @@ const MyPageAlarmSetting = () => {
   const toggleList = [
     {
       id: 1,
-      label: '회의 초대',
-      caption: '새로운 회의에 초대되면 알려드려요.',
-      apiUrl: '',
-    },
-    {
-      id: 2,
-      label: '회의 변경',
-      caption: '참여중인 회의에 변경사항이 있을 때 알려드려요.',
-      apiUrl: '',
-    },
-    {
-      id: 3,
-      label: '회의 리마인드',
-      caption: '회의 시간이 다가오면 30분 전에 다시 한 번 알려드려요.',
+      label: '회의 알림',
+      caption: '회의 리마인드, 초대, 변경 사항이 있을 때 알려드려요.',
       apiUrl: '',
     },
   ];


### PR DESCRIPTION
# 작업 내용
- 알림 수신 설정 항목 변경
   - 회의 초대, 회의 변경, 회의 리마인드에서 회의 알림으로 수정
- 알림 해지시 안내 팝업이 나타나도록 구현
   **해당 기능을 구현하다가 발생한 문제**
   - 안내 팝업에는 '계속 받을래요'와 '그만 받을래요' 버튼이 존재하는데, '그만 받을래요'를 클릭하지 않았는데도 토글을 클릭하기만 하면 바로 off 상태가 되어버리는 문제가 있었음.
   - 해당 문제가 발생한 이유는 알람에서 내가 원하는 대로 제어한 checked 상태가 전혀 반영되지 않고 있었음.
      문제가 발생한 코드는 다음과 같음.  input에서 checked 속성이 따로 존재하지 않는 상태임.
      ```jsx
      <input className={`${styles['common-toggle']} ${styles[theme]}`} type="checkbox" onChange={onChange} />
      ```
   - 그래서 props로 알람 토글 체크 상태(checked)를 전달받게해서 '그만 받을래요'를 클릭했을 때 변경된 체크 상태가 토글에 반영되게 함. 만약에 '계속 받을래요'를 누르면 토글 상태가 변경되지 않고 기존 값으로 유지됨.
      수정한 코드는 다음과 같음.
      ```jsx
      <input
        className={`${styles['common-toggle']} ${styles[theme]}`}
        type="checkbox"
        checked={checked}
        onChange={onChange}
      />
      ```