### PR TITLE
Feat(RT-49): 예약리스트 검색 필터에서 카테고리 및 회의실 전체 검색 기능 추가

### DIFF
--- a/src/components/ui/Radio/styles/styles.module.css
+++ b/src/components/ui/Radio/styles/styles.module.css
@@ -25,7 +25,7 @@
 
 .common-radio-label.white:has(.common-radio-input[type='radio']:checked) {
   box-shadow: none;
-  border: 1px solid #b5312c;
+  box-shadow: inset 0 0 0 1px #b5312c;
   color: #b5312c;
   background-color: #ffffff;
 }

--- a/src/features/reservation/components/ReservationFilter/index.tsx
+++ b/src/features/reservation/components/ReservationFilter/index.tsx
@@ -41,6 +41,8 @@ const ReservationFilter = () => {
   const handleChangeMeetingRoom = (value: number) => {
     if (selectedRoomIdList.includes(value)) {
       setSelectedRoomIdList((prevState) => prevState.filter((item) => item !== value));
+    } else if (value === 0) {
+      setSelectedRoomIdList([]);
     } else {
       setSelectedRoomIdList((prevState) => [value]);
     }
@@ -49,6 +51,8 @@ const ReservationFilter = () => {
   const handleChangeCategory = (value: number) => {
     if (selectedCategoryIdList.includes(value)) {
       setSelectedCategoryIdList((prevState) => prevState.filter((item) => item !== value));
+    } else if (value === 0) {
+      setSelectedCategoryIdList([]);
     } else {
       setSelectedCategoryIdList((prevState) => [value]);
     }
@@ -110,6 +114,15 @@ const ReservationFilter = () => {
         {/* 회의실 */}
         <p {...stylex.props(Typography.SubTextLargeSemiBold, Styles.Title)}>회의실</p>
         <div {...stylex.props(Styles.RadioContainer)}>
+          <Radio
+            name="congressRoom"
+            id={`congressRoomAll`}
+            theme="white"
+            label={'전체'}
+            value={0}
+            onChange={() => handleChangeMeetingRoom(0)}
+            checked={selectedRoomIdList.length === 0}
+          />
           {congressRoomData?.congressRoomList?.map((item) => (
             <Radio
               name="congressRoom"
@@ -126,6 +139,15 @@ const ReservationFilter = () => {
         {/* 카테고리 */}
         <p {...stylex.props(Typography.SubTextLargeSemiBold, Styles.Title)}>카테고리</p>
         <div {...stylex.props(Styles.RadioContainer)}>
+          <Radio
+            name="category"
+            id={`categoryAll`}
+            theme="white"
+            label={'전체'}
+            value={0}
+            onChange={() => handleChangeCategory(0)}
+            checked={selectedCategoryIdList.length === 0}
+          />
           {congressCategoryData?.congressCategoryList?.map((item) => (
             <Radio
               name="category"

--- a/src/pages/reservations/index.tsx
+++ b/src/pages/reservations/index.tsx
@@ -11,7 +11,7 @@ import { useRouter } from 'next/router';
 
 const Reservations = () => {
   const router = useRouter();
-  const { my: queryMy, cc: queryCc } = router.query;
+  const { my: queryMy, cc: queryCc, roomIds: queryRoomIds } = router.query;
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [year, setYear] = useState<number>(dayjs().year());
   const [month, setMonth] = useState<number>(dayjs().month() + 1);
@@ -19,8 +19,8 @@ const Reservations = () => {
   const { data } = useGetWorkspaceCongressListQuery({
     date: year && month && day ? dayjs(`${year}-${month}-${day}`).format('YYYY-MM-DD') : dayjs().format('YYYY-MM-DD'),
     ...(queryMy ? { my: queryMy as string } : {}),
-    ...(queryCc ? { cc: queryCc as string } : {}), // [ ] 택 1로 하나만 선택하는 건지 확인하기
-    // [ ] 회의실 필터 추가
+    ...(queryCc ? { cc: queryCc as string } : {}),
+    ...(queryRoomIds ? { RoomId: queryRoomIds as string } : {}),
   });
 
   const handleClickDateWheel = () => {

--- a/src/queries/workspace/useGetWorkspaceCongressListQuery.tsx
+++ b/src/queries/workspace/useGetWorkspaceCongressListQuery.tsx
@@ -51,6 +51,7 @@ interface Params {
   cc?: string; // [ ] 택 1로 하나만 선택하는 건지 확인 후, 택 1이면 number로 변경
   my?: number | string;
   rct?: string;
+  RoomId?: string;
 }
 
 const getWorkspaceCongressListApi = async (WorkspaceId: number, params: Params): Promise<CongressListResponse> => {


### PR DESCRIPTION
# 작업 내용
- 라디오 버튼 컴포넌트에서 라디오 버튼이 선택되었을 때, 테두리 색상 지정을 border에서 box-shadow로 변경
   - 라디오 버튼 컴포넌트 내부에서 테두리 색상 지정이 border와 box-shadow로 이분화되어 있어서 라디오 버튼을 선택할 때 크기가 커졌다 작아졌다하는 문제가 발생함. 그래서 box-shadow로 통일해줌.
- 예약 리스트 페이지 > 검색 필터에 카테고리 및 회의실 전체를 검색할 수 있게 하는 기능 추가
   - 기존 필터 기능에서 특정 회의실 및 카테고리 검색 기능만 있어서 '전체'를 검색할 수 있는 기능도 추가해줌.
   <img width="50%" alt="image" src="https://github.com/user-attachments/assets/a2b328cf-67bc-4f5b-9c45-1deb5392702e" />
