### PR TITLE
Feat(RT-46): 멤버 및 팀 수정을 벌크성에서 개별성 수정으로 변경 및 팀 검색 기능 추가

### DIFF
--- a/src/components/icons/EllipsisOutlined.tsx
+++ b/src/components/icons/EllipsisOutlined.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
-const EllipsisOutlined = (props) => {
-  const { width, height } = props;
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const EllipsisOutlined: FC<IconProps> = (props) => {
+  const { width, height, color } = props;
 
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
       <g clipPath="url(#a)">
         <path
-          fill="#999"
+          fill={color || '#999'}
           d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2m0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
         />
       </g>

--- a/src/components/icons/SearchOutlinedV2.tsx
+++ b/src/components/icons/SearchOutlinedV2.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const SearchOutlinedV2: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <g clipPath="url(#a)">
+        <path
+          fill="#999"
+          d="M15.5 14h-.79l-.28-.27A6.47 6.47 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+        />
+      </g>
+      <defs>
+        <clipPath id="a">
+          <path fill="#fff" d="M0 0h24v24H0z" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+export default SearchOutlinedV2;

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -10,10 +10,13 @@ interface DropdownProps {
     icon: React.ReactNode;
     onClick: () => void;
   }[];
+  ellipsisIconStyle?: {
+    color: string;
+  };
 }
 
 const Dropdown: FC<DropdownProps> = (props) => {
-  const { menuList } = props;
+  const { menuList, ellipsisIconStyle } = props;
   const [isOpen, setIsOpen] = useState(false);
 
   const handleClickDropdown = () => {
@@ -39,7 +42,7 @@ const Dropdown: FC<DropdownProps> = (props) => {
       <div {...stylex.props(Styles.dropdownContainer)}>
         {/* 드롭박스 */}
         <button type="button" onClick={handleClickDropdown}>
-          <EllipsisOutlined width={24} height={24} />
+          <EllipsisOutlined width={24} height={24} color={ellipsisIconStyle?.color} />
         </button>
         {isOpen && (
           <>

--- a/src/components/ui/ProfileImg/index.tsx
+++ b/src/components/ui/ProfileImg/index.tsx
@@ -50,6 +50,7 @@ export default ProfileImg;
 const Styles = stylex.create({
   imgContainer: {
     position: 'relative',
+    flexShrink: 0,
   },
   img: (size, borderProperties) => ({
     width: `${size}px`,

--- a/src/constants/member.ts
+++ b/src/constants/member.ts
@@ -1,0 +1,7 @@
+export const MEMBER_ROLE_KOREAN_LABELS = {
+  owner: '최고 관리자',
+  admin: '중간 관리자',
+  member: '멤버',
+} as const;
+
+export type MemberKoreanRoleLabel = (typeof MEMBER_ROLE_KOREAN_LABELS)[keyof typeof MEMBER_ROLE_KOREAN_LABELS];

--- a/src/features/calendar/components/DateWheelPicker/index.tsx
+++ b/src/features/calendar/components/DateWheelPicker/index.tsx
@@ -31,7 +31,6 @@ const selections = {
  */
 const DateWheelPicker: FC<DateWheelPickerProps> = (props) => {
   const { isOpen, onClose, onSelect, defaultValue } = props;
-  console.log({ defaultValue }, dayjs(`${defaultValue.year}.${defaultValue.month}.${defaultValue.day}}`));
   const todayDate = dayjs(`${defaultValue.year}-${defaultValue.month}-${defaultValue.day}`).format(
     'YYYY년 M월 D일 ddd요일'
   );

--- a/src/features/mypage/queries/useGetMypageInfoQuery.tsx
+++ b/src/features/mypage/queries/useGetMypageInfoQuery.tsx
@@ -1,4 +1,5 @@
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import { MemberRole } from '@src/shared/types/member';
 import clientInstance from '@src/utils/api/clientInstance';
 import { useQuery } from '@tanstack/react-query';
 
@@ -12,6 +13,7 @@ export interface MypageInfo {
     email: string;
     isShowOnboarding: boolean;
     hasNewNotification: boolean;
+    role: MemberRole;
     teamInfo: {
       TeamId: number;
       teamName: string;

--- a/src/features/mypage/workspace/member/components/AddTeamBottomSheet/index.tsx
+++ b/src/features/mypage/workspace/member/components/AddTeamBottomSheet/index.tsx
@@ -6,8 +6,8 @@ import { colors, Typography } from '../../../../../../../public/styles/vars.styl
 import Input from '@src/components/ui/Input';
 import useInput from '@src/hooks/useInput';
 import { hideModal } from '@src/slices/modal';
-import { addTeam } from '../../slices/member';
 import useGetTeamListQuery from '@src/queries/team/useGetTeamListQuery';
+import useAddTeamNameQuery from '../../queries/useAddTeamNameQuery';
 
 let bottomSheetId = 'add-congress-room-bottom-sheet';
 
@@ -16,6 +16,7 @@ const AddTeamBottomSheet = () => {
   const [validMsg, setValidMsg] = useState<string>('');
   const dispatch = useDispatch();
   const { data } = useGetTeamListQuery();
+  const { mutate: AddTeamMutate } = useAddTeamNameQuery();
 
   useEffect(() => {
     if (name.length > 0) {
@@ -29,7 +30,7 @@ const AddTeamBottomSheet = () => {
       return;
     }
 
-    dispatch(addTeam({ teamName: name }));
+    AddTeamMutate({ teamName: name });
     dispatch(hideModal());
   };
 

--- a/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
+++ b/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
@@ -5,48 +5,49 @@ import BottomSheet from '@src/components/ui/BottomSheet';
 import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
 import { hideModal } from '@src/slices/modal';
 import { saveTeamList } from '../../slices/member';
-import { MemberInfoItem } from '@src/queries/team/useGetTeamListQuery';
+import useGetTeamListQuery, { MemberInfoItem } from '@src/queries/team/useGetTeamListQuery';
 import { RootState } from '@src/store';
 import TriangleFilled from '@src/components/icons/TriangleFilled';
+import useUpdateMemberQuery from '../../queries/useUpdateMemberQuery';
+import { MEMBER_ROLE_KOREAN_LABELS } from '@src/constants/member';
 
 let bottomSheetId = 'move-member-bottom-sheet';
 
 interface MoveMemberBottomSheetProps {
   data: MemberInfoItem;
-  selectMemberTeamIdx: number;
+  teamId: number;
 }
 
 const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
-  const { data, selectMemberTeamIdx } = props;
+  const { data, teamId } = props;
+  const { data: teamListData } = useGetTeamListQuery();
   const dispatch = useDispatch();
-  const { editTeamList } = useSelector((state: RootState) => state.member);
-  const selectOptionList = editTeamList.filter((item, index) => index !== selectMemberTeamIdx); // 이미 참여한 팀은 option에 나타나지 않게 함.
-  const [selectTeamIdx, setSelectTeamIdx] = useState<number>(selectOptionList[0].TeamId);
+  const teamOptionList = teamListData.teamList; // 이미 참여한 팀은 option에 나타나지 않게 함.
+  const [selectTeamId, setSelectTeamId] = useState<number>(teamId);
+  const [selectRole, setSelectRole] = useState<string>(data.role);
+  const { mutate: UpdateMemberMutate } = useUpdateMemberQuery();
+
+  const roleOptionList = [
+    { id: 1, role: 'member' },
+    { id: 2, role: 'admin' },
+    { id: 3, role: 'owner' },
+  ];
 
   const handleClickSelectTeam = (e) => {
     const value = Number(e.target.value);
 
-    setSelectTeamIdx(value);
+    setSelectTeamId(value);
+  };
+
+  const handleClickSelectRole = (e) => {
+    const value = e.target.value;
+
+    setSelectRole(value);
   };
 
   const handleClickRegister = () => {
-    const moveMemberTeamList = editTeamList.map((item, idx) => {
-      // 원래 있던 팀에서 삭제
-      if (idx === selectMemberTeamIdx) {
-        const tempDeleteMemberList = item.memberList.filter((memberItem) => memberItem.MemberId !== data.MemberId);
+    UpdateMemberMutate({ MemberId: data.MemberId, role: selectRole, TeamId: selectTeamId });
 
-        return { ...item, memberList: tempDeleteMemberList };
-      }
-
-      // 새로운 팀에서 멤버 추가
-      if (item.TeamId === selectTeamIdx) {
-        return { ...item, memberList: [...item.memberList, data] };
-      }
-
-      return item;
-    });
-
-    dispatch(saveTeamList(moveMemberTeamList));
     dispatch(hideModal());
   };
 
@@ -55,8 +56,30 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
       <div {...stylex.props(Styles.Container)}>
         <p {...stylex.props(Typography.SubtitleRegularSemiBold, Styles.Title)}>멤버 수정</p>
 
-        {/* 팀 선택 영역 */}
         <div {...stylex.props(Styles.TeamSelectContainer)}>
+          {/* 팀 이동을 위해 선택한 멤버 */}
+          <div {...stylex.props(Styles.DisplayNameWrapper, Typography.SubTextLargeRegular)}>{data.displayName}</div>
+
+          {/* 역할 선택 영역 */}
+          <div {...stylex.props(Styles.SelectContainer)}>
+            <div {...stylex.props(Styles.SelectIcon)}>
+              <TriangleFilled width={24} height={24} />
+            </div>
+            <select
+              name="role"
+              onChange={handleClickSelectRole}
+              defaultValue={data.role}
+              {...stylex.props(Styles.Select, Typography.SubTextLargeRegular)}
+            >
+              {roleOptionList.map((item) => (
+                <option key={item.id} value={item.role}>
+                  {MEMBER_ROLE_KOREAN_LABELS[item.role]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 팀 선택 영역 */}
           <div {...stylex.props(Styles.SelectContainer)}>
             <div {...stylex.props(Styles.SelectIcon)}>
               <TriangleFilled width={24} height={24} />
@@ -64,16 +87,14 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
             <select
               name="team"
               onChange={handleClickSelectTeam}
+              defaultValue={teamId}
               {...stylex.props(Styles.Select, Typography.SubTextLargeRegular)}
             >
-              {selectOptionList.map((item, index) => (
-                <option value={index}>{item.teamName}</option>
+              {teamOptionList.map((item) => (
+                <option value={item.TeamId}>{item.teamName}</option>
               ))}
             </select>
           </div>
-
-          {/* 팀 이동을 위해 선택한 멤버 */}
-          <div {...stylex.props(Styles.DisplayNameWrapper, Typography.SubTextLargeRegular)}>{data.displayName}</div>
         </div>
 
         {/* 닫기 및 적용 버튼 */}
@@ -113,6 +134,7 @@ const Styles = stylex.create({
     marginBottom: '24px',
     display: 'flex',
     gap: '8px',
+    flexDirection: 'column',
   },
   ButtonContainer: {
     display: 'flex',

--- a/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
+++ b/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
@@ -111,7 +111,7 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
             onClick={handleClickRegister}
             {...stylex.props(Styles.Button, Styles.RegisterButton, Typography.TextSmallMedium)}
           >
-            등록
+            완료
           </button>
         </div>
       </div>

--- a/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
+++ b/src/features/mypage/workspace/member/components/MoveMemberBottomSheet/index.tsx
@@ -22,7 +22,7 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
   const { data, teamId } = props;
   const { data: teamListData } = useGetTeamListQuery();
   const dispatch = useDispatch();
-  const teamOptionList = teamListData.teamList; // 이미 참여한 팀은 option에 나타나지 않게 함.
+  const teamOptionList = teamListData?.teamList; // 이미 참여한 팀은 option에 나타나지 않게 함.
   const [selectTeamId, setSelectTeamId] = useState<number>(teamId);
   const [selectRole, setSelectRole] = useState<string>(data.role);
   const { mutate: UpdateMemberMutate } = useUpdateMemberQuery();
@@ -90,9 +90,7 @@ const MoveMemberBottomSheet: FC<MoveMemberBottomSheetProps> = (props) => {
               defaultValue={teamId}
               {...stylex.props(Styles.Select, Typography.SubTextLargeRegular)}
             >
-              {teamOptionList.map((item) => (
-                <option value={item.TeamId}>{item.teamName}</option>
-              ))}
+              {teamOptionList?.map((item) => <option value={item.TeamId}>{item.teamName}</option>)}
             </select>
           </div>
         </div>

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -1,63 +1,75 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import ArrowHeadOutlinedV2 from '@src/components/icons/ArrowHeadOutlinedV2';
-import { MemberInfoItem } from '@src/queries/team/useGetTeamListQuery';
+import { MemberInfoItem, TeamInfoItem } from '@src/queries/team/useGetTeamListQuery';
 import { colors, Typography } from '../../../../../../../public/styles/vars.stylex';
 import CircleCloseFilled from '@src/components/icons/CircleCloseFilled';
-import { useDispatch, useSelector } from 'react-redux';
-import { saveTeamList, tempRemoveTeam } from '../../slices/member';
-import { RootState } from '@src/store';
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import MoveMemberBottomSheet from '../MoveMemberBottomSheet';
-import { EditTeamItem } from '../../types/member';
 import { confirm } from '@src/components/ui/Modal/confirm';
 import ProfileImg from '@src/components/ui/ProfileImg';
 import Link from 'next/link';
+import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
+import Dropdown from '@src/components/ui/Dropdown';
+import PencilOutlined from '@src/components/icons/PencilOutlined';
+import TrashcanOutlined from '@src/components/icons/TrashcanOutlined';
+import useDeleteTeamQuery from '../../queries/useDeleteTeamQuery';
+import useUpdateTeamNameQuery from '../../queries/useUpdateTeamNameQuery';
+import useInput from '@src/hooks/useInput';
 
 interface TeamToggleProps {
-  data: EditTeamItem;
-  isEdit?: boolean;
+  data: TeamInfoItem;
   teamIdx: number;
   isLastIdx: boolean;
 }
 
 const TeamToggle: FC<TeamToggleProps> = (props) => {
-  const { data, isEdit, teamIdx, isLastIdx } = props;
-  const dispatch = useDispatch();
+  const { data, teamIdx, isLastIdx } = props;
+  const { data: myInfoData } = useGetMypageInfoQuery();
   const { renderModal } = useRenderModal();
-  const { editTeamList } = useSelector((state: RootState) => state.member);
+  const [isTeamNameEdit, setIsTeamNameEdit] = useState<boolean>(false);
   const [isOpen, setIsOpen] = useState<boolean>(true);
+  const [teamName, handleChangeTeamName] = useInput(data.teamName);
+  const { mutate: DeleteTeamMutate } = useDeleteTeamQuery();
+  const { mutate: UpdateTeamNameMutate } = useUpdateTeamNameQuery();
+
+  const getMenuList = (item: TeamInfoItem) => {
+    return [
+      {
+        id: '1',
+        label: '변경하기',
+        icon: <PencilOutlined width={16} height={16} />,
+        onClick: () => {
+          setIsTeamNameEdit(true);
+        },
+      },
+      {
+        id: '2',
+        label: '삭제하기',
+        icon: <TrashcanOutlined width={16} height={16} />,
+        onClick: () => {
+          confirm({
+            content: '팀 삭제 후 취소할 수 없어요.\n기존 팀원들은 다른 팀으로 배치해주세요',
+            cancelBtnName: '유지할래요',
+            okBtnName: '삭제할래요',
+            onOk: () => DeleteTeamMutate({ TeamId: item.TeamId }),
+          });
+        },
+      },
+    ];
+  };
+
+  const handleClickTeamNameEditComplete = () => {
+    UpdateTeamNameMutate({ TeamId: data.TeamId, teamName: teamName });
+    setIsTeamNameEdit(false);
+  };
+
+  const handleClickTeamNameEditCancel = () => {
+    setIsTeamNameEdit(false);
+  };
 
   const handleClickToggle = () => {
     setIsOpen(!isOpen);
-  };
-
-  const handleChangeData = useCallback(
-    (key: 'teamName') => (e) => {
-      const value = e.target.value;
-      const mappingTeamList = editTeamList.map((item) =>
-        item.TeamId === data.TeamId ? { ...item, [key]: value } : item
-      );
-      const index = editTeamList.findIndex((item) => item.TeamId === data.TeamId);
-
-      if (index === -1) {
-        return null;
-      }
-
-      const updateTeamList = [...editTeamList];
-      updateTeamList[index] = { ...updateTeamList[index], [key]: value };
-
-      dispatch(saveTeamList(mappingTeamList));
-    },
-    [editTeamList, data.TeamId, dispatch]
-  );
-  const handleClickTempDelete = () => {
-    confirm({
-      content: '팀 삭제를 하면 기존 팀원들은 미분류로 이동돼요.\n수정 완료 전까지 팀 변경 가능해요.',
-      cancelBtnName: '유지할래요',
-      okBtnName: '삭제할래요',
-      onOk: () => dispatch(tempRemoveTeam(data.tempTeamId ? { ...data, tempTeamId: data.tempTeamId } : { ...data })),
-    });
   };
 
   const handleClickMoveMember = (item: MemberInfoItem, idx: number) => {
@@ -67,28 +79,32 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
   return (
     <div {...stylex.props(isLastIdx && Styles.LastIdxContainer)}>
       {/* 팀 이름 */}
-      {isEdit ? (
+      {isTeamNameEdit ? (
         <div {...stylex.props(Styles.EditToggleContainer)}>
           <input
             type="text"
-            value={data.teamName}
-            onChange={handleChangeData('teamName')}
+            value={teamName}
+            onChange={handleChangeTeamName}
             {...stylex.props(Styles.TextInput, Typography.TextSmallMedium)}
           />
-          <button type="button" onClick={handleClickToggle} {...stylex.props(Styles.MiniToggleButton)}>
-            <ArrowHeadOutlinedV2 width={24} height={24} rotate={isOpen ? 270 : 90} />
+          <button type="button" onClick={handleClickTeamNameEditComplete} {...stylex.props(Styles.MiniToggleButton)}>
+            <span {...stylex.props(Typography.TextSmallMedium, Styles.TeamNameEditCompleteText)}>완료</span>
           </button>
-          <button type="button" onClick={handleClickTempDelete}>
+          <button type="button" onClick={handleClickTeamNameEditCancel}>
             <CircleCloseFilled width={24} height={24} />
           </button>
         </div>
       ) : (
-        <button type="button" onClick={handleClickToggle} {...stylex.props(Styles.ToggleButton)}>
-          <p {...stylex.props(Typography.TextSmallMedium)}>
-            {data.teamName}({data.memberList.length})
-          </p>
-          <ArrowHeadOutlinedV2 width={24} height={24} rotate={isOpen ? 270 : 90} />
-        </button>
+        <div {...stylex.props(Styles.ActionButtonContainer)}>
+          <button type="button" onClick={handleClickToggle} {...stylex.props(Styles.ToggleButton)}>
+            <p {...stylex.props(Typography.TextSmallMedium)}>
+              {data.teamName}({data.memberList.length})
+            </p>
+            <ArrowHeadOutlinedV2 width={24} height={24} rotate={isOpen ? 270 : 90} color="#000000" />
+          </button>
+
+          <Dropdown menuList={getMenuList(data)} ellipsisIconStyle={{ color: '#000000' }} />
+        </div>
       )}
 
       {/* 토글이 열렸을 떄 */}
@@ -108,7 +124,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
                       />
                       <span>{item.displayName}</span>
                     </Link>
-                    {isEdit && (
+                    {/* {isEdit && (
                       <button
                         type="button"
                         onClick={() => handleClickMoveMember(item, idx)}
@@ -116,7 +132,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
                       >
                         이동
                       </button>
-                    )}
+                    )} */}
                   </div>
                 </li>
               ))
@@ -138,7 +154,6 @@ const Styles = stylex.create({
   },
   ToggleButton: {
     width: '100%',
-    padding: '16px',
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -170,6 +185,7 @@ const Styles = stylex.create({
     display: 'flex',
   },
   MiniToggleButton: {
+    display: 'flex',
     marginRight: '12px',
   },
   MoveButton: {
@@ -190,5 +206,18 @@ const Styles = stylex.create({
     alignItems: 'center',
     textDecoration: 'none',
     color: colors.black300,
+  },
+  ActionButtonContainer: {
+    padding: '16px',
+    display: 'flex',
+    gap: '8px',
+    alignItems: 'center',
+    alignContent: 'center',
+    lineHeight: 1,
+  },
+  TeamNameEditCompleteText: {
+    lineHeight: 1,
+    flexShrink: 0,
+    alignSelf: 'center',
   },
 });

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -32,6 +32,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
   const [teamName, handleChangeTeamName] = useInput(data.teamName);
   const { mutate: DeleteTeamMutate } = useDeleteTeamQuery();
   const { mutate: UpdateTeamNameMutate } = useUpdateTeamNameQuery();
+  const isEditable = ['admin', 'owner'].includes(myInfoData?.myInfo.role);
 
   const getMenuList = () => {
     return [
@@ -103,7 +104,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
             <ArrowHeadOutlinedV2 width={24} height={24} rotate={isOpen ? 270 : 90} color="#000000" />
           </button>
 
-          <Dropdown menuList={getMenuList()} ellipsisIconStyle={{ color: '#000000' }} />
+          {isEditable && <Dropdown menuList={getMenuList()} ellipsisIconStyle={{ color: '#000000' }} />}
         </div>
       )}
 
@@ -124,7 +125,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
                       />
                       <span>{item.displayName}</span>
                     </Link>
-                    {['admin', 'owner'].includes(myInfoData?.myInfo.role) && (
+                    {isEditable && (
                       <button
                         type="button"
                         onClick={() => handleClickMoveMember(item, idx)}

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -20,11 +20,10 @@ import useInput from '@src/hooks/useInput';
 interface TeamToggleProps {
   data: TeamInfoItem;
   teamIdx: number;
-  isLastIdx: boolean;
 }
 
 const TeamToggle: FC<TeamToggleProps> = (props) => {
-  const { data, teamIdx, isLastIdx } = props;
+  const { data } = props;
   const { data: myInfoData } = useGetMypageInfoQuery();
   const { renderModal } = useRenderModal();
   const [isTeamNameEdit, setIsTeamNameEdit] = useState<boolean>(false);
@@ -78,7 +77,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
   };
 
   return (
-    <div {...stylex.props(isLastIdx && Styles.LastIdxContainer)}>
+    <div>
       {/* 팀 이름 */}
       {isTeamNameEdit ? (
         <div {...stylex.props(Styles.EditToggleContainer)}>
@@ -150,9 +149,6 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
 export default TeamToggle;
 
 const Styles = stylex.create({
-  LastIdxContainer: {
-    paddingBottom: '104px',
-  },
   ToggleButton: {
     width: '100%',
     display: 'flex',

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -73,7 +73,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
   };
 
   const handleClickMoveMember = (item: MemberInfoItem, idx: number) => {
-    renderModal(MoveMemberBottomSheet, { data: item, selectMemberTeamIdx: teamIdx });
+    renderModal(MoveMemberBottomSheet, { data: item, teamId: data.TeamId });
   };
 
   return (
@@ -124,7 +124,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
                       />
                       <span>{item.displayName}</span>
                     </Link>
-                    {/* {isEdit && (
+                    {['admin', 'owner'].includes(myInfoData?.myInfo.role) && (
                       <button
                         type="button"
                         onClick={() => handleClickMoveMember(item, idx)}
@@ -132,7 +132,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
                       >
                         이동
                       </button>
-                    )} */}
+                    )}
                   </div>
                 </li>
               ))

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -31,7 +31,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
   const [teamName, handleChangeTeamName] = useInput(data.teamName);
   const { mutate: DeleteTeamMutate } = useDeleteTeamQuery();
   const { mutate: UpdateTeamNameMutate } = useUpdateTeamNameQuery();
-  const isEditable = ['admin', 'owner'].includes(myInfoData?.myInfo.role);
+  const isEditable = ['owner'].includes(myInfoData?.myInfo.role);
 
   const getMenuList = () => {
     return [

--- a/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
+++ b/src/features/mypage/workspace/member/components/TeamToggle/index.tsx
@@ -33,7 +33,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
   const { mutate: DeleteTeamMutate } = useDeleteTeamQuery();
   const { mutate: UpdateTeamNameMutate } = useUpdateTeamNameQuery();
 
-  const getMenuList = (item: TeamInfoItem) => {
+  const getMenuList = () => {
     return [
       {
         id: '1',
@@ -52,7 +52,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
             content: '팀 삭제 후 취소할 수 없어요.\n기존 팀원들은 다른 팀으로 배치해주세요',
             cancelBtnName: '유지할래요',
             okBtnName: '삭제할래요',
-            onOk: () => DeleteTeamMutate({ TeamId: item.TeamId }),
+            onOk: () => DeleteTeamMutate({ TeamId: data.TeamId }),
           });
         },
       },
@@ -103,7 +103,7 @@ const TeamToggle: FC<TeamToggleProps> = (props) => {
             <ArrowHeadOutlinedV2 width={24} height={24} rotate={isOpen ? 270 : 90} color="#000000" />
           </button>
 
-          <Dropdown menuList={getMenuList(data)} ellipsisIconStyle={{ color: '#000000' }} />
+          <Dropdown menuList={getMenuList()} ellipsisIconStyle={{ color: '#000000' }} />
         </div>
       )}
 

--- a/src/features/mypage/workspace/member/queries/useAddTeamNameQuery.tsx
+++ b/src/features/mypage/workspace/member/queries/useAddTeamNameQuery.tsx
@@ -1,0 +1,57 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+
+type ResponseData = null;
+
+interface TeamInfo {
+  teamName: string;
+}
+
+const postTeamNameApi = async (WorkspaceId, data: TeamInfo): Promise<ResponseData> => {
+  const { teamName } = data;
+
+  const response = await clientInstance.post(`/v1/workspace/@${WorkspaceId}/manage/team`, { teamName });
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 팀 추가하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 팀 추가 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const useAddTeamNameQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: TeamInfo) => postTeamNameApi(workspaceId, data),
+    onSuccess: () => {
+      // 업데이트 후 팀 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['teamList'] });
+    },
+    onError: (error) => {
+      if (error.status !== 452) {
+        // alert 도 모달로 수정해주기
+        alert(`서버 에러가 발생했습니다. (code: ${error.status})`);
+      } else {
+        // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+        confirm({ content: error?.response.data.message.errMsg });
+      }
+    },
+  });
+
+  return mutation;
+};
+
+export default useAddTeamNameQuery;

--- a/src/features/mypage/workspace/member/queries/useDeleteTeamQuery.tsx
+++ b/src/features/mypage/workspace/member/queries/useDeleteTeamQuery.tsx
@@ -1,0 +1,51 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+
+type ResponseData = null;
+
+const deleteTeamApi = async (WorkspaceId, TeamId): Promise<ResponseData> => {
+  const response = await clientInstance.delete(`/v1/workspace/@${WorkspaceId}/manage/team/${TeamId}`);
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 팀을 삭제하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 팀 데이터 삭제 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const useDeleteTeamQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: { TeamId: number }) => deleteTeamApi(workspaceId, data.TeamId),
+    onSuccess: () => {
+      // 업데이트 후 팀 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['teamList'] });
+    },
+    onError: (error, context) => {
+      if (error.status !== 452) {
+        // alert 도 모달로 수정해주기
+        alert(`서버 에러가 발생했습니다. (code: ${error.status})`);
+      } else {
+        // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+        confirm({ content: error?.response.data.message.errMsg });
+      }
+    },
+  });
+
+  return mutation;
+};
+
+export default useDeleteTeamQuery;

--- a/src/features/mypage/workspace/member/queries/useUpdateMemberQuery.tsx
+++ b/src/features/mypage/workspace/member/queries/useUpdateMemberQuery.tsx
@@ -1,0 +1,61 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+
+type ResponseData = null;
+
+interface MemberInfo {
+  MemberId: number;
+  position?: string;
+  role: string;
+  isAdmin?: boolean;
+  TeamId: number;
+}
+
+const patchMemberApi = async (WorkspaceId, data: MemberInfo): Promise<ResponseData> => {
+  const { MemberId, ...rest } = data;
+
+  const response = await clientInstance.patch(`/v1/workspace/@${WorkspaceId}/manage/members/${MemberId}`, { ...rest });
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 멤버를 수정하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 멤버 수정 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const useUpdateMemberQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: MemberInfo) => patchMemberApi(workspaceId, data),
+    onSuccess: () => {
+      // 업데이트 후 팀 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['teamList'] });
+    },
+    onError: (error) => {
+      if (error.status !== 452) {
+        // alert 도 모달로 수정해주기
+        alert(`서버 에러가 발생했습니다. (code: ${error.status})`);
+      } else {
+        // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+        confirm({ content: error?.response.data.message.errMsg });
+      }
+    },
+  });
+
+  return mutation;
+};
+
+export default useUpdateMemberQuery;

--- a/src/features/mypage/workspace/member/queries/useUpdateTeamNameQuery.tsx
+++ b/src/features/mypage/workspace/member/queries/useUpdateTeamNameQuery.tsx
@@ -1,0 +1,58 @@
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
+
+type ResponseData = null;
+
+interface TeamInfo {
+  TeamId: number;
+  teamName: string;
+}
+
+const patchTeamNameApi = async (WorkspaceId, data: TeamInfo): Promise<ResponseData> => {
+  const { TeamId, teamName } = data;
+
+  const response = await clientInstance.patch(`/v1/workspace/@${WorkspaceId}/manage/team/${TeamId}`, { teamName });
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 워크스페이스 팀 이름 수정하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 팀 이름 수정 후 반환하는 응답데이터 없음
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isIdle`: 쿼리 비활성화 여부 (enabled가 true 이고 쿼리 불러오기가 시작될 때까지 isIdle 은 true)
+ *   - `isPending`: mutation 실행중인지에 대한 여부
+ *   - `isError`: 에러가 발생했는지에 대한 여부
+ *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
+ */
+const useUpdateTeamNameQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const queryClient = useQueryClient();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const mutation = useCustomMutation({
+    mutationFn: (data: TeamInfo) => patchTeamNameApi(workspaceId, data),
+    onSuccess: () => {
+      // 업데이트 후 팀 리스트 데이터 재요청 (쿼리 무효화)
+      queryClient.invalidateQueries({ queryKey: ['teamList'] });
+    },
+    onError: (error) => {
+      if (error.status !== 452) {
+        // alert 도 모달로 수정해주기
+        alert(`서버 에러가 발생했습니다. (code: ${error.status})`);
+      } else {
+        // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+        confirm({ content: error?.response.data.message.errMsg });
+      }
+    },
+  });
+
+  return mutation;
+};
+
+export default useUpdateTeamNameQuery;

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -82,14 +82,16 @@ const Member = () => {
 
         {/* 팀 추가 */}
         {['admin', 'owner'].includes(myInfoData?.myInfo.role) && (
-          <button
-            type="button"
-            {...stylex.props(Styles.AddTeamBtn, Typography.TextSmallMedium)}
-            onClick={handleClickAddTeam}
-          >
-            <PlusOutlined width={24} height={24} />
-            <span>팀 추가</span>
-          </button>
+          <div {...stylex.props(Styles.AddTeamBtnContainer)}>
+            <button
+              type="button"
+              {...stylex.props(Styles.AddTeamBtn, Typography.TextSmallMedium)}
+              onClick={handleClickAddTeam}
+            >
+              <PlusOutlined width={24} height={24} />
+              <span>팀 추가</span>
+            </button>
+          </div>
         )}
       </div>
     </MainLayout>
@@ -104,7 +106,6 @@ const Styles = stylex.create({
     height: 'calc(100vh - 60px)',
     position: 'relative',
     padding: '16px',
-    marginBottom: '24px',
     overflowY: 'auto',
   },
   TotalCountWrapper: {
@@ -112,16 +113,22 @@ const Styles = stylex.create({
   },
   TeamListContainer: {
     width: '100%',
-    height: 'calc(100vh - 212px)',
+    // height: 'calc(100vh - 400px)',
+    marginBottom: '80px',
     display: 'flex',
     flexDirection: 'column',
   },
-  AddTeamBtn: {
-    maxWidth: '735px',
+  AddTeamBtnContainer: {
     width: 'calc(100% - 32px)',
+    maxWidth: '735px',
     padding: '16px',
     position: 'fixed',
-    bottom: '16px',
+    bottom: '0',
+    background: colors.white500,
+  },
+  AddTeamBtn: {
+    width: '100%',
+    padding: '16px',
     display: 'flex',
     gap: '8px',
     justifyContent: 'center',

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -75,23 +75,13 @@ const Member = () => {
 
         {/* 팀 목록 */}
         <div {...stylex.props(Styles.TeamListContainer)}>
-          {isEdit
-            ? editTeamList?.map((item, idx) => (
-                <TeamToggle
-                  key={item.TeamId}
-                  data={item}
-                  teamIdx={idx}
-                  isEdit={isEdit}
-                  isLastIdx={editTeamList.length - 1 === idx}
-                />
-              ))
-            : data?.teamList?.map((item, idx) => (
-                <TeamToggle key={item.TeamId} data={item} teamIdx={idx} isLastIdx={editTeamList.length - 1 === idx} />
-              ))}
+          {data?.teamList?.map((item, idx) => (
+            <TeamToggle key={item.TeamId} data={item} teamIdx={idx} isLastIdx={editTeamList.length - 1 === idx} />
+          ))}
         </div>
 
         {/* 팀 추가 */}
-        {isEdit && (
+        {['admin', 'owner'].includes(myInfoData?.myInfo.role) && (
           <button
             type="button"
             {...stylex.props(Styles.AddTeamBtn, Typography.TextSmallMedium)}

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -19,6 +19,7 @@ const Member = () => {
   const [searchKeyword, handleChangeSearchKeyword] = useInput('');
   const debounceKeyword = useDebounce(searchKeyword);
   const { data } = useGetTeamListQuery(debounceKeyword);
+  const isEditable = ['owner'].includes(myInfoData?.myInfo.role);
 
   const totalMemberCount = data?.teamList?.reduce(
     (prevValue, currentValue) => prevValue + currentValue?.memberList?.length,
@@ -56,7 +57,7 @@ const Member = () => {
         </div>
 
         {/* 팀 추가 */}
-        {['admin', 'owner'].includes(myInfoData?.myInfo.role) && (
+        {isEditable && (
           <div {...stylex.props(Styles.AddTeamBtnContainer)}>
             <button
               type="button"

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -9,11 +9,16 @@ import useRenderModal from '@src/hooks/ui/useRenderModal';
 import MainLayout from '@src/layouts/MainLayout';
 import AddTeamBottomSheet from '@src/features/mypage/workspace/member/components/AddTeamBottomSheet';
 import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
+import useInput from '@src/hooks/useInput';
+import SearchOutlinedV2 from '@src/components/icons/SearchOutlinedV2';
+import useDebounce from '@src/hooks/useDebounce';
 
 const Member = () => {
   const { data: myInfoData } = useGetMypageInfoQuery();
-  const { data } = useGetTeamListQuery();
   const { renderModal } = useRenderModal();
+  const [searchKeyword, handleChangeSearchKeyword] = useInput('');
+  const debounceKeyword = useDebounce(searchKeyword);
+  const { data } = useGetTeamListQuery(debounceKeyword);
 
   const totalMemberCount = data?.teamList?.reduce(
     (prevValue, currentValue) => prevValue + currentValue?.memberList?.length,
@@ -27,9 +32,19 @@ const Member = () => {
   return (
     <MainLayout>
       <Header title="멤버" prevUrl="/mypage/workspace" />
-      {/* 검색 */}
-
       <div {...{ ...stylex.props(Styles.Container) }}>
+        {/* 검색 */}
+        <div {...stylex.props(Styles.SearchContainer)}>
+          <SearchOutlinedV2 width={24} height={24} />
+          <input
+            type="text"
+            placeholder="검색어를 입력해주세요"
+            value={searchKeyword}
+            onChange={handleChangeSearchKeyword}
+            {...stylex.props(Typography.SubTextLargeRegular, Styles.SearchInput)}
+          />
+        </div>
+
         {/* 전체 멤버수 */}
         <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
           전체 멤버 ({totalMemberCount})
@@ -96,5 +111,23 @@ const Styles = stylex.create({
     background: colors.red500,
     color: colors.white500,
     borderRadius: '20px',
+  },
+  SearchContainer: {
+    marginBottom: '20px',
+    padding: '8px 12px',
+    display: 'flex',
+    gap: '10px',
+    alignItems: 'center',
+    border: `1px solid ${colors.gray40}`,
+    borderRadius: '12px',
+  },
+  SearchInput: {
+    width: '100%',
+    padding: 0,
+    border: 'none',
+    outline: 'none',
+    '::placeholder': {
+      color: colors.gray60,
+    },
   },
 });

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -1,26 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
 import stylex from '@stylexjs/stylex';
 import Header from '@src/components/ui/Header';
 import { colors, Typography } from '../../../../public/styles/vars.stylex';
 import TeamToggle from '@src/features/mypage/workspace/member/components/TeamToggle';
 import useGetTeamListQuery from '@src/queries/team/useGetTeamListQuery';
-import { saveTeamList } from '@src/features/mypage/workspace/member/slices/member';
-import { RootState } from '@src/store';
 import PlusOutlined from '@src/components/icons/PlusOutlined';
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import MainLayout from '@src/layouts/MainLayout';
 import AddTeamBottomSheet from '@src/features/mypage/workspace/member/components/AddTeamBottomSheet';
-import usePutTeamQuery from '@src/features/mypage/workspace/member/queries/usePutTeamQuery';
 import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
 
 const Member = () => {
   const { data: myInfoData } = useGetMypageInfoQuery();
   const { data } = useGetTeamListQuery();
-  const mutation = usePutTeamQuery();
-  const dispatch = useDispatch();
-  const { editTeamList, tempDeleteTeamList } = useSelector((state: RootState) => state.member);
-  const [isEdit, setIsEdit] = useState<boolean>(false);
   const { renderModal } = useRenderModal();
 
   const totalMemberCount = data?.teamList?.reduce(
@@ -28,43 +20,13 @@ const Member = () => {
     0
   );
 
-  const completeBtnProps = {
-    name: isEdit ? '완료' : '수정',
-    isActive: isEdit,
-    onClick: () => {
-      const removeTempTeamIdInTemList = editTeamList.map((item) => {
-        const { tempTeamId = null, ...anotherItem } = item;
-
-        return tempTeamId ? anotherItem : item;
-      });
-
-      if (isEdit) {
-        mutation.mutate({
-          teamList: removeTempTeamIdInTemList,
-          deleteTeamList: tempDeleteTeamList,
-        });
-      }
-      setIsEdit(!isEdit);
-    },
-  };
-
   const handleClickAddTeam = () => {
     renderModal(AddTeamBottomSheet, null);
   };
 
-  useEffect(() => {
-    if (isEdit) {
-      dispatch(saveTeamList(data.teamList));
-    }
-  }, [isEdit]);
-
   return (
     <MainLayout>
-      <Header
-        title="멤버"
-        prevUrl="/mypage/workspace"
-        {...(myInfoData?.myInfo?.isAdmin ? { rightBtnInfo: completeBtnProps } : {})}
-      />
+      <Header title="멤버" prevUrl="/mypage/workspace" />
       {/* 검색 */}
 
       <div {...{ ...stylex.props(Styles.Container) }}>
@@ -75,9 +37,7 @@ const Member = () => {
 
         {/* 팀 목록 */}
         <div {...stylex.props(Styles.TeamListContainer)}>
-          {data?.teamList?.map((item, idx) => (
-            <TeamToggle key={item.TeamId} data={item} teamIdx={idx} isLastIdx={editTeamList.length - 1 === idx} />
-          ))}
+          {data?.teamList?.map((item, idx) => <TeamToggle key={item.TeamId} data={item} teamIdx={idx} />)}
         </div>
 
         {/* 팀 추가 */}

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -11,7 +11,7 @@ import ProfilePersonalDataList from '@src/features/profile/components/ProfilePer
 import useGetWorkspaceMemberQuery from '@src/features/profile/queries/useGetWorkspaceMemberQuery';
 import MainLayout from '@src/layouts/MainLayout';
 import { Typography } from '../../../public/styles/vars.stylex';
-import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
+import { MEMBER_ROLE_KOREAN_LABELS } from '@src/constants/member';
 
 const UserProfile = () => {
   const router = useRouter();
@@ -28,12 +28,6 @@ const UserProfile = () => {
     { id: 3, name: data?.member?.email, icon: <MailOutlined width={24} height={24} /> },
   ];
 
-  const roleName = {
-    owner: '최고 관리자',
-    admin: '중간 관리자',
-    member: '멤버',
-  };
-
   return (
     <MainLayout>
       <Header prevOnClick={handlePrevOnClick} />
@@ -44,7 +38,7 @@ const UserProfile = () => {
 
         <div {...stylex.props(Styles.nameContainer)}>
           <p {...stylex.props(Typography.TitleRegularBold)}>{data?.member?.displayName}</p>
-          <p {...stylex.props(Typography.SubTextLargeRegular)}>{roleName[data?.member?.role]}</p>
+          <p {...stylex.props(Typography.SubTextLargeRegular)}>{MEMBER_ROLE_KOREAN_LABELS[data?.member?.role]}</p>
         </div>
       </div>
 

--- a/src/queries/team/useGetTeamListQuery.tsx
+++ b/src/queries/team/useGetTeamListQuery.tsx
@@ -51,6 +51,8 @@ const useGetTeamListQuery = (skeywd?: string) => {
 
   const result = useQuery({
     queryKey: ['teamList', skeywd],
+    staleTime: 3 * 60 * 1000,
+    gcTime: 3 * 60 * 1000,
     queryFn: () => getTeamListApi(workspaceId, skeywd),
     enabled: Boolean(workspaceId),
   });

--- a/src/queries/workspace/useGetWorkspaceListQuery.tsx
+++ b/src/queries/workspace/useGetWorkspaceListQuery.tsx
@@ -31,7 +31,8 @@ const useGetWorkspaceListQuery = () => {
   const result = useQuery({
     queryKey: ['workspaceList'],
     queryFn: () => getWorkspaceListApi(),
-    gcTime: 3 * 60 * 1000,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
     retry: false,
   });
 


### PR DESCRIPTION
# 작업 내용
- 멤버 정보 페이지
  - 기존에 멤버 및 팀 관련 수정을 할 때 벌크로 수정을 진행했는데, 멤버 권한을 적용하는 부분이 벌크 수정에서 부자연스럽다는 의견을 주고 받아서 개별성 수정으로 변경함. 
     그리고 기존에는 관리자라는 역할만 존재했는데, '중간 관리자' 역할이 추가되면서 멤버와 팀 수정을 '최고 관리자', '중간 관리자'가 할 수 있도록 변경해줌.
     - 기존
        <img width="776" height="820" alt="image" src="https://github.com/user-attachments/assets/0407b277-ee5a-4756-b19b-fb9132a9604a" />
     - 변경 후
        <img width="769" height="821" alt="image" src="https://github.com/user-attachments/assets/549d3cd4-56de-4e57-8845-123ab1253944" />
  - 팀 검색 기능 추가
     <img width="756" height="812" alt="image" src="https://github.com/user-attachments/assets/587158a1-fa7b-47ea-b3e5-068cb38dfd5e" />

# 개선해야 할 사항
- 멤버 검색이 불가능해서 추후에 멤버를 검색할 수 있도록 수정이 필요할 것 같음.