### PR TITLE
Feat(RT-41): 알림 페이지에서 알림 삭제 기능 구현

### DIFF
--- a/src/features/alarm/components/AlarmList/index.tsx
+++ b/src/features/alarm/components/AlarmList/index.tsx
@@ -8,6 +8,7 @@ import useGetNotificationsInfiniteQuery from '@src/queries/alarm/useGetNotificat
 import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
 import { useAlarmCategory } from '../../contexts/AlarmCategoryContext';
 import usePatchNotificationsQuery from '../../queries/usePatchNotificationsQuery';
+import useDeleteNotificationsQuery from '../../queries/useDeleteNotificationsQuery';
 
 // fromNow를 사용하기 위해 플러그인 사용
 dayjs.extend(relativeTime);
@@ -18,6 +19,7 @@ dayjs.extend(relativeTime);
 const AlarmList = () => {
   const { category } = useAlarmCategory();
   const { mutate: patchNotifications } = usePatchNotificationsQuery();
+  const { mutate: deleteNotifications } = useDeleteNotificationsQuery();
 
   const { notifications, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useGetNotificationsInfiniteQuery(
     { alarmCategory: category }
@@ -43,6 +45,11 @@ const AlarmList = () => {
   const handleAlarmClick = (e: React.MouseEvent, notificationId: number, congressId: number) => {
     e.preventDefault();
     patchNotifications({ NotificationId: notificationId, CongressId: congressId });
+  };
+
+  const handleClickDeleteAlarm = (e: React.MouseEvent, notificationId: number) => {
+    e.preventDefault();
+    deleteNotifications({ NotificationId: notificationId });
   };
 
   return (
@@ -89,7 +96,11 @@ const AlarmList = () => {
           </a>
 
           {/* 알람 삭제 */}
-          <button type="button" {...stylex.props(AlarmStyles.DeleteButton)}>
+          <button
+            type="button"
+            onClick={(e) => handleClickDeleteAlarm(e, item.NotificationId)}
+            {...stylex.props(AlarmStyles.DeleteButton)}
+          >
             <CloseOutlined width={16} height={16} />
           </button>
         </li>

--- a/src/features/alarm/queries/useDeleteNotificationsQuery.tsx
+++ b/src/features/alarm/queries/useDeleteNotificationsQuery.tsx
@@ -1,0 +1,54 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+
+type ResponseData = null;
+
+interface NotificationRequestData {
+  NotificationId: number;
+}
+
+const deleteNotificationsApi = async (WorkspaceId, data: NotificationRequestData): Promise<ResponseData> => {
+  const { NotificationId } = data;
+
+  const response = await clientInstance.delete(`/v1/workspace/@${WorkspaceId}/mypage/notifications/${NotificationId}`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 알림을 삭제하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 알림 삭제 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const useDeleteNotificationsQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: NotificationRequestData) => {
+      return deleteNotificationsApi(workspaceId, data);
+    },
+    onSuccess: (data, variables) => {
+      // 업데이트 후 알림 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+    onError: (error, variables, context) => {
+      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+      confirm({ content: error?.response.data.message.errMsg });
+    },
+  });
+
+  return mutation;
+};
+
+export default useDeleteNotificationsQuery;


### PR DESCRIPTION
# 작업 내용
- 알림 삭제 기능 구현
- 알림 페이지에 알림 삭제 버튼에 알림 삭제 API 연결
   - React-query를 사용하여 알림 삭제 커스텀 훅 구현

# 개선이 필요한 사항
- 알림 로직이 뷰 로직과 섞여 있어서 추후에 유지보수하기가 번거로울 것 같음.
- 알림 읽기, 삭제 등을 다루는 로직은 알림 로직 커스텀 훅으로 따로 분리시키는 방향으로 개선이 필요함.
