### PR TITLE
Feat(RT-44): 멤버 정보 페이지 및 타인이 보는 개인 프로필 페이지에서 멤버 권한 표시 추가

### DIFF
--- a/src/components/icons/CircleAdminFilled.tsx
+++ b/src/components/icons/CircleAdminFilled.tsx
@@ -1,0 +1,21 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const CircleAdminFilled: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <rect width={19} height={19} x={0.5} y={0.5} fill="#fff" rx={9.5} />
+      <rect width={19} height={19} x={0.5} y={0.5} stroke="#E2E2E2" rx={9.5} />
+      <path
+        stroke="#444"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.167}
+        d="M9.744 4.909a.292.292 0 0 1 .511 0l1.722 3.269a.583.583 0 0 0 .885.171l2.495-2.137a.292.292 0 0 1 .465.303l-1.653 5.977a.58.58 0 0 1-.558.428H6.39a.584.584 0 0 1-.558-.428L4.178 6.515a.292.292 0 0 1 .466-.302L7.138 8.35a.583.583 0 0 0 .884-.172zM5.917 15.25h8.167"
+      />
+    </svg>
+  );
+};
+export default CircleAdminFilled;

--- a/src/components/icons/CircleOwnerFilled.tsx
+++ b/src/components/icons/CircleOwnerFilled.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const CircleOwnerFilled: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <rect width={19} height={19} x={0.5} y={0.5} fill="#fff" rx={9.5} />
+      <rect width={19} height={19} x={0.5} y={0.5} stroke="#E2E2E2" rx={9.5} />
+      <g stroke="#B5312C" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.167} clipPath="url(#a)">
+        <path
+          fill="#B5312C"
+          d="M9.744 4.909a.292.292 0 0 1 .511 0l1.722 3.269a.583.583 0 0 0 .885.171l2.495-2.137a.292.292 0 0 1 .465.303l-1.653 5.977a.58.58 0 0 1-.558.428H6.39a.584.584 0 0 1-.558-.428L4.178 6.515a.292.292 0 0 1 .466-.302L7.138 8.35a.583.583 0 0 0 .884-.172z"
+        />
+        <path d="M5.917 15.25h8.167" />
+      </g>
+      <defs>
+        <clipPath id="a">
+          <path fill="#fff" d="M3 3h14v14H3z" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+export default CircleOwnerFilled;

--- a/src/components/ui/ProfileImg/index.tsx
+++ b/src/components/ui/ProfileImg/index.tsx
@@ -1,6 +1,9 @@
 import React, { FC } from 'react';
 import stylex from '@stylexjs/stylex';
 import { s3ImgUrlConfig } from '@src/config';
+import CircleAdminFilled from '@src/components/icons/CircleAdminFilled';
+import CircleOwnerFilled from '@src/components/icons/CircleOwnerFilled';
+import { MemberRole } from '@src/shared/types/member';
 
 interface ProfileImgProps extends React.ImgHTMLAttributes<Omit<HTMLImageElement, 'src'>> {
   size: number;
@@ -10,6 +13,7 @@ interface ProfileImgProps extends React.ImgHTMLAttributes<Omit<HTMLImageElement,
     color?: string;
     radius?: string;
   };
