### PR TITLE
Feat(RT-50): 알림 페이지 디자인 변경 및 알림 관련 타입 수정

### DIFF
--- a/src/features/alarm/components/AlarmList/index.tsx
+++ b/src/features/alarm/components/AlarmList/index.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { Typography, colors } from '../../../../../public/styles/vars.stylex';
 import CloseOutlined from '@src/components/icons/CloseOutlined';
-import useGetNotificationsInfiniteQuery from '@src/queries/alarm/useGetNotificationsInfiniteQuery';
+import useGetNotificationsInfiniteQuery, { AlarmCategory } from '@src/queries/alarm/useGetNotificationsInfiniteQuery';
 import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
 import { useAlarmCategory } from '../../contexts/AlarmCategoryContext';
 import usePatchNotificationsQuery from '../../queries/usePatchNotificationsQuery';
@@ -31,16 +31,31 @@ const AlarmList = () => {
     }
   });
 
-  const alarmCategoryInfo = {
-    reserve: { imgKey: 'public/images/alarm/checked 1.png', korean: '예약' },
-    invite: { imgKey: 'public/images/alarm/plus 1.png', korean: '초대' },
-    change: { imgKey: 'public/images/alarm/shuffle 1.png', korean: '변경' },
-    remind: { imgKey: 'public/images/alarm/bell 1.png', korean: '리마인드' },
+  const alarmCategoryInfo: Record<
+    AlarmCategory,
+    { imgKey: string; korean: string; title?: string; isDisplayNameInTitle?: boolean }
+  > = {
+    reserve: {
+      imgKey: 'public/images/alarm/checked 1.png',
+      korean: '예약',
+      isDisplayNameInTitle: true,
+    },
+    invite: {
+      imgKey: 'public/images/alarm/plus 1.png',
+      korean: '초대',
+      isDisplayNameInTitle: true,
+    },
+    change: {
+      imgKey: 'public/images/alarm/shuffle 1.png',
+      korean: '변경',
+      isDisplayNameInTitle: false,
+    },
+    remind: {
+      imgKey: 'public/images/alarm/bell 1.png',
+      korean: '리마인드',
+      isDisplayNameInTitle: false,
+    },
   };
-
-  if (isLoading) {
-    return <div>로딩 중...</div>;
-  }
 
   const handleAlarmClick = (e: React.MouseEvent, notificationId: number, congressId: number) => {
     e.preventDefault();
@@ -52,6 +67,10 @@ const AlarmList = () => {
     deleteNotifications({ NotificationId: notificationId });
   };
 
+  if (notifications.length === 0) {
+    return <div {...stylex.props(AlarmStyles.EmptyText, Typography.TextSmallRegular)}>알람이 없습니다.</div>;
+  }
+
   return (
     <ul>
       {notifications.map((item, index) => (
@@ -59,12 +78,12 @@ const AlarmList = () => {
           key={item.NotificationId}
           // 마지막 항목에 Intersection Observer 적용
           ref={index === notifications.length - 1 ? loadMoreRef : undefined}
-          {...stylex.props(AlarmStyles.Item)}
+          {...stylex.props(AlarmStyles.Item, !item.checkedAt && AlarmStyles.NotRead)}
         >
           <a
             href="#"
             onClick={(e) => handleAlarmClick(e, item.NotificationId, item.CongressId)}
-            {...stylex.props(AlarmStyles.Link, !item.checkedAt && AlarmStyles.NotRead)}
+            {...stylex.props(AlarmStyles.Link)}
           >
             {/* 알람 정보 */}
             <div {...stylex.props(AlarmStyles.InfoContainer)}>
@@ -74,33 +93,52 @@ const AlarmList = () => {
               </div>
 
               {/* 카테고리 이미지 */}
-              <div {...stylex.props(AlarmStyles.ImgWrapper)}>
+              <div {...stylex.props(AlarmStyles.CategoryImgWrapper)}>
                 <img
                   src={`${process.env.NEXT_PUBLIC_S3_URL}/${alarmCategoryInfo[item?.notificationType].imgKey}`}
                   alt={alarmCategoryInfo[item?.notificationType].korean}
-                  width={24}
+                  {...stylex.props(AlarmStyles.CategoryImg)}
                 />
               </div>
 
               {/* 카테고리와 알람내용, 날짜 */}
-              <div>
-                <p {...stylex.props(Typography.SubTextLargeMedium, AlarmStyles.CategoryText)}>
-                  {alarmCategoryInfo[item?.notificationType].korean}
-                </p>
-                <p {...stylex.props(Typography.TextSmallMedium, AlarmStyles.ContentText)}>{item.content}</p>
-                <p {...stylex.props(Typography.CaptionRegularRegular, AlarmStyles.DateText)}>
-                  {dayjs(item.createdAt).fromNow()}
-                </p>
+              <div {...stylex.props(AlarmStyles.ContentContainer)}>
+                <div {...stylex.props(AlarmStyles.CategoryAndDateContainer)}>
+                  <span {...stylex.props(Typography.SubTextLargeMedium, AlarmStyles.CategoryText)}>
+                    {alarmCategoryInfo[item?.notificationType].korean}
+                  </span>
+                  <span {...stylex.props(AlarmStyles.Circle)} />
+                  <span {...stylex.props(Typography.CaptionRegularRegular, AlarmStyles.DateText)}>
+                    {dayjs(item.createdAt).fromNow()}
+                  </span>
+                </div>
+
+                <div {...stylex.props(Typography.SubtitleRegularBold, AlarmStyles.MainTitleText)}>
+                  {alarmCategoryInfo[item?.notificationType].isDisplayNameInTitle ? (
+                    <div {...stylex.props(AlarmStyles.DisplayNameContainer)}>
+                      <span {...stylex.props(AlarmStyles.Quotes)}>{"'"}</span>
+                      <span {...stylex.props(AlarmStyles.DisplayName)}>{item.congress.organizer.displayName}</span>
+                      <span {...stylex.props(AlarmStyles.Quotes)}>{"'"}</span>
+                    </div>
+                  ) : (
+                    ''
+                  )}
+
+                  <span>{item.content}</span>
+                </div>
+
+                <div {...stylex.props(AlarmStyles.CongressInfoContainer)}>
+                  <p {...stylex.props(Typography.TextSmallRegular)}>회의 : {item.congress.congressTitle}</p>
+                  <p {...stylex.props(Typography.TextSmallRegular)}>
+                    일시 : {dayjs(item.congress.startDt).format('YYYY.MM.DD HH:mm')}
+                  </p>
+                </div>
               </div>
             </div>
           </a>
 
           {/* 알람 삭제 */}
-          <button
-            type="button"
-            onClick={(e) => handleClickDeleteAlarm(e, item.NotificationId)}
-            {...stylex.props(AlarmStyles.DeleteButton)}
-          >
+          <button type="button" onClick={(e) => handleClickDeleteAlarm(e, item.NotificationId)}>
             <CloseOutlined width={16} height={16} />
           </button>
         </li>
@@ -114,11 +152,14 @@ export default AlarmList;
 const AlarmStyles = stylex.create({
   Item: {
     position: 'relative',
+    padding: '16px 12px 16px 16px',
+    display: 'flex',
+    alignItems: 'flex-start',
   },
   Link: {
     width: '100%',
-    padding: '16px',
     display: 'flex',
+    minWidth: 0,
     justifyContent: 'space-between',
     alignItems: 'flex-start',
     textDecoration: 'none',
@@ -127,7 +168,10 @@ const AlarmStyles = stylex.create({
     background: '#FFF3F3',
   },
   InfoContainer: {
+    width: '100%',
     display: 'flex',
+    minWidth: 0,
+    whiteSpace: 'nowrap',
   },
   DotWrapper: {
     width: '4px',
@@ -140,16 +184,29 @@ const AlarmStyles = stylex.create({
     borderRadius: '50%',
     verticalAlign: 'top',
   },
-  ImgWrapper: {
+  CategoryImgWrapper: {
+    width: '24px',
+    height: '24px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     marginRight: '11px',
   },
+  CategoryImg: {
+    flexShrink: 0,
+  },
   CategoryText: {
-    marginBottom: '4px',
     color: colors.black300,
   },
-  ContentText: {
-    marginBottom: '4px',
+  MainTitleText: {
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    minWidth: 0,
+    paddingBottom: '6px',
+    marginBottom: '6px',
     color: colors.black300,
+    borderBottom: `1px solid ${colors.gray30}`,
   },
   DateText: {
     color: colors.gray60,
@@ -158,10 +215,46 @@ const AlarmStyles = stylex.create({
     textAlign: 'center',
     padding: '16px',
   },
-  DeleteButton: {
-    position: 'absolute',
-    top: '16px',
-    right: '16px',
-    cursor: 'pointer',
+
+  Circle: {
+    width: '3px',
+    height: '3px',
+    display: 'inline-block',
+    background: colors.gray60,
+  },
+  CategoryAndDateContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+  },
+  DisplayNameContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    minWidth: 0, // flex item이 축소될 수 있도록 함
+    whiteSpace: 'nowrap',
+  },
+  DisplayName: {
+    flex: 1,
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+  },
+  ContentContainer: {
+    width: '100%',
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    whiteSpace: 'nowrap',
+  },
+  Quotes: {
+    whiteSpace: 'nowrap',
+  },
+  CongressInfoContainer: {
+    color: colors.black300,
+  },
+  EmptyText: {
+    textAlign: 'center',
+    padding: '16px',
+    color: colors.gray60,
   },
 });

--- a/src/queries/alarm/useGetNotificationsInfiniteQuery.tsx
+++ b/src/queries/alarm/useGetNotificationsInfiniteQuery.tsx
@@ -16,6 +16,17 @@ export interface NotificationItem {
   createdAt: string;
   content: string;
   checkedAt: string | null;
+  congress: {
+    congressTitle: string;
+    startDt: string;
+    endDt: string;
+    organizer: {
+      displayName: string;
+    };
+  };
+  sender: {
+    displayName: string;
+  };
 }
 
 interface Notification {


### PR DESCRIPTION
# 작업 내용
- 이전 디자인이 알림 가독성이 좋지 않아서 개선하기 위해 알림 페이지 디자인을 변경함.
- 기존에는 서버에서 전달하는 알림 제목을 그대로 사용했으나, 일부 카테고리 알림 제목에서 닉네임이 긴 경우 말줄임으로 대응하기가 어려울 것 같아서 프론트에서 닉네임과 서버에서 전달해주는 제목을 조합해서 사용함.
- 카테고리를 이동할 때 로딩중 상태가 빠르게 잠깐 보였다가 사라지는 게 거슬려서 제거함.
- 카테고리 항목에서 존재하는 알림이 없는 경우, 알림이 없다는 문구를 나타내도록 함.
- alarmCategoryInfo 객체에 대한 타입을 선언하고isDisplayNameInTitle 키를 추가함.
- NotificationItem 타입에  congress와 sender 추가함.
# 스크린샷
- 변경 전
   <img width="409" height="534" alt="image" src="https://github.com/user-attachments/assets/55b0c86e-27e8-4254-9155-a7c6a462548a" />

- 변경 후
   <img width="795" height="540" alt="image" src="https://github.com/user-attachments/assets/77844a9c-7763-4cc7-bf26-b1271421a0e8" />
