### PR TITLE
Feat(RT-41): 알림 읽기 및 모든 알림 읽음 처리하는 기능 구현

### DIFF
--- a/src/features/alarm/components/AlarmList/index.tsx
+++ b/src/features/alarm/components/AlarmList/index.tsx
@@ -7,6 +7,7 @@ import CloseOutlined from '@src/components/icons/CloseOutlined';
 import useGetNotificationsInfiniteQuery from '@src/queries/alarm/useGetNotificationsInfiniteQuery';
 import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
 import { useAlarmCategory } from '../../contexts/AlarmCategoryContext';
+import usePatchNotificationsQuery from '../../queries/usePatchNotificationsQuery';
 
 // fromNow를 사용하기 위해 플러그인 사용
 dayjs.extend(relativeTime);
@@ -16,6 +17,7 @@ dayjs.extend(relativeTime);
  */
 const AlarmList = () => {
   const { category } = useAlarmCategory();
+  const { mutate: patchNotifications } = usePatchNotificationsQuery();
 
   const { notifications, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useGetNotificationsInfiniteQuery(
     { alarmCategory: category }
@@ -38,45 +40,56 @@ const AlarmList = () => {
     return <div>로딩 중...</div>;
   }
 
+  const handleAlarmClick = (e: React.MouseEvent, notificationId: number, congressId: number) => {
+    e.preventDefault();
+    patchNotifications({ NotificationId: notificationId, CongressId: congressId });
+  };
+
   return (
     <ul>
       {notifications.map((item, index) => (
         <li
           key={item.NotificationId}
-          {...stylex.props(AlarmStyles.Item, !item.checkedAt && AlarmStyles.NotRead)}
           // 마지막 항목에 Intersection Observer 적용
           ref={index === notifications.length - 1 ? loadMoreRef : undefined}
+          {...stylex.props(AlarmStyles.Item)}
         >
-          {/* 알람 정보 */}
-          <div {...stylex.props(AlarmStyles.InfoContainer)}>
-            {/* 읽었는지 안 읽었는지 체크하는 dot */}
-            <div {...stylex.props(AlarmStyles.DotWrapper)}>
-              {item.checkedAt ? '' : <span {...stylex.props(AlarmStyles.Dot)} />}
-            </div>
+          <a
+            href="#"
+            onClick={(e) => handleAlarmClick(e, item.NotificationId, item.CongressId)}
+            {...stylex.props(AlarmStyles.Link, !item.checkedAt && AlarmStyles.NotRead)}
+          >
+            {/* 알람 정보 */}
+            <div {...stylex.props(AlarmStyles.InfoContainer)}>
+              {/* 읽었는지 안 읽었는지 체크하는 dot */}
+              <div {...stylex.props(AlarmStyles.DotWrapper)}>
+                {item.checkedAt ? '' : <span {...stylex.props(AlarmStyles.Dot)} />}
+              </div>
 
-            {/* 카테고리 이미지 */}
-            <div {...stylex.props(AlarmStyles.ImgWrapper)}>
-              <img
-                src={`${process.env.NEXT_PUBLIC_S3_URL}/${alarmCategoryInfo[item?.notificationType].imgKey}`}
-                alt={alarmCategoryInfo[item?.notificationType].korean}
-                width={24}
-              />
-            </div>
+              {/* 카테고리 이미지 */}
+              <div {...stylex.props(AlarmStyles.ImgWrapper)}>
+                <img
+                  src={`${process.env.NEXT_PUBLIC_S3_URL}/${alarmCategoryInfo[item?.notificationType].imgKey}`}
+                  alt={alarmCategoryInfo[item?.notificationType].korean}
+                  width={24}
+                />
+              </div>
 
-            {/* 카테고리와 알람내용, 날짜 */}
-            <div>
-              <p {...stylex.props(Typography.SubTextLargeMedium, AlarmStyles.CategoryText)}>
-                {alarmCategoryInfo[item?.notificationType].korean}
-              </p>
-              <p {...stylex.props(Typography.TextSmallMedium, AlarmStyles.ContentText)}>{item.content}</p>
-              <p {...stylex.props(Typography.CaptionRegularRegular, AlarmStyles.DateText)}>
-                {dayjs(item.createdAt).fromNow()}
-              </p>
+              {/* 카테고리와 알람내용, 날짜 */}
+              <div>
+                <p {...stylex.props(Typography.SubTextLargeMedium, AlarmStyles.CategoryText)}>
+                  {alarmCategoryInfo[item?.notificationType].korean}
+                </p>
+                <p {...stylex.props(Typography.TextSmallMedium, AlarmStyles.ContentText)}>{item.content}</p>
+                <p {...stylex.props(Typography.CaptionRegularRegular, AlarmStyles.DateText)}>
+                  {dayjs(item.createdAt).fromNow()}
+                </p>
+              </div>
             </div>
-          </div>
+          </a>
 
           {/* 알람 삭제 */}
-          <button type="button">
+          <button type="button" {...stylex.props(AlarmStyles.DeleteButton)}>
             <CloseOutlined width={16} height={16} />
           </button>
         </li>
@@ -89,11 +102,15 @@ export default AlarmList;
 
 const AlarmStyles = stylex.create({
   Item: {
+    position: 'relative',
+  },
+  Link: {
     width: '100%',
     padding: '16px',
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
+    textDecoration: 'none',
   },
   NotRead: {
     background: '#FFF3F3',
@@ -129,5 +146,11 @@ const AlarmStyles = stylex.create({
   LoadingItem: {
     textAlign: 'center',
     padding: '16px',
+  },
+  DeleteButton: {
+    position: 'absolute',
+    top: '16px',
+    right: '16px',
+    cursor: 'pointer',
   },
 });

--- a/src/features/alarm/queries/usePatchNotificationsQuery.tsx
+++ b/src/features/alarm/queries/usePatchNotificationsQuery.tsx
@@ -1,0 +1,71 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import { hideModal } from '@src/slices/modal';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { useDispatch } from 'react-redux';
+
+interface ResponseData {}
+
+interface ClientCustomResponseData extends ResponseData {
+  CongressId: number;
+}
+
+interface AlarmRequestData {
+  NotificationId: number;
+  isReadAll?: boolean;
+}
+
+interface MutationFnData extends AlarmRequestData {
+  CongressId: number;
+}
+
+const patchNotificationsApi = async (WorkspaceId: number, data: MutationFnData): Promise<ClientCustomResponseData> => {
+  const { CongressId, ...restData } = data;
+  const response = await clientInstance.patch(`/v1/workspace/@${WorkspaceId}/mypage/notifications`, restData);
+
+  return { ...response.data, CongressId };
+};
+
+/**
+ * React-query를 사용하여 알림을 읽은 상태로 변경하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const usePatchNotificationsQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+  const router = useRouter();
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: MutationFnData) => {
+      return patchNotificationsApi(workspaceId, data);
+    },
+    onSuccess: (data, variables) => {
+      const { CongressId } = data;
+      // 업데이트 후 알람 설정 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+
+      // 회의 페이지 이동
+      router.push(`/reservations/${CongressId}`);
+    },
+    onError: (error, variables, context) => {
+      console.log('error', error);
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
+  });
+
+  return mutation;
+};
+
+export default usePatchNotificationsQuery;

--- a/src/features/alarm/queries/usePatchNotificationsQuery.tsx
+++ b/src/features/alarm/queries/usePatchNotificationsQuery.tsx
@@ -14,12 +14,12 @@ interface ClientCustomResponseData extends ResponseData {
 }
 
 interface AlarmRequestData {
-  NotificationId: number;
+  NotificationId?: number;
   isReadAll?: boolean;
 }
 
 interface MutationFnData extends AlarmRequestData {
-  CongressId: number;
+  CongressId?: number;
 }
 
 const patchNotificationsApi = async (WorkspaceId: number, data: MutationFnData): Promise<ClientCustomResponseData> => {
@@ -55,8 +55,10 @@ const usePatchNotificationsQuery = () => {
       // 업데이트 후 알람 설정 데이터 재요청 (쿼리 무효화)
       queryClient.invalidateQueries({ queryKey: ['notifications'] });
 
-      // 회의 페이지 이동
-      router.push(`/reservations/${CongressId}`);
+      // CongressId가 있는 경우, 회의 페이지 이동 (모두 읽음 처리를 하는 경우에는 회의 페이지로 이동하지 않음)
+      if (CongressId) {
+        router.push(`/reservations/${CongressId}`);
+      }
     },
     onError: (error, variables, context) => {
       console.log('error', error);

--- a/src/pages/alarm.tsx
+++ b/src/pages/alarm.tsx
@@ -2,16 +2,17 @@ import Header from '@src/components/ui/Header';
 import AlarmCategoryList from '@src/features/alarm/components/AlarmCategoryList';
 import AlarmList from '@src/features/alarm/components/AlarmList';
 import { AlarmCategoryProvider } from '@src/features/alarm/contexts/AlarmCategoryContext';
+import usePatchNotificationsQuery from '@src/features/alarm/queries/usePatchNotificationsQuery';
 import MainLayout from '@src/layouts/MainLayout';
 import React, { useState } from 'react';
 
 const Alarm = () => {
-  const [isReadAll, setIsReadAll] = useState<boolean>(false);
+  const { mutate: patchNotifications } = usePatchNotificationsQuery();
 
   const readAllBtnProps = {
     name: '모두 읽기',
     isActive: true,
-    onClick: () => console.log(''),
+    onClick: () => patchNotifications({ isReadAll: true }),
   };
 
   // 컨텍스트로 알림 카테고리 관리하기


### PR DESCRIPTION
# 작업 내용
- 알림 읽음 처리 후 링크 이동하거나 모든 알림을 읽음 처리하는 React-query 훅 구현
- 도착한 알림 목록에서 알림을 클릭했을 때, 알림 읽음 처리하고 해당 알림과 관련된 페이지로 이동하도록 구현
- 알림 페이지에서 "모두 읽기" 클릭시 모두 읽음 처리가 되도록 구현

# 개선이 필요한 사항
- 알림 읽음 처리 후 링크 이동하거나 모든 알림을 읽음 처리하는 React-query 훅 리팩토링 필요
   - 직관적으로 이해할 수 있는 코드로 작성할 필요가 있음.
   - 하나의 api에서 2가지 기능(단일 읽음 처리, 모두 읽음 처리)하는데 그게 코드에 잘 드러나지 않음. 그래서 리팩토링이 필요함.
     ```js
      const patchNotificationsApi = async (WorkspaceId: number, data: MutationFnData): Promise<ClientCustomResponseData> => {
        const { CongressId, ...restData } = data;
        const response = await clientInstance.patch(`/v1/workspace/@${WorkspaceId}/mypage/notifications`, restData);
      
        return { ...response.data, CongressId };
      };
      ```