### PR TITLE
Feat(OB-41): 알림 리스트 API 연결 및 알림 페이지 무한 스크롤 적용

### DIFF
--- a/src/components/icons/AlarmOutlined.tsx
+++ b/src/components/icons/AlarmOutlined.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react';
+import { IconProps } from './types';
+
+const AlarmOutlined: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <path
+        stroke="#333"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9.354 21c.705.622 1.632 1 2.646 1s1.94-.378 2.646-1M18 8A6 6 0 1 0 6 8c0 3.09-.78 5.206-1.65 6.605-.735 1.18-1.102 1.771-1.089 1.936.015.182.054.252.2.36.133.099.732.099 1.928.099H18.61c1.196 0 1.795 0 1.927-.098.147-.11.186-.179.2-.361.014-.165-.353-.755-1.088-1.936C18.78 13.206 18 11.09 18 8"
+      />
+    </svg>
+  );
+};
+
+export default AlarmOutlined;

--- a/src/features/alarm/components/AlarmCategoryList/index.tsx
+++ b/src/features/alarm/components/AlarmCategoryList/index.tsx
@@ -1,17 +1,22 @@
 import React, { useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import { Typography, colors } from '../../../../../public/styles/vars.stylex';
+import { AlarmCategory } from '@src/queries/alarm/useGetNotificationsInfiniteQuery';
+import { useAlarmCategory } from '../../contexts/AlarmCategoryContext';
 
 const AlarmCategoryList = () => {
-  const [selectCategory, setSelectCategory] = useState<string>('all');
-  const categoryList = [
-    { id: 1, name: '전체', value: 'all' },
-    { id: 2, name: '테스트', value: 'test' },
+  const { category, setCategory } = useAlarmCategory();
+  const categoryList: { id: number; name: string; value: AlarmCategory }[] = [
+    { id: 1, name: '전체', value: null },
+    { id: 2, name: '예약', value: 'reserve' },
+    { id: 3, name: '초대', value: 'invite' },
+    { id: 4, name: '변경', value: 'change' },
+    { id: 5, name: '리마인드', value: 'remind' },
   ];
 
   const handleClick = (e) => {
     const value = e.target.getAttribute('value');
-    setSelectCategory(value);
+    setCategory(value);
   };
 
   return (
@@ -25,7 +30,7 @@ const AlarmCategoryList = () => {
               AlarmCategoryStyles.Item,
               Typography.SubTextLargeRegular,
               idx === categoryList.length - 1 && AlarmCategoryStyles.LastItem,
-              item.value === selectCategory && AlarmCategoryStyles.Active
+              item.value === category && AlarmCategoryStyles.Active
             )}
           >
             {item.name}

--- a/src/features/alarm/components/AlarmList/index.tsx
+++ b/src/features/alarm/components/AlarmList/index.tsx
@@ -6,6 +6,7 @@ import { Typography, colors } from '../../../../../public/styles/vars.stylex';
 import CloseOutlined from '@src/components/icons/CloseOutlined';
 import useGetNotificationsInfiniteQuery from '@src/queries/alarm/useGetNotificationsInfiniteQuery';
 import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
+import { useAlarmCategory } from '../../contexts/AlarmCategoryContext';
 
 // fromNow를 사용하기 위해 플러그인 사용
 dayjs.extend(relativeTime);
@@ -14,8 +15,11 @@ dayjs.extend(relativeTime);
  * 알람 리스트 컴포넌트
  */
 const AlarmList = () => {
-  const { notifications, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    useGetNotificationsInfiniteQuery();
+  const { category } = useAlarmCategory();
+
+  const { notifications, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useGetNotificationsInfiniteQuery(
+    { alarmCategory: category }
+  );
 
   const loadMoreRef = useIntersectionObserver(() => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/src/features/alarm/components/AlarmList/index.tsx
+++ b/src/features/alarm/components/AlarmList/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import stylex, { props } from '@stylexjs/stylex';
+import stylex from '@stylexjs/stylex';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { Typography, colors } from '../../../../../public/styles/vars.stylex';
 import CloseOutlined from '@src/components/icons/CloseOutlined';
+import useGetNotificationsInfiniteQuery from '@src/queries/alarm/useGetNotificationsInfiniteQuery';
+import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
 
 // fromNow를 사용하기 위해 플러그인 사용
 dayjs.extend(relativeTime);
@@ -12,47 +14,47 @@ dayjs.extend(relativeTime);
  * 알람 리스트 컴포넌트
  */
 const AlarmList = () => {
-  const data = [
-    {
-      id: 1,
-      isRead: false,
-      category: 'reservation',
-      content: `'레나'님의 회의가 예약되었어요.`,
-      createdAt: '2024-05-24',
-    },
-    {
-      id: 2,
-      isRead: true,
-      category: 'reservation',
-      content: `'레나'님의 회의가 예약되었어요.`,
-      createdAt: '2024-05-24',
-    },
-  ];
+  const { notifications, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    useGetNotificationsInfiniteQuery();
+
+  const loadMoreRef = useIntersectionObserver(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  });
 
   const alarmCategoryInfo = {
-    reservation: { imgKey: 'public/images/alarm/checked 1.png', korean: '예약' },
+    reserve: { imgKey: 'public/images/alarm/checked 1.png', korean: '예약' },
     invite: { imgKey: 'public/images/alarm/plus 1.png', korean: '초대' },
     change: { imgKey: 'public/images/alarm/shuffle 1.png', korean: '변경' },
-    notice: { imgKey: 'public/images/alarm/volume-up 1.png', korean: '공지' },
     remind: { imgKey: 'public/images/alarm/bell 1.png', korean: '리마인드' },
   };
 
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
   return (
     <ul>
-      {data.map((item) => (
-        <li key={item.id} {...stylex.props(AlarmStyles.Item, !item.isRead && AlarmStyles.NotRead)}>
+      {notifications.map((item, index) => (
+        <li
+          key={item.NotificationId}
+          {...stylex.props(AlarmStyles.Item, !item.checkedAt && AlarmStyles.NotRead)}
+          // 마지막 항목에 Intersection Observer 적용
+          ref={index === notifications.length - 1 ? loadMoreRef : undefined}
+        >
           {/* 알람 정보 */}
           <div {...stylex.props(AlarmStyles.InfoContainer)}>
             {/* 읽었는지 안 읽었는지 체크하는 dot */}
             <div {...stylex.props(AlarmStyles.DotWrapper)}>
-              {item.isRead ? '' : <span {...stylex.props(AlarmStyles.Dot)} />}
+              {item.checkedAt ? '' : <span {...stylex.props(AlarmStyles.Dot)} />}
             </div>
 
             {/* 카테고리 이미지 */}
             <div {...stylex.props(AlarmStyles.ImgWrapper)}>
               <img
-                src={`${process.env.NEXT_PUBLIC_S3_URL}/${alarmCategoryInfo[item.category].imgKey}`}
-                alt={alarmCategoryInfo[item.category].korean}
+                src={`${process.env.NEXT_PUBLIC_S3_URL}/${alarmCategoryInfo[item?.notificationType].imgKey}`}
+                alt={alarmCategoryInfo[item?.notificationType].korean}
                 width={24}
               />
             </div>
@@ -60,7 +62,7 @@ const AlarmList = () => {
             {/* 카테고리와 알람내용, 날짜 */}
             <div>
               <p {...stylex.props(Typography.SubTextLargeMedium, AlarmStyles.CategoryText)}>
-                {alarmCategoryInfo[item.category].korean}
+                {alarmCategoryInfo[item?.notificationType].korean}
               </p>
               <p {...stylex.props(Typography.TextSmallMedium, AlarmStyles.ContentText)}>{item.content}</p>
               <p {...stylex.props(Typography.CaptionRegularRegular, AlarmStyles.DateText)}>
@@ -119,5 +121,9 @@ const AlarmStyles = stylex.create({
   },
   DateText: {
     color: colors.gray60,
+  },
+  LoadingItem: {
+    textAlign: 'center',
+    padding: '16px',
   },
 });

--- a/src/features/alarm/contexts/AlarmCategoryContext.tsx
+++ b/src/features/alarm/contexts/AlarmCategoryContext.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState } from 'react';
+import { AlarmCategory } from '@src/queries/alarm/useGetNotificationsInfiniteQuery';
+
+interface AlarmCategoryContextType {
+  category: AlarmCategory;
+  setCategory: (category: AlarmCategory) => void;
+}
+
+const AlarmCategoryContext = createContext<AlarmCategoryContextType | undefined>(undefined);
+
+export const AlarmCategoryProvider = ({ children }: { children: React.ReactNode }) => {
+  const [category, setCategory] = useState<AlarmCategory>(null);
+
+  return <AlarmCategoryContext.Provider value={{ category, setCategory }}>{children}</AlarmCategoryContext.Provider>;
+};
+
+export const useAlarmCategory = () => {
+  const context = useContext(AlarmCategoryContext);
+  if (context === undefined) {
+    throw new Error('useAlarmCategory는 반드시 AlarmCategoryProvider 안에서 사용되어야 합니다.');
+  }
+  return context;
+};

--- a/src/features/home/components/UserGreeting/workspaceUser.tsx
+++ b/src/features/home/components/UserGreeting/workspaceUser.tsx
@@ -2,20 +2,30 @@ import ProfileImg from '@src/components/ui/ProfileImg';
 import stylex from '@stylexjs/stylex';
 import React, { FC } from 'react';
 import useGetWorkspaceMainInfoQuery from '../../queries/useGetWorkspaceMainInfoQuery';
+import Link from 'next/link';
+import AlarmOutlined from '@src/components/icons/AlarmOutlined';
 
 /**
- * 홈 화면에서 워크스페이스에 가입된 사용자에게 인사를 하는 내용을 담은 컴포넌트
+ * 홈 화면에서 워크스페이스에 가입된 사용자에게 환영하는 내용을 담은 컴포넌트
  */
 const WorkspaceUserGreeting = () => {
   const { data } = useGetWorkspaceMainInfoQuery();
 
   return (
     <div {...stylex.props(Styles.container)}>
-      <ProfileImg src={data?.memberInfo.profileImgKey} size={50} borderProperties={{ radius: '50%' }} />
-      <div {...stylex.props(Styles.textContent)}>
-        <p {...stylex.props(Styles.greetingText)}>룸렛에 오신걸 환영해요 🖐🏻</p>
-        <p {...stylex.props(Styles.nicknameText)}>{data?.memberInfo.displayName}님</p>
+      {/* 유저 정보 */}
+      <div {...stylex.props(Styles.userInfoContainer)}>
+        <ProfileImg src={data?.memberInfo.profileImgKey} size={50} borderProperties={{ radius: '50%' }} />
+        <div {...stylex.props(Styles.textContent)}>
+          <p {...stylex.props(Styles.greetingText)}>룸렛에 오신걸 환영해요 🖐🏻</p>
+          <p {...stylex.props(Styles.nicknameText)}>{data?.memberInfo.displayName}님</p>
+        </div>
       </div>
+
+      {/* 알림 이동 링크 */}
+      <Link href="/alarm">
+        <AlarmOutlined width={24} height={24} />
+      </Link>
     </div>
   );
 };
@@ -24,6 +34,11 @@ export default WorkspaceUserGreeting;
 
 const Styles = stylex.create({
   container: {
+    display: 'flex',
+    gap: '16px',
+    alignItems: 'center',
+  },
+  userInfoContainer: {
     width: '100%',
     display: 'flex',
     gap: '16px',

--- a/src/hooks/useIntersectionObserver.tsx
+++ b/src/hooks/useIntersectionObserver.tsx
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * 무한 스크롤을 위한 Intersection Observer 커스텀 훅
+ * @param onIntersect 인터섹션 콜백
+ * @param options 옵션 (기본값: { threshold: 0.1 })
+ * @returns
+ */
+const useIntersectionObserver = (onIntersect: () => void, options?: IntersectionObserverInit) => {
+  const targetRef = useRef<HTMLLIElement>(null);
+
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          onIntersect();
+        }
+      });
+    },
+    [onIntersect]
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(callback, {
+      threshold: 0.1,
+      ...options,
+    });
+
+    const currentTarget = targetRef.current;
+    if (currentTarget) {
+      observer.observe(currentTarget);
+    }
+
+    return () => {
+      if (currentTarget) {
+        observer.unobserve(currentTarget);
+      }
+    };
+  }, [callback, options]);
+
+  return targetRef;
+};
+
+export default useIntersectionObserver;

--- a/src/pages/alarm.tsx
+++ b/src/pages/alarm.tsx
@@ -15,7 +15,7 @@ const Alarm = () => {
 
   // 컨텍스트로 알림 카테고리 관리하기
   return (
-    <MainLayout>
+    <MainLayout isScroll>
       <Header title="알림" prevUrl="/" rightBtnInfo={readAllBtnProps} />
 
       {/* 알림 카테고리 */}

--- a/src/pages/alarm.tsx
+++ b/src/pages/alarm.tsx
@@ -1,6 +1,7 @@
 import Header from '@src/components/ui/Header';
 import AlarmCategoryList from '@src/features/alarm/components/AlarmCategoryList';
 import AlarmList from '@src/features/alarm/components/AlarmList';
+import { AlarmCategoryProvider } from '@src/features/alarm/contexts/AlarmCategoryContext';
 import MainLayout from '@src/layouts/MainLayout';
 import React, { useState } from 'react';
 
@@ -17,12 +18,13 @@ const Alarm = () => {
   return (
     <MainLayout isScroll>
       <Header title="알림" prevUrl="/" rightBtnInfo={readAllBtnProps} />
+      <AlarmCategoryProvider>
+        {/* 알림 카테고리 */}
+        <AlarmCategoryList />
 
-      {/* 알림 카테고리 */}
-      <AlarmCategoryList />
-
-      {/* 알림 리스트 */}
-      <AlarmList />
+        {/* 알림 리스트 */}
+        <AlarmList />
+      </AlarmCategoryProvider>
     </MainLayout>
   );
 };

--- a/src/queries/alarm/useGetNotificationsInfiniteQuery.tsx
+++ b/src/queries/alarm/useGetNotificationsInfiniteQuery.tsx
@@ -2,11 +2,17 @@ import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceList
 import clientInstance from '@src/utils/api/clientInstance';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
+export type AlarmCategory = 'reserve' | 'invite' | 'change' | 'remind';
+
+interface Params {
+  alarmCategory: AlarmCategory;
+}
+
 export interface NotificationItem {
   NotificationId: number;
   WorkspaceId: number;
   CongressId: number;
-  notificationType: 'reserve' | 'invite' | 'change' | 'remind';
+  notificationType: AlarmCategory;
   createdAt: string;
   content: string;
   checkedAt: string | null;
@@ -20,10 +26,14 @@ interface Notification {
 
 const PER_PAGE = 20;
 
-const getNotificationApi = async (WorkspaceId: number, page: number): Promise<Notification> => {
-  const response = await clientInstance.get(
-    `/v1/workspace/@${WorkspaceId}/mypage/notifications?page=${page}&perPage=${PER_PAGE}`
-  );
+const getNotificationApi = async (
+  WorkspaceId: number,
+  alarmCategory: AlarmCategory,
+  page: number
+): Promise<Notification> => {
+  const response = await clientInstance.get(`/v1/workspace/@${WorkspaceId}/mypage/notifications`, {
+    params: { page, perPage: PER_PAGE, ...(alarmCategory && { notyp: alarmCategory }) },
+  });
 
   return response.data;
 };
@@ -41,13 +51,13 @@ const getNotificationApi = async (WorkspaceId: number, page: number): Promise<No
  *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
  *   - `notifications`: 모든 페이지의 알림을 평면화한 배열
  */
-const useGetNotificationsInfiniteQuery = () => {
+const useGetNotificationsInfiniteQuery = ({ alarmCategory }: Params) => {
   const { data } = useGetWorkspaceListQuery();
   const workspaceId = data?.workspaceList[0]?.WorkspaceId;
 
   const result = useInfiniteQuery({
-    queryKey: ['notifications', workspaceId],
-    queryFn: ({ pageParam }) => getNotificationApi(workspaceId!, pageParam),
+    queryKey: ['notifications', workspaceId, alarmCategory],
+    queryFn: ({ pageParam }) => getNotificationApi(workspaceId!, alarmCategory, pageParam),
     initialPageParam: 1,
     getNextPageParam: (lastPage, pages) => {
       // 알림이 20개 미만이면 마지막 페이지

--- a/src/queries/alarm/useGetNotificationsInfiniteQuery.tsx
+++ b/src/queries/alarm/useGetNotificationsInfiniteQuery.tsx
@@ -1,0 +1,76 @@
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export interface NotificationItem {
+  NotificationId: number;
+  WorkspaceId: number;
+  CongressId: number;
+  notificationType: 'reserve' | 'invite' | 'change' | 'remind';
+  createdAt: string;
+  content: string;
+  checkedAt: string | null;
+}
+
+interface Notification {
+  success: boolean;
+  code: number;
+  notificationList: NotificationItem[];
+}
+
+const PER_PAGE = 20;
+
+const getNotificationApi = async (WorkspaceId: number, page: number): Promise<Notification> => {
+  const response = await clientInstance.get(
+    `/v1/workspace/@${WorkspaceId}/mypage/notifications?page=${page}&perPage=${PER_PAGE}`
+  );
+
+  return response.data;
+};
+
+/**
+ * React-query의 useInfiniteQuery를 사용하여 워크스페이스 알림 목록을 무한 스크롤로 불러오는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 페이지별 알림 데이터
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `isFetchingNextPage`: 다음 페이지 로딩 여부
+ *   - `hasNextPage`: 다음 페이지 존재 여부
+ *   - `fetchNextPage`: 다음 페이지를 수동으로 불러오는 함수
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ *   - `notifications`: 모든 페이지의 알림을 평면화한 배열
+ */
+const useGetNotificationsInfiniteQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const result = useInfiniteQuery({
+    queryKey: ['notifications', workspaceId],
+    queryFn: ({ pageParam }) => getNotificationApi(workspaceId!, pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, pages) => {
+      // 알림이 20개 미만이면 마지막 페이지
+      if (lastPage.notificationList.length < PER_PAGE) {
+        console.log('Less than 20 notifications, this is the last page');
+        return undefined;
+      }
+
+      // 다음 페이지 번호 반환
+      const nextPage = pages.length + 1;
+
+      return nextPage;
+    },
+    enabled: !!workspaceId,
+  });
+
+  // 모든 페이지의 알림을 평면화
+  const notifications = result.data?.pages.flatMap((page) => page.notificationList) ?? [];
+
+  return {
+    ...result,
+    notifications,
+  };
+};
+
+export default useGetNotificationsInfiniteQuery;


### PR DESCRIPTION
# 작업 내용
- 홈 화면에 알림 페이지로 이동하는 버튼 추가
- 알림 리스트 API 연결
-  react-query의 useInfiniteQuery를 사용하여 알림 페이지에 무한 스크롤을 구현
- 선택한 알림 카테고리에 맞는 알림 리스트가 로드되게 구현
   - 알림 카테고리는 자주 변경될 일이 없다고 판단하여 프론트에서 관리하기로 함. 추후에 알림 카테고리가 자주 변경될 일이 생기면 알림 카테고리 api를 전달 받기로 함.
   - 알림 카테고리 컴포넌트와 알림 리스트 컴포넌트 사이에 원활한 state 공유를 위해 Context API를 사용함. 원래 redux toolkit을 사용하려고 했으나, 페이지 이동시 redux toolkit에 저장된 state가 자동으로 초기화되지 않는 문제가 있어서 별도로 추가 작업을 해줘야 했는데 코드가 전방위로 쪼개져서 나중에 유지보수하기가 어려울 것 같다는 생각이 들었음. Context API를 사용하면 페이지 단위로 상태르를 관리할 수 있어서 자동으로 페이지를 벗어나면 상태가 초기화됨.

# 추후에 작업할 내용
- 알림 읽기 기능 구현
- 알림 삭제 기능 구현
- 알림 모두 읽기 기능 구현
- 브라우저 알림 연결 세팅하기