### PR TITLE
Feat(RT-51): Header 컴포넌트에서 뒤로가기 로직 변경

### DIFF
--- a/src/components/ui/Header/index.tsx
+++ b/src/components/ui/Header/index.tsx
@@ -1,12 +1,12 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import Link from 'next/link';
 import stylex from '@stylexjs/stylex';
 import { Typography, colors } from '../../../../public/styles/vars.stylex';
 import ArrowHeadOutlined from '@src/components/icons/ArrowHeadOutlined';
+import useBackNavigation from '@src/hooks/useBackNavigation';
 
 type HeaderProps = {
   title?: string; // 제목
-  prevUrl?: string; // 이전으로 이동할 url
   prevOnClick?: () => void;
   rightBtnInfo?: {
     name: string;
@@ -16,20 +16,15 @@ type HeaderProps = {
 };
 
 const Header: FC<HeaderProps> = (props) => {
-  const { title, prevUrl, prevOnClick, rightBtnInfo } = props;
+  const { title, prevOnClick, rightBtnInfo } = props;
+  const { goBackOrHome } = useBackNavigation();
 
   return (
     <div {...stylex.props(Styles.container, rightBtnInfo && Styles.withRightBtn)}>
-      {prevUrl && (
-        <Link href={prevUrl}>
-          <ArrowHeadOutlined width={24} height={24} />
-        </Link>
-      )}
-      {prevOnClick && (
-        <button type="button" onClick={prevOnClick}>
-          <ArrowHeadOutlined width={24} height={24} />
-        </button>
-      )}
+      <button type="button" onClick={prevOnClick || goBackOrHome}>
+        <ArrowHeadOutlined width={24} height={24} />
+      </button>
+
       <h1 {...stylex.props(Typography.TitleSmallSemiBold)}>{title}</h1>
       {/* 오른쪽 상단에 배치되는 버튼 */}
       {rightBtnInfo && (

--- a/src/hooks/useBackNavigation.tsx
+++ b/src/hooks/useBackNavigation.tsx
@@ -1,0 +1,34 @@
+import { useRouter } from 'next/router';
+
+/**
+ * 직전 페이지로 이동하거나 홈 페이지로 이동하는 함수를 반환하는 커스텀 훅
+ */
+const useBackNavigation = () => {
+  const router = useRouter();
+
+  const goBackOrHome = () => {
+    // 1. referrer 체크
+    const referrer = document.referrer;
+    const allowedDomains = [
+      process.env.NEXT_PUBLIC_FRONTEND_URL, // 환경변수로 관리
+    ].filter(Boolean);
+
+    const isInternalReferrer = referrer && allowedDomains.some((domain) => referrer.includes(domain));
+
+    // 2. 히스토리 길이 체크 (추가 안전장치)
+    const hasHistory = window.history.length > 1;
+
+    // 3. Next.js 라우터 히스토리 체크 (가장 안전)
+    const canGoBack = router.asPath !== router.pathname || hasHistory;
+
+    if (isInternalReferrer && canGoBack) {
+      router.back();
+    } else {
+      router.push('/home');
+    }
+  };
+
+  return { goBackOrHome };
+};
+
+export default useBackNavigation;

--- a/src/pages/alarm.tsx
+++ b/src/pages/alarm.tsx
@@ -18,7 +18,7 @@ const Alarm = () => {
   // 컨텍스트로 알림 카테고리 관리하기
   return (
     <MainLayout isScroll>
-      <Header title="알림" prevUrl="/home" rightBtnInfo={readAllBtnProps} />
+      <Header title="알림" rightBtnInfo={readAllBtnProps} />
       <AlarmCategoryProvider>
         {/* 알림 카테고리 */}
         <AlarmCategoryList />

--- a/src/pages/booking.tsx
+++ b/src/pages/booking.tsx
@@ -143,7 +143,7 @@ const Booking = () => {
 
   return (
     <MainLayout isScroll>
-      <Header title="예약하기" prevUrl="/calendar" />
+      <Header title="예약하기" />
 
       {/* 예약하기 폼 */}
       <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/pages/mypage/alarm.tsx
+++ b/src/pages/mypage/alarm.tsx
@@ -18,7 +18,7 @@ const MyPageAlarmSetting = () => {
 
   return (
     <MainLayout>
-      <Header title="알림 수신 설정" prevUrl="/mypage" />
+      <Header title="알림 수신 설정" />
 
       <section>
         {toggleList.map((item) => (

--- a/src/pages/mypage/profile.tsx
+++ b/src/pages/mypage/profile.tsx
@@ -70,11 +70,7 @@ const MyPageProfile = () => {
 
   return (
     <GnbNavLayout backgroundColor={colors.white500}>
-      <Header
-        title="프로필 수정"
-        prevUrl="/mypage"
-        rightBtnInfo={isWorkspace ? myInfoCompleteBtnProps : profileCompleteBtnProps}
-      />
+      <Header title="프로필 수정" rightBtnInfo={isWorkspace ? myInfoCompleteBtnProps : profileCompleteBtnProps} />
 
       {/* 이미지 업로드 및 이름 입력 */}
       <div {...stylex.props(Styles.SettingContainer)}>

--- a/src/pages/mypage/workspace/category.tsx
+++ b/src/pages/mypage/workspace/category.tsx
@@ -58,11 +58,7 @@ const Category = () => {
 
   return (
     <MainLayout>
-      <Header
-        title={isEdit ? '수정하기' : '카테고리'}
-        prevUrl="/mypage/workspace"
-        {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})}
-      />
+      <Header title={isEdit ? '수정하기' : '카테고리'} {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})} />
       {/* 검색 */}
 
       <div {...{ ...stylex.props(Styles.Container) }}>

--- a/src/pages/mypage/workspace/congress-room.tsx
+++ b/src/pages/mypage/workspace/congress-room.tsx
@@ -57,7 +57,7 @@ const MeetingRoom = () => {
 
   return (
     <MainLayout backgroundColor="#FAFAFA">
-      <Header title="회의실" prevUrl="/mypage/workspace" {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})} />
+      <Header title="회의실" {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})} />
 
       <div {...stylex.props(Styles.Container)}>
         {/* 회의실 개수 */}

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -50,7 +50,6 @@ const WorkspaceHome = () => {
     <MainLayout>
       <Header
         title="워크스페이스 정보"
-        prevUrl="/mypage"
         {...(isAdmin
           ? {
               rightBtnInfo: {

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -32,7 +32,7 @@ const Member = () => {
 
   return (
     <MainLayout>
-      <Header title="멤버" prevUrl="/mypage/workspace" />
+      <Header title="멤버" />
       <div {...{ ...stylex.props(Styles.Container) }}>
         {/* 검색 */}
         <div {...stylex.props(Styles.SearchContainer)}>

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -18,10 +18,6 @@ const UserProfile = () => {
   const { id } = router.query;
   const { data } = useGetWorkspaceMemberQuery(Number(id));
 
-  const handlePrevOnClick = () => {
-    router.back();
-  };
-
   const dataList = [
     { id: 1, name: data?.member?.teamInfo?.teamName, icon: <DataflowOutlined width={24} height={24} /> },
     { id: 2, name: data?.member?.position || '직책 없음', icon: <UserSquareOutlined width={24} height={24} /> },
@@ -30,7 +26,7 @@ const UserProfile = () => {
 
   return (
     <MainLayout>
-      <Header prevOnClick={handlePrevOnClick} />
+      <Header />
 
       {/* 프로필 이미지 */}
       <div {...stylex.props(Styles.ProfileContainer)}>

--- a/src/pages/reservations/[id].tsx
+++ b/src/pages/reservations/[id].tsx
@@ -21,8 +21,8 @@ const ReservationInfo = dynamic(() => import('@src/features/reservation/componen
 const MeetingDetails = () => {
   return (
     <MainLayout isScroll>
-      {/* 직전 페이지로 이동할 수 잇게 구현하기 */}
-      <Header prevUrl="/calendar" />
+      <Header />
+
       <ReservationInfo />
 
       {/* 경계선 */}


### PR DESCRIPTION
# 작업 내용
- useBackNavigation 커스텀 훅 생성
  - useBackNavigation 커스텀 훅에서 제공하는 goBackOrHome 함수는 룸렛 내부 사이트를 탐색한 경우에는 전부 router.back() 처리를 하고 외부 사이트에서 룸렛 사이트로 이동한 경우에는 홈으로 이동하게 함.
- Header 컴포넌트에서 prevUrl 속성 제거
   - 이에 따라 Header 컴포넌트를 사용한 모든 코드에 prevUrl 속성을 제거해줌.
   - 기존에는 뒤로가기 버튼 클릭시 이동할 url을 prevUrl prop으로 직접 지정했는데, 알림 목록에서 회의 상세 페이지 이동 후 다시 알림 목록으로 가지 않고 캘린더 url로 이동하는 것이 어색하고 불편하다고 느껴졌음.
   - 그래서 prevUrl 속성을 지우고 뒤로가기 버튼에 디폴트 함수로 goBackOrHome를 설정해둠.
   - 예외적으로 댓글 수정의 경우 뒤로가기 버튼이 모달의 닫기 버튼 기능과 동일하여 goBackOrHome를 사용하지 않고 prevOnClick를 사용할 수 있도록 함.
   
# 스크린샷
- 뒤로가기 버튼 예시 이미지
<img width="766" height="395" alt="image" src="https://github.com/user-attachments/assets/ba0a5b5e-5d08-4b87-afe4-4591ca7ddead" />
