### PR TITLE
Update(RT-47): 멤버 역할 세분화에 따라 카테고리 및 회의실 수정, 삭제 권한 부여 코드 수정

### DIFF
--- a/src/pages/mypage/workspace/category.tsx
+++ b/src/pages/mypage/workspace/category.tsx
@@ -24,6 +24,7 @@ const Category = () => {
   );
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const { renderModal } = useRenderModal();
+  const isEditable = ['owner', 'admin'].includes(myInfoData?.myInfo.role);
 
   const completeBtnProps = {
     name: isEdit ? '완료' : '수정',
@@ -60,7 +61,7 @@ const Category = () => {
       <Header
         title={isEdit ? '수정하기' : '카테고리'}
         prevUrl="/mypage/workspace"
-        {...(myInfoData?.myInfo?.isAdmin ? { rightBtnInfo: completeBtnProps } : {})}
+        {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})}
       />
       {/* 검색 */}
 

--- a/src/pages/mypage/workspace/congress-room.tsx
+++ b/src/pages/mypage/workspace/congress-room.tsx
@@ -23,6 +23,7 @@ const MeetingRoom = () => {
   const { editCongressRoomList, tempDeleteCongressRoomList } = useSelector((state: RootState) => state.congressRoom);
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const { renderModal } = useRenderModal();
+  const isEditable = ['owner', 'admin'].includes(myInfoData?.myInfo.role);
 
   const completeBtnProps = {
     name: isEdit ? '완료' : '수정',
@@ -56,11 +57,7 @@ const MeetingRoom = () => {
 
   return (
     <MainLayout backgroundColor="#FAFAFA">
-      <Header
-        title="회의실"
-        prevUrl="/mypage/workspace"
-        {...(myInfoData?.myInfo?.isAdmin ? { rightBtnInfo: completeBtnProps } : {})}
-      />
+      <Header title="회의실" prevUrl="/mypage/workspace" {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})} />
 
       <div {...stylex.props(Styles.Container)}>
         {/* 회의실 개수 */}


### PR DESCRIPTION
# 작업 내용
- 마이페이지의 카테고리 관리 및 회의실 관리를 할 수 있는 권한 코드 수정
   - 기존에는 관리자,유저로만 역할이 이루어져 있어서 isAdmin으로만 권한을 확인하면 되었음. 
   - 그러나 단순히 카테고리와 회의실 수정, 삭제만 다룰 수 있는 역할을 부여하기 위해 멤버 관리도 할 수 있는 '관리자' 역할을 유저에게 부여하는 게 옳지 않다고 판단함. 
   - 그래서 카테고리와 회의실 수정, 삭제만 가능한 중간 관리자 역할을 추가하게 됨. 
   - 사용자 데이터에서 role이 'owner'(최고 관리자), 'admin'(중간 관리자)이면 권한이 부여됨.