### PR TITLE
Fix(RT-24): 프로필 이미지가 제대로 보이지 않는 문제 해결

### DIFF
--- a/src/components/ui/ProfileImg/index.tsx
+++ b/src/components/ui/ProfileImg/index.tsx
@@ -20,7 +20,12 @@ interface ProfileImgProps extends React.ImgHTMLAttributes<HTMLImageElement> {
 const ProfileImg: FC<ProfileImgProps> = (props) => {
   const { src, size, borderProperties } = props;
 
-  return <img {...stylex.props(Styles.img(size, borderProperties))} src={src || s3ImgUrlConfig.defaultProfile} />;
+  return (
+    <img
+      {...stylex.props(Styles.img(size, borderProperties))}
+      src={src ? `${process.env.NEXT_PUBLIC_S3_URL}/${src}` : s3ImgUrlConfig.defaultProfile}
+    />
+  );
 };
 
 export default ProfileImg;
@@ -29,7 +34,8 @@ const Styles = stylex.create({
   img: (size, borderProperties) => ({
     width: `${size}px`,
     height: `${size}px`,
-    backgroundSize: 'cover',
+    objectFit: 'cover',
+    objectPosition: 'center',
     flexShrink: 0,
     borderWidth: borderProperties?.width,
     borderRadius: borderProperties?.radius || '50%',

--- a/src/components/ui/ProfileImg/index.tsx
+++ b/src/components/ui/ProfileImg/index.tsx
@@ -2,8 +2,9 @@ import React, { FC } from 'react';
 import stylex from '@stylexjs/stylex';
 import { s3ImgUrlConfig } from '@src/config';
 
-interface ProfileImgProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+interface ProfileImgProps extends React.ImgHTMLAttributes<Omit<HTMLImageElement, 'src'>> {
   size: number;
+  imgKey: string;
   borderProperties?: {
     width?: string;
     color?: string;
@@ -13,17 +14,17 @@ interface ProfileImgProps extends React.ImgHTMLAttributes<HTMLImageElement> {
 
 /**
  * 프로필 이미지를 보여주는 컴포넌트
- * @params src 이미지 주소
+ * @params imgKey 이미지 S3 키
  * @params size 이미지 크기
  * @params borderProperties border를 적용할 경우 border의 스타일
  */
 const ProfileImg: FC<ProfileImgProps> = (props) => {
-  const { src, size, borderProperties } = props;
+  const { imgKey, size, borderProperties } = props;
 
   return (
     <img
       {...stylex.props(Styles.img(size, borderProperties))}
-      src={src ? `${process.env.NEXT_PUBLIC_S3_URL}/${src}` : s3ImgUrlConfig.defaultProfile}
+      src={imgKey ? `${process.env.NEXT_PUBLIC_S3_URL}/${imgKey}` : s3ImgUrlConfig.defaultProfile}
     />
   );
 };

--- a/src/features/booking/components/BookingMemberSelect/MemberSearchSelect/index.tsx
+++ b/src/features/booking/components/BookingMemberSelect/MemberSearchSelect/index.tsx
@@ -81,7 +81,7 @@ const MemberSearchSelect = () => {
                     }
                   >
                     <div {...stylex.props(Styles.MemberInfoContainer)}>
-                      <ProfileImg size={20} src={memberItem.profileImgKey} />
+                      <ProfileImg size={20} imgKey={memberItem.profileImgKey} />
                       <span {...stylex.props(Typography.TagLargeMedium)}>{memberItem.displayName}</span>
                     </div>
                   </Checkbox>
@@ -117,7 +117,7 @@ const MemberSearchSelect = () => {
                       >
                         {/* 멤버 정보 */}
                         <div {...stylex.props(Styles.MemberInfoContainer)}>
-                          <ProfileImg size={20} src={memberItem.profileImgKey} />
+                          <ProfileImg size={20} imgKey={memberItem.profileImgKey} />
                           <span {...stylex.props(Typography.TagLargeMedium)}>{memberItem.displayName}</span>
                         </div>
                       </Checkbox>

--- a/src/features/booking/components/BookingMemberSelect/index.tsx
+++ b/src/features/booking/components/BookingMemberSelect/index.tsx
@@ -57,7 +57,7 @@ const BookingMemberSelect: FC<BookingMemberSelectProps> = (props) => {
               <div {...stylex.props(Styles.MemberListContainer)}>
                 {selectBookingMemberObj[teamName].map((memberItem) => (
                   <div {...stylex.props(Styles.MemberInfoContainer)}>
-                    <ProfileImg size={20} src={memberItem.profileImgKey} />
+                    <ProfileImg size={20} imgKey={memberItem.profileImgKey} />
                     <span {...stylex.props(Typography.TagLargeMedium)}>{memberItem.displayName}</span>
                   </div>
                 ))}
@@ -68,7 +68,7 @@ const BookingMemberSelect: FC<BookingMemberSelectProps> = (props) => {
       ) : (
         // 아직 선택된 멤버가 없을 때
         <button type="button" onClick={handleClickMemberSelect}>
-          <ProfileImg size={32} src={defaultImgUrl} />
+          <ProfileImg size={32} imgKey={defaultImgUrl} />
         </button>
       )}
 

--- a/src/features/comment/components/CommentList/index.tsx
+++ b/src/features/comment/components/CommentList/index.tsx
@@ -66,7 +66,7 @@ const CommentList = () => {
             <div {...stylex.props(Styles.profileAndCommentInfoContainer)}>
               {/* 프로필 이미지 */}
               <Link href={`/profile/${item.member.MemberId}`}>
-                <ProfileImg src={item.member.profileImgKey} size={32} />
+                <ProfileImg imgKey={item.member.profileImgKey} size={32} />
               </Link>
 
               <div {...stylex.props(Styles.commentInfoContainer)}>

--- a/src/features/home/components/UserGreeting/nonWorkspaceUser.tsx
+++ b/src/features/home/components/UserGreeting/nonWorkspaceUser.tsx
@@ -11,7 +11,7 @@ const NonWorkspaceUserGreeting = () => {
 
   return (
     <div {...stylex.props(Styles.container)}>
-      <ProfileImg src={data?.profile.profileImgKey} size={50} borderProperties={{ radius: '50%' }} />
+      <ProfileImg imgKey={data?.profile.profileImgKey} size={50} borderProperties={{ radius: '50%' }} />
       <div {...stylex.props(Styles.textContent)}>
         <p {...stylex.props(Styles.greetingText)}>룸렛에 오신걸 환영해요 🖐🏻</p>
         <p {...stylex.props(Styles.nicknameText)}>{data?.profile.displayName}님</p>

--- a/src/features/home/components/UserGreeting/workspaceUser.tsx
+++ b/src/features/home/components/UserGreeting/workspaceUser.tsx
@@ -15,7 +15,7 @@ const WorkspaceUserGreeting = () => {
     <div {...stylex.props(Styles.container)}>
       {/* 유저 정보 */}
       <div {...stylex.props(Styles.userInfoContainer)}>
-        <ProfileImg src={data?.memberInfo.profileImgKey} size={50} borderProperties={{ radius: '50%' }} />
+        <ProfileImg imgKey={data?.memberInfo.profileImgKey} size={50} borderProperties={{ radius: '50%' }} />
         <div {...stylex.props(Styles.textContent)}>
           <p {...stylex.props(Styles.greetingText)}>룸렛에 오신걸 환영해요 🖐🏻</p>
           <p {...stylex.props(Styles.nicknameText)}>{data?.memberInfo.displayName}님</p>

--- a/src/features/mypage/compontents/MyPageImgUpload/index.tsx
+++ b/src/features/mypage/compontents/MyPageImgUpload/index.tsx
@@ -58,7 +58,7 @@ const MyPageImgUpload: FC<MyPageImgUploadProps> = (props) => {
     <div {...stylex.props(Styles.Container)}>
       <div {...stylex.props(Styles.ImgContainer)}>
         {/* [ ] src 타입 수정하기 */}
-        <ProfileImg src={imgUrl || initialImgUrl} size={68} />
+        <ProfileImg imgKey={imgUrl || initialImgUrl} size={68} />
         <input
           type="file"
           style={{ display: 'none' }}

--- a/src/features/mypage/compontents/MypageSummaryProfile/index.tsx
+++ b/src/features/mypage/compontents/MypageSummaryProfile/index.tsx
@@ -19,7 +19,7 @@ const MypageSummaryProfile: FC<MypageSummaryProfileProps> = (props) => {
   return (
     <div {...stylex.props(Styles.Container)}>
       <Link href="/mypage/profile" {...stylex.props(Styles.ProfileLink)} passHref>
-        <ProfileImg src={data?.profileImgKey} size={60} />
+        <ProfileImg imgKey={data?.profileImgKey} size={60} />
         <div {...stylex.props(Styles.UserInfoContainer)}>
           <div>
             <p {...stylex.props(Styles.NameText, Typography.SubTextRegularBold)}>{data?.displayName}</p>

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -100,7 +100,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
                 <li {...stylex.props(Typography.SubtitleRegularSemiBold)}>
                   <div {...stylex.props(Styles.MemberItemContainer)}>
                     <Link {...stylex.props(Styles.MemberInfoLink)} href={`/profile/${item.MemberId}`}>
-                      <ProfileImg src={item.profileImgKey} size={42} borderProperties={{ radius: '12px' }} />
+                      <ProfileImg imgKey={item.profileImgKey} size={42} borderProperties={{ radius: '12px' }} />
                       <span>{item.displayName}</span>
                     </Link>
                     {isEdit && (

--- a/src/features/reservation/components/ReservationInfo/index.tsx
+++ b/src/features/reservation/components/ReservationInfo/index.tsx
@@ -85,7 +85,7 @@ const ReservationInfo = () => {
                         {...stylex.props(Styles.memberLink)}
                       >
                         <div {...stylex.props(Styles.MemberInfoContainer)}>
-                          <ProfileImg size={20} src={memberItem.profileImgKey} />
+                          <ProfileImg size={20} imgKey={memberItem.profileImgKey} />
                           <span {...stylex.props(Typography.TagLargeMedium)}>{memberItem.displayName}</span>
                         </div>
                       </Link>

--- a/src/features/reservation/components/ReservationList/index.tsx
+++ b/src/features/reservation/components/ReservationList/index.tsx
@@ -48,7 +48,7 @@ const ReservationList: FC<ReservationListProps> = (props) => {
                     {item.attendMemberList.map((item) => (
                       <div {...stylex.props(Styles.profileContent)}>
                         <ProfileImg
-                          src={item?.profileImgKey}
+                          imgKey={item?.profileImgKey}
                           size={34}
                           borderProperties={{ color: '#D9D9D9', width: '1px', radius: '50%' }}
                         />

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -69,7 +69,7 @@ const Invite = () => {
                       {data?.inviteInfo?.workspace?.memberList.slice(0, 2).map((item) => (
                         <div {...stylex.props(Styles.memberGroupItemWrapper)}>
                           <ProfileImg
-                            src={item.profileImgKey}
+                            imgKey={item.profileImgKey}
                             alt={`${item.displayName}의 프로필 사진`}
                             size={60}
                             borderProperties={{ radius: '1.6rem', color: colors.gray40, width: '1px' }}
@@ -81,7 +81,7 @@ const Invite = () => {
                     <EllipsisImg />
                     <div {...stylex.props(Styles.memberGroupItemWrapper)}>
                       <ProfileImg
-                        src={data?.inviteInfo?.workspace?.memberList?.slice(-1)[0]?.profileImgKey}
+                        imgKey={data?.inviteInfo?.workspace?.memberList?.slice(-1)[0]?.profileImgKey}
                         alt="프로필 사진"
                         size={60}
                         borderProperties={{ radius: '1.6rem', color: colors.gray40, width: '1px' }}
@@ -93,7 +93,7 @@ const Invite = () => {
                     {data?.inviteInfo?.workspace?.memberList.map((item) => (
                       <div {...stylex.props(Styles.memberGroupItemWrapper)}>
                         <ProfileImg
-                          src={item.profileImgKey}
+                          imgKey={item.profileImgKey}
                           alt={`${item.displayName}의 프로필 사진`}
                           size={60}
                           borderProperties={{ radius: '1.6rem', color: colors.gray40, width: '1px' }}

--- a/src/pages/invite/join.tsx
+++ b/src/pages/invite/join.tsx
@@ -85,7 +85,7 @@ const Join = () => {
                       {data?.inviteInfo?.workspace?.memberList.slice(0, 2).map((item) => (
                         <div {...stylex.props(Styles.memberGroupItemWrapper)}>
                           <ProfileImg
-                            src={item.profileImgKey}
+                            imgKey={item.profileImgKey}
                             alt={`${item.displayName}의 프로필 사진`}
                             size={60}
                             borderProperties={{ radius: '1.6rem', color: colors.gray40, width: '1px' }}
@@ -97,7 +97,7 @@ const Join = () => {
                     <EllipsisImg />
                     <div {...stylex.props(Styles.memberGroupItemWrapper)}>
                       <ProfileImg
-                        src={data?.inviteInfo?.workspace?.memberList?.slice(-1)[0]?.profileImgKey}
+                        imgKey={data?.inviteInfo?.workspace?.memberList?.slice(-1)[0]?.profileImgKey}
                         alt="프로필 사진"
                         size={60}
                         borderProperties={{ radius: '1.6rem', color: colors.gray40, width: '1px' }}
@@ -109,7 +109,7 @@ const Join = () => {
                     {data?.inviteInfo?.workspace?.memberList.map((item) => (
                       <div {...stylex.props(Styles.memberGroupItemWrapper)}>
                         <ProfileImg
-                          src={item.profileImgKey}
+                          imgKey={item.profileImgKey}
                           alt={`${item.displayName}의 프로필 사진`}
                           size={60}
                           borderProperties={{ radius: '1.6rem', color: colors.gray40, width: '1px' }}
@@ -131,7 +131,7 @@ const Join = () => {
             <div {...stylex.props(Styles.userInfoContainer)}>
               <div {...stylex.props(Styles.profileInfoContainer)}>
                 <ProfileImg
-                  src={profileData?.profile.profileImgKey}
+                  imgKey={profileData?.profile.profileImgKey}
                   size={34}
                   borderProperties={{ radius: '2px', color: colors.gray40, width: '1px' }}
                 />

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -24,7 +24,7 @@ const WorkspaceHome = () => {
   const [workspaceName, handleChangeWorkspaceName] = useInput<string>(data?.workspace.workspaceName);
   const [workspaceImgFile, setWorkspaceImgFile] = useState<Blob | null>(null);
   const isAdmin = myInfoData?.myInfo.isAdmin;
-  const workspaceImgUrl = `${process.env.NEXT_PUBLIC_S3_URL}/${data?.workspace.workspaceImgKey}`;
+  const workspaceImgUrl = data?.workspace.workspaceImgKey;
   const commonUrl = 'mypage/workspace';
   const menuList = [
     {

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -85,7 +85,7 @@ const WorkspaceHome = () => {
         </div>
       ) : (
         <div {...stylex.props(Styles.ProfileContainer)}>
-          <ProfileImg src={workspaceImgUrl} size={68} />
+          <ProfileImg imgKey={workspaceImgUrl} size={68} />
           <p {...stylex.props(Typography.TitleRegularBold)}>{data.workspace.workspaceName}</p>
         </div>
       )}

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -34,7 +34,7 @@ const UserProfile = () => {
 
       {/* 프로필 이미지 */}
       <div {...stylex.props(Styles.ProfileContainer)}>
-        <ProfileImg size={68} src={data?.member?.profileImgKey} />
+        <ProfileImg size={68} imgKey={data?.member?.profileImgKey} />
         <span {...stylex.props(Typography.TitleRegularBold)}>{data?.member?.displayName}</span>
       </div>
 


### PR DESCRIPTION
# 문제 상황
- 프로필 이미지가 제대로 나타나지 않는 문제가 발생함.
   <img width="775" height="337" alt="image" src="https://github.com/user-attachments/assets/c888f477-45cb-414a-b454-c02df33c0a42" />


# 문제가 발생한 이유
- <ProfileImg /> 컴포넌트에서 src 속성에 전달되는 값이 url이 아니라 s3 이미지 key 값만 전달되고 있었기 때문에 이미지가 제대로 보이지 않았음.
   ```jsx
   // home.jsx
   <ProfileImg imgKey={data?.memberInfo.profileImgKey} size={50} borderProperties={{ radius: '50%' }} />
   ```
   ```jsx
   // ProfileImg.tsx
    const ProfileImg: FC<ProfileImgProps> = (props) => {
      const { src, size, borderProperties } = props;

      return (
        <img
          {...stylex.props(Styles.img(size, borderProperties))}
          src={src || s3ImgUrlConfig.defaultProfile}
        />
      );
    };
   ```

# 문제 해결 방법
- <ProfileImg /> 컴포넌트에서 src 속성값을 그대로 전달받아서 표현하지 않고, s3 url + src 속성값을 조합하여 표현할 수 있게 해서 문제를 해결함.
- 이 때, src라는 속성 이름은 imgKey로 변경함. src라고 하면 전체 url을 전달하는 느낌이 강해서 실제로 전달받는 데이터에 맞게 속성 이름을 수정하는 게 맞다고 판단하여 변경함. 그리고 컴포넌트 속성에서 src 값 전달 여부와 상관없이 이미 img 태그에서 src 속성을 사용하고 있었기 때문에 ImgHTMLAttributes 타입을 가져올 때도 src는 제거하고 가져오도록 함.
- 최종 코드
   ```jsx
   interface ProfileImgProps extends React.ImgHTMLAttributes<Omit<HTMLImageElement, 'src'>> {
      size: number;
      imgKey: string;
      borderProperties?: {
        width?: string;
        color?: string;
        radius?: string;
      };
    }
    
    /**
     * 프로필 이미지를 보여주는 컴포넌트
     * @params imgKey 이미지 S3 키
     * @params size 이미지 크기
     * @params borderProperties border를 적용할 경우 border의 스타일
     */
    const ProfileImg: FC<ProfileImgProps> = (props) => {
      const { imgKey, size, borderProperties } = props;
    
      return (
        <img
          {...stylex.props(Styles.img(size, borderProperties))}
          src={imgKey ? `${process.env.NEXT_PUBLIC_S3_URL}/${imgKey}` : s3ImgUrlConfig.defaultProfile}
        />
      );
    };
    
    export default ProfileImg;
   ```