+  role?: MemberRole;
 }
 
 /**
@@ -17,21 +21,36 @@ interface ProfileImgProps extends React.ImgHTMLAttributes<Omit<HTMLImageElement,
  * @params imgKey 이미지 S3 키
  * @params size 이미지 크기
  * @params borderProperties border를 적용할 경우 border의 스타일
+ * @params role 멤버 권한 (owner : 최고 관리자, admin : 중간 관리자, member : 멤버)
  */
 const ProfileImg: FC<ProfileImgProps> = (props) => {
-  const { imgKey, size, borderProperties } = props;
+  const { imgKey, size, borderProperties, role } = props;
+
+  const roleIcon = {
+    member: null,
+    admin: <CircleAdminFilled width={20} height={20} />,
+    owner: <CircleOwnerFilled width={20} height={20} />,
+  };
 
   return (
-    <img
-      {...stylex.props(Styles.img(size, borderProperties))}
-      src={imgKey ? `${process.env.NEXT_PUBLIC_S3_URL}/${imgKey}` : s3ImgUrlConfig.defaultProfile}
-    />
+    <div {...stylex.props(Styles.imgContainer)}>
+      <img
+        {...stylex.props(Styles.img(size, borderProperties))}
+        src={imgKey ? `${process.env.NEXT_PUBLIC_S3_URL}/${imgKey}` : s3ImgUrlConfig.defaultProfile}
+      />
+      <div {...stylex.props(Styles.roleIconWrapper, borderProperties?.radius ? Styles.offsetPosition : null)}>
+        {roleIcon[role]}
+      </div>
+    </div>
   );
 };
 
 export default ProfileImg;
 
 const Styles = stylex.create({
+  imgContainer: {
+    position: 'relative',
+  },
   img: (size, borderProperties) => ({
     width: `${size}px`,
     height: `${size}px`,
@@ -43,4 +62,17 @@ const Styles = stylex.create({
     borderColor: borderProperties?.color,
     borderStyle: borderProperties?.width ? 'solid' : null,
   }),
+  roleIconWrapper: {
+    position: 'absolute',
+    display: 'flex',
+    bottom: '0',
+    right: '0',
+    flexShrink: 0,
+    lineHeight: 1,
+    height: 'fit-content',
+  },
+  offsetPosition: {
+    bottom: '-2px',
+    right: '-2px',
+  },
 });

--- a/src/features/booking/components/BookingMemberSelect/index.tsx
+++ b/src/features/booking/components/BookingMemberSelect/index.tsx
@@ -57,7 +57,7 @@ const BookingMemberSelect: FC<BookingMemberSelectProps> = (props) => {
               <div {...stylex.props(Styles.MemberListContainer)}>
                 {selectBookingMemberObj[teamName].map((memberItem) => (
                   <div {...stylex.props(Styles.MemberInfoContainer)}>
-                    <ProfileImg size={20} imgKey={memberItem.profileImgKey} />
+                    <ProfileImg size={20} imgKey={memberItem.profileImgKey} role={memberItem.role} />
                     <span {...stylex.props(Typography.TagLargeMedium)}>{memberItem.displayName}</span>
                   </div>
                 ))}

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -100,7 +100,12 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
                 <li {...stylex.props(Typography.SubtitleRegularSemiBold)}>
                   <div {...stylex.props(Styles.MemberItemContainer)}>
                     <Link {...stylex.props(Styles.MemberInfoLink)} href={`/profile/${item.MemberId}`}>
-                      <ProfileImg imgKey={item.profileImgKey} size={42} borderProperties={{ radius: '12px' }} />
+                      <ProfileImg
+                        imgKey={item.profileImgKey}
+                        size={42}
+                        borderProperties={{ radius: '12px' }}
+                        role={item.role}
+                      />
                       <span>{item.displayName}</span>
                     </Link>
                     {isEdit && (

--- a/src/features/profile/queries/useGetWorkspaceMemberQuery.tsx
+++ b/src/features/profile/queries/useGetWorkspaceMemberQuery.tsx
@@ -1,4 +1,5 @@
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import { MemberRole } from '@src/shared/types/member';
 import clientInstance from '@src/utils/api/clientInstance';
 import { useQuery } from '@tanstack/react-query';
 
@@ -17,6 +18,7 @@ interface Member {
   email: string;
   ourself: boolean;
   teamInfo: TeamInfo;
+  role: MemberRole;
 }
 
 interface TeamInfo {

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -28,6 +28,12 @@ const UserProfile = () => {
     { id: 3, name: data?.member?.email, icon: <MailOutlined width={24} height={24} /> },
   ];
 
+  const roleName = {
+    owner: '최고 관리자',
+    admin: '중간 관리자',
+    member: '멤버',
+  };
+
   return (
     <MainLayout>
       <Header prevOnClick={handlePrevOnClick} />
@@ -35,7 +41,11 @@ const UserProfile = () => {
       {/* 프로필 이미지 */}
       <div {...stylex.props(Styles.ProfileContainer)}>
         <ProfileImg size={68} imgKey={data?.member?.profileImgKey} role={data?.member?.role} />
-        <span {...stylex.props(Typography.TitleRegularBold)}>{data?.member?.displayName}</span>
+
+        <div {...stylex.props(Styles.nameContainer)}>
+          <p {...stylex.props(Typography.TitleRegularBold)}>{data?.member?.displayName}</p>
+          <p {...stylex.props(Typography.SubTextLargeRegular)}>{roleName[data?.member?.role]}</p>
+        </div>
       </div>
 
       {/* 경계선 */}
@@ -63,5 +73,11 @@ const Styles = stylex.create({
     flexDirection: 'column',
     alignItems: 'center',
     gap: '16px',
+  },
+  nameContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '8px',
   },
 });

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -34,7 +34,7 @@ const UserProfile = () => {
 
       {/* 프로필 이미지 */}
       <div {...stylex.props(Styles.ProfileContainer)}>
-        <ProfileImg size={68} imgKey={data?.member?.profileImgKey} />
+        <ProfileImg size={68} imgKey={data?.member?.profileImgKey} role={data?.member?.role} />
         <span {...stylex.props(Typography.TitleRegularBold)}>{data?.member?.displayName}</span>
       </div>
 

--- a/src/queries/team/useGetTeamListQuery.tsx
+++ b/src/queries/team/useGetTeamListQuery.tsx
@@ -1,4 +1,5 @@
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import { MemberRole } from '@src/shared/types/member';
 import clientInstance from '@src/utils/api/clientInstance';
 import { useQuery } from '@tanstack/react-query';
 
@@ -9,6 +10,7 @@ export interface MemberInfoItem {
   position: string;
   isAdmin: boolean;
   email: string;
+  role: MemberRole;
 }
 
 export interface TeamInfoItem {

--- a/src/shared/types/member.ts
+++ b/src/shared/types/member.ts
@@ -1,0 +1,1 @@
+export type MemberRole = 'member' | 'admin' | 'owner';


### PR DESCRIPTION
# 작업한 내용
- <ProfileImg /> 컴포넌트에서 멤버 권한에 맞는 아이콘을 표시하기 위해 role 속성 추가
   - 아이콘을 표시할 떄, border-radius가 존재하는 경우에는 bottom과 right 값을 -2px씩 적용되게 함.
      ```jsx
      // ProfileImg.tsx
      <div {...stylex.props(Styles.roleIconWrapper, borderProperties?.radius ? Styles.offsetPosition : null)}>
        {roleIcon[role]}
      </div>
      ...

      const Styles = stylex.create({
        ...,
        offsetPosition: {
          bottom: '-2px',
          right: '-2px',
        },
      });
      ```
- 멤버 정보 페이지에서 프로필 사진에 멤버 권한에 맞는 아이콘 표시
   <img width="146" height="142" alt="image" src="https://github.com/user-attachments/assets/3415dc8d-8d5c-4ae9-8afe-1175891d052b" />

- 타인이보는 프로필 페이지에서 프로필 사진에 멤버 권한 아이콘 표시 / 한글로 멤버 권한 표시
   <img width="158" height="176" alt="image" src="https://github.com/user-attachments/assets/9009edd2-db05-4f07-a09c-79a08e0ed511" />
