### PR TITLE
Feat(RT-45): 홈 화면의 알림 아이콘에 새로운 알림 도착 표시 기능 추가

### DIFF
--- a/src/components/icons/AlarmOutlined.tsx
+++ b/src/components/icons/AlarmOutlined.tsx
@@ -1,8 +1,12 @@
 import { FC } from 'react';
 import { IconProps } from './types';
 
-const AlarmOutlined: FC<IconProps> = (props) => {
-  const { width, height } = props;
+interface AlarmOutlinedProps extends IconProps {
+  hasNewNotification: boolean;
+}
+
+const AlarmOutlined: FC<IconProps & AlarmOutlinedProps> = (props) => {
+  const { width, height, hasNewNotification } = props;
 
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
@@ -13,6 +17,7 @@ const AlarmOutlined: FC<IconProps> = (props) => {
         strokeWidth={2}
         d="M9.354 21c.705.622 1.632 1 2.646 1s1.94-.378 2.646-1M18 8A6 6 0 1 0 6 8c0 3.09-.78 5.206-1.65 6.605-.735 1.18-1.102 1.771-1.089 1.936.015.182.054.252.2.36.133.099.732.099 1.928.099H18.61c1.196 0 1.795 0 1.927-.098.147-.11.186-.179.2-.361.014-.165-.353-.755-1.088-1.936C18.78 13.206 18 11.09 18 8"
       />
+      {hasNewNotification && <circle cx={22} cy={2} r={2} fill="#D14444" />}
     </svg>
   );
 };

--- a/src/features/home/components/UserGreeting/workspaceUser.tsx
+++ b/src/features/home/components/UserGreeting/workspaceUser.tsx
@@ -4,27 +4,28 @@ import React, { FC } from 'react';
 import useGetWorkspaceMainInfoQuery from '../../queries/useGetWorkspaceMainInfoQuery';
 import Link from 'next/link';
 import AlarmOutlined from '@src/components/icons/AlarmOutlined';
+import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
 
 /**
  * 홈 화면에서 워크스페이스에 가입된 사용자에게 환영하는 내용을 담은 컴포넌트
  */
 const WorkspaceUserGreeting = () => {
-  const { data } = useGetWorkspaceMainInfoQuery();
+  const { data } = useGetMypageInfoQuery();
 
   return (
     <div {...stylex.props(Styles.container)}>
       {/* 유저 정보 */}
       <div {...stylex.props(Styles.userInfoContainer)}>
-        <ProfileImg imgKey={data?.memberInfo.profileImgKey} size={50} borderProperties={{ radius: '50%' }} />
+        <ProfileImg imgKey={data?.myInfo.profileImgKey} size={50} borderProperties={{ radius: '50%' }} />
         <div {...stylex.props(Styles.textContent)}>
           <p {...stylex.props(Styles.greetingText)}>룸렛에 오신걸 환영해요 🖐🏻</p>
-          <p {...stylex.props(Styles.nicknameText)}>{data?.memberInfo.displayName}님</p>
+          <p {...stylex.props(Styles.nicknameText)}>{data?.myInfo.displayName}님</p>
         </div>
       </div>
 
       {/* 알림 이동 링크 */}
       <Link href="/alarm">
-        <AlarmOutlined width={24} height={24} />
+        <AlarmOutlined width={24} height={24} hasNewNotification={data?.myInfo.hasNewNotification} />
       </Link>
     </div>
   );

--- a/src/features/mypage/queries/useGetMypageInfoQuery.tsx
+++ b/src/features/mypage/queries/useGetMypageInfoQuery.tsx
@@ -10,6 +10,8 @@ export interface MypageInfo {
     position: string;
     isAdmin: boolean;
     email: string;
+    isShowOnboarding: boolean;
+    hasNewNotification: boolean;
     teamInfo: {
       TeamId: number;
       teamName: string;


### PR DESCRIPTION
# 작업 내용
- 홈 화면의 알림 아이콘에 새로운 알림 도착을 알려주는 기능 추가
  - 워크스페이스 내 정보 API 응답 데이터에 isShowOnboarding, hasNewNotification가 추가되어 MypageInfo 타입 수정
  - WorkspaceUserGreeting 컴포넌트에서 useGetMypageInfoQuery를 사용하여 사용자 정보를 가져오도록 변경하고, 프로필 이미지 및 사용자 이름을 업데이트함.
  - AlarmOutlined 컴포넌트에 hasNewNotification 속성을 추가하여 새로운 알림이 있을 경우 아이콘에 표시하도록 수정함.
  - 결과 이미지
     - 새로운 알림이 도착한 경우, 아래와 같이 빨간 점이 보이게 됨.
     <img width="771" height="372" alt="image" src="https://github.com/user-attachments/assets/1fc094f4-8ed0-4e3a-bfd5-155a82b4b86f" />
