### PR TITLE
Update(RT-51): 헤더의 뒤로가기 로직을 세션 스토리지를 사용한 코드로 변경

### DIFF
--- a/src/hooks/useBackNavigation.tsx
+++ b/src/hooks/useBackNavigation.tsx
@@ -7,18 +7,16 @@ const useBackNavigation = () => {
   const router = useRouter();
 
   const goBackOrHome = () => {
-    // 1. referrer 체크
-    const referrer = document.referrer;
+    const referer = sessionStorage.getItem('referer');
+
     const allowedDomains = [
       process.env.NEXT_PUBLIC_FRONTEND_URL, // 환경변수로 관리
     ].filter(Boolean);
 
-    const isInternalReferrer = referrer && allowedDomains.some((domain) => referrer.includes(domain));
+    const isInternalReferrer = referer && allowedDomains.some((domain) => referer.includes(domain));
 
-    // 2. 히스토리 길이 체크 (추가 안전장치)
     const hasHistory = window.history.length > 1;
 
-    // 3. Next.js 라우터 히스토리 체크 (가장 안전)
     const canGoBack = router.asPath !== router.pathname || hasHistory;
 
     if (isInternalReferrer && canGoBack) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,9 +7,20 @@ export async function middleware(request: NextRequest) {
   let refreshToken = request.cookies.get('refresh_token');
   let isRefreshToken = request.cookies.has('refresh_token');
   let isAccessToken = request.cookies.has('access_token');
+  const referer = request.headers.get('referer');
+  const response = NextResponse.next();
 
   const path = request.nextUrl.pathname;
   const prevUrl = `${process.env.NEXT_PUBLIC_FRONTEND_URL}${request.nextUrl.pathname}${request.nextUrl.search}`; // 로그인 페이지 이전에 있었던 url
+
+  if (referer) {
+    response.cookies.set('page_referer', referer, {
+      httpOnly: false, // 클라이언트에서 접근 가능하게 함.
+      sameSite: 'lax',
+    });
+  } else {
+    response.cookies.delete('page_referer');
+  }
 
   if (isRefreshToken) {
     if (['/login', '/'].includes(path)) {
@@ -17,7 +28,7 @@ export async function middleware(request: NextRequest) {
       return NextResponse.redirect(new URL('/home', request.url));
     }
 
-    return null;
+    return response;
   }
 
   // 로그인을 하지 않은 경우, 로그인 페이지로 이동 (초대 페이지, 로그인 페이지, 랜딩 페이지를 제외한 모든 페이지 접근 불가)
@@ -25,7 +36,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL(`/login?prev_url=${encodeURIComponent(prevUrl)}`, request.url));
   }
 
-  return null;
+  return response;
 }
 
 export const config = {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { AppProps } from 'next/app';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
@@ -20,9 +20,11 @@ import '../features/authentication/assets/onboarding-slider.css';
 import '../features/booking/assets/custom-react-calendar.css';
 import '../features/calendar/styles/custom-react-calendar.css';
 import { ToastContainer } from 'react-toastify';
+import { useRouter } from 'next/router';
 // import '../features/calendar/styles/styles.css';
 
 export default function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -44,6 +46,24 @@ export default function App({ Component, pageProps }: AppProps) {
 
   // 로케일 설정
   dayjs.locale('ko');
+
+  // sessionStorage에 referer 저장
+  useEffect(() => {
+    const tempReferer = document.cookie
+      .split('; ')
+      .find((row) => row.startsWith('page_referer='))
+      ?.split('=')[1];
+
+    if (tempReferer) {
+      sessionStorage.setItem('referer', decodeURIComponent(tempReferer));
+
+      // 쿠키 삭제
+      document.cookie = 'page_referer=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    } else {
+      // 외부 페이지로 부터 온 경우, 세션 스토리지에 저장되어 있던 기존 referer 삭제
+      sessionStorage.removeItem('referer');
+    }
+  }, [router.asPath]);
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
# 작업 내용
- document.referer 값이 빈 문자열이라서 뒤로가기가 제대로 동작하지 않는 문제 해결
   - 미들웨어로 referer를 가져와서 쿠키에 저장한 후, 쿠키에서 세션 스토리지에 다시 저장한 값으로 뒤로가기 로직을 구현하여 문제를 해결함.
   - 쿠키에서 세션 스토리지로 옮긴 이유는 쿠키에 저장한 값이 모든 탭에 공유되어서 외부 사이트에서 룸렛으로 접근한 탭의 기록이 다른 탭에 영향을 미쳤음.
   - 그래서 쿠키에서 세션 스토리지로 값을 옮겨서, 독립적으로 각 탭에서 뒤로가기가 동작할 수 있게 함.