### PR TITLE
Fix(RT-52): 모바일에서 워크스페이스 가입 페이지 css 일부 수정 및 온보딩 화면이 나타나는 문제 해결 

### DIFF
--- a/src/components/ui/Checkbox/index.tsx
+++ b/src/components/ui/Checkbox/index.tsx
@@ -9,14 +9,20 @@ interface CHeckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
 const CHeckbox: FC<CHeckboxProps> = (props) => {
   const { id, children, variant = 'default', ...anotherProps } = props;
 
-  const labelClass =
-    variant === 'circle' ? `${styles['common-checkbox-label']} ${styles['circle']}` : styles['common-checkbox-label'];
+  const checkboxClass =
+    variant === 'circle' ? `${styles['common-checkbox']} ${styles['circle']}` : styles['common-checkbox'];
 
   return (
     <>
-      <label className={labelClass} htmlFor={id}>
+      <label className={styles['common-checkbox-label']} htmlFor={id}>
+        {/* 체크박스 */}
+        <div className={checkboxClass}>
+          <span className={styles['common-checkbox-checkmark']} />
+        </div>
         <input className={styles['common-checkbox-input']} type="checkbox" id={id} {...anotherProps} />
-        {children}
+
+        {/* 체크박스 텍스트 */}
+        <div className={styles['common-checkbox-text']}>{children}</div>
       </label>
     </>
   );

--- a/src/components/ui/Checkbox/styles/styles.module.css
+++ b/src/components/ui/Checkbox/styles/styles.module.css
@@ -7,23 +7,21 @@
 .common-checkbox-label {
   position: relative;
   display: inline-flex;
-  align-items: center;
+  align-items: flex-start;
   cursor: pointer;
   font-size: 16px;
   line-height: 1.5;
-  padding-left: 30px; /* 체크박스 영역 공간 확보 */
   color: #333;
+  gap: 6px;
 }
 
 /* 체크박스 디자인 */
-.common-checkbox-label::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
+.common-checkbox {
+  position: relative;
   width: 20px;
   height: 20px;
+  margin: 4px;
+  flex-shrink: 0;
   border: 1px solid #a7abad;
   border-radius: 4px; /* 둥근 모서리 */
   background-color: #fff;
@@ -33,22 +31,23 @@
 }
 
 /* 원형 체크박스 디자인 */
-.common-checkbox-label.circle::before {
+.common-checkbox.circle {
   border-radius: 50%; /* 원형으로 변경 */
 }
 
 /* 체크된 상태 스타일 */
-.common-checkbox-label:has(.common-checkbox-input[type='checkbox']:checked)::before {
+.common-checkbox-label:has(.common-checkbox-input[type='checkbox']:checked) .common-checkbox {
   background-color: #b5312c; /* 체크박스 배경색 */
   border-color: #b5312c;
 }
 
 /* 체크 표시를 이미지로 설정 */
-.common-checkbox-label:has(.common-checkbox-input[type='checkbox']:checked)::after {
+.common-checkbox-label:has(.common-checkbox-input[type='checkbox']:checked) .common-checkbox-checkmark {
   content: '';
   position: absolute;
-  left: 4px;
-  top: 6px;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
   width: 12px;
   height: 12px;
   background-image: url('https://roomlet.s3.ap-northeast-2.amazonaws.com/public/images/common/checkmark.png'); /* 체크 표시 이미지 경로 */
@@ -58,15 +57,21 @@
 }
 
 /* 원형 체크박스의 체크 표시 위치 조정 */
-.common-checkbox-label.circle:has(.common-checkbox-input[type='checkbox']:checked)::after {
-  left: 5px;
-  top: 8px;
+.common-checkbox-label:has(.common-checkbox-input[type='checkbox']:checked)
+  .common-checkbox.circle.common-checkbox-checkmark {
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
   width: 10px;
   height: 8px;
   background-image: url('https://roomlet.s3.ap-northeast-2.amazonaws.com/public/images/common/checkmark_v2.png'); /* 체크 표시 이미지 경로 */
 }
 
 /* 호버 효과 */
-.common-checkbox-label:hover::before {
+.common-checkbox:hover {
   border-color: #666;
+}
+
+.common-checkbox-text {
+  align-self: center;
 }

--- a/src/features/invite/queries/usePostWorkspaceJoinQuery.tsx
+++ b/src/features/invite/queries/usePostWorkspaceJoinQuery.tsx
@@ -2,6 +2,7 @@ import { confirm } from '@src/components/ui/Modal/confirm';
 import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
 import { hideModal } from '@src/slices/modal';
 import clientInstance from '@src/utils/api/clientInstance';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { useDispatch } from 'react-redux';
 
@@ -39,6 +40,7 @@ const postWorkspaceJoinApi = async (data: JoinInfo): Promise<WorkspaceInfo> => {
  *   - `isSuccess`: mutation이 성공했고, mutation data를 사용할 수 있는지에 대한 여부
  */
 const usePostWorkspaceJoinQuery = () => {
+  const queryClient = useQueryClient();
   const router = useRouter();
   const dispatch = useDispatch();
   const asPath = router.asPath;
@@ -46,7 +48,8 @@ const usePostWorkspaceJoinQuery = () => {
   const mutation = useCustomMutation({
     mutationFn: (data: JoinInfo) => postWorkspaceJoinApi(data),
     onSuccess: () => {
-      // 가입 성공 시 홈 화면으로 이동
+      // 가입 성공 시 모든 쿼리 무효화 후 홈 화면으로 이동 (새로 가입한 워크스페이스에 맞게 데이터를 다시 로드하기 위해 모든 쿼리 무효화)
+      queryClient.invalidateQueries();
       router.push('/home');
     },
     onError: (error, variables, context) => {

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -7,6 +7,7 @@ import { workspaceExists } from '@src/slices/workspace';
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 import OnboardingSlider from '@src/features/onboarding/components/OnboardingSlider';
 import useGetMyPageProfileQuery from '@src/features/mypage/profile/queries/useGetMyPageProfileQuery';
+import { useRouter } from 'next/router';
 
 interface MainLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
   isScroll?: boolean; // 전체 화면에 스크롤이 적용되게 할지 말지 결정
@@ -16,10 +17,12 @@ interface MainLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const MainLayout: FC<MainLayoutProps> = (props) => {
   const { isScroll, backgroundColor, children } = props;
+  const router = useRouter();
   const modal = useSelector((state: RootState) => state.modal);
   const { data } = useGetWorkspaceListQuery();
   const { data: myPageProfileData, isLoading } = useGetMyPageProfileQuery();
   const isShowOnboarding = myPageProfileData?.profile?.isShowOnboarding;
+  const disableOnboardingPages = ['/invite', '/invite/join'];
 
   const dispatch = useDispatch();
 
@@ -31,7 +34,7 @@ const MainLayout: FC<MainLayoutProps> = (props) => {
   return (
     <div id="main-layout" {...stylex.props(Styles.container(isScroll, backgroundColor))}>
       {modal && <div {...stylex.props(Styles.modalWrapper)}>{modal}</div>}
-      {isShowOnboarding === true && !isLoading && (
+      {isShowOnboarding === true && !isLoading && !disableOnboardingPages.includes(router.pathname) && (
         <div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100dvh', zIndex: 1000 }}>
           <OnboardingSlider />
         </div>

--- a/src/pages/api/auth.ts
+++ b/src/pages/api/auth.ts
@@ -11,6 +11,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const { refresh_token, access_token } = req.cookies;
   const refreshTokenExp = refresh_token ? jwtDecode(refresh_token).exp : 0;
   const accessTokenExp = access_token ? jwtDecode(access_token).exp : 0;
+  const refreshTokenUuid = refresh_token ? jwtDecode<{ uuid?: string }>(refresh_token).uuid : 0;
+  const accessTokenUuid = access_token ? jwtDecode<{ uuid?: string }>(access_token).uuid : 0;
 
   // refresh Token 만료
   if (dayjs().isAfter(refreshTokenExp * 1000)) {
@@ -23,8 +25,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   } else {
     // refresh token 유효한 경우
 
-    // access Token 만료
-    if (dayjs().isAfter(accessTokenExp * 1000)) {
+    // 로그아웃하지않고 구글 계정을 변경한 경우 or access Token 만료
+    if (refreshTokenUuid !== accessTokenUuid || dayjs().isAfter(accessTokenExp * 1000)) {
       try {
         // 재발급
         const result = await axiosInstance.get('/v1/auth/refresh', {

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -121,8 +121,8 @@ const Invite = () => {
               </p>
               <div {...stylex.props(Styles.chromeRecommendContainer)}>
                 <p {...stylex.props(Styles.chromeRecommendText, Typography.SubTextLargeRegular)}>
-                  원활한 서비스 이용을 위해 <span {...stylex.props(Styles.chromeBold)}>Chrome 브라우저</span> 사용을
-                  권장해요
+                  원활한 서비스 이용을 위해 <br />
+                  <span {...stylex.props(Styles.chromeBold)}>Chrome 브라우저</span> 사용을 권장해요
                 </p>
               </div>
             </div>
@@ -245,6 +245,7 @@ const Styles = stylex.create({
     textAlign: 'center',
   },
   guideText: {
+    marginBottom: '8px',
     textAlign: 'center',
     color: colors.black500,
   },


### PR DESCRIPTION
# 작업 내용
- 룸렛에 가입한 직후 /invite, /invite/join 페이지 접속시 온보딩 화면이 보여지는 문제 해결
   - '룸렛 가입 -> 워크스페이스 가입 -> 온보딩 화면' 이런 과정을 거쳐야하는데, '룸렛 가입 -> 온보딩 화면 -> 워크스페이스 가입' 과정으로 온보딩 화면이 보여지는 문제가 있었음.
   - 이 문제는 로그인한 사용자 기준으로 어떤 페이지에서든 온보딩 화면을 수 있게 해서 발생한 문제인데, 그래서 /invite, /invite/join 페이지 자체에서는 온보딩 화면이 보이지 않게하고, 워크스페이스 가입한 후에 홈 화면으로 이동하면서 온보딩 화면을 볼 수 있게 함.
- 로그아웃하지 않고 구글 계정을 변경했을 때 이전에 로그인했던 계정 정보가 보여지는 문제 해결
   - 로그인 직후 뒤로가기를 통해 구글 계정을 변경하게 되면, 변경한 구글 계정 정보가 보여져야하는데 이전에 로그인했던 계정 정보가 보여지는 문제가 있었음.
   - 바뀐 계정에 대한 리프레시 토큰은 서버로 전달받았는데, 프론트에서 액세스 토큰을 발급하는 과정에서 만료한 액세스 토큰의 경우에만 새로운 토큰을 발급받도록 하는 로직으로 인해 이전 계정에 대한 액세스 토큰이 쿠키에 남아있어서 발생한 문제였음.
   - 그래서 리프레스 토큰과 액세스 토큰에 담긴 정보중 uuid를 비교해서 uuid가 다르면 액세스 토큰을 새로 발급 받도록 함.
- 워크스페이스 가입 성공 후 /home으로 이동했을 때, 워크스페이스 생성 전 상태로 보여지는 문제 해결
   - 워크스페이스 가입에 성공했음에도 불구하고, 워크스페이스 리스트 api를 다시 요청하지 않고 워크스페이스 가입 전에 요청했던 데이터를 그대로 사용하고 있어서 발생한 문제였음.
   - 그래서 워크스페이스 가입을 성공하면 모든 쿼리 키를 무효화하고, /home으로 이동할 수 있게해서 문제를 해결함.
- 체크박스가 체크된 상태에서 텍스트가 2줄로 표현될 때, 체크마크가 보이지 않는 문제 해결
   - 기존에 체크박스를 나타내는 코드가 label 태그에 의존해서 ::before, ::after로 표현되고 있었음.
   - 이로 인해, label 태그의 높이가 변경되면 체크박스의 디자인 형태가 유지되지 못하고 변경되어버리는 문제가 발생함.
   - 그래서 label 태그에 의존하지 않고 체크박스 디자인만 담당하는 태그를 생성해서 문제를 해결해줌.
- '원활한 서비스 이용을 위해 Chrome 브라우저 사용을 권장해요' 문장을 2줄로 표현되게 수정
   - `<br />`을 사용하지 않고 한줄로 표현했을 때 모바일 화면에서 문장이 끊겨지는 부분이 매끄럽지 못해서 수정해줌.

# 스크린샷
- '원활한 서비스 ~ ' 문구 수정
   - 수정 전
      <img width="345" height="169" alt="image" src="https://github.com/user-attachments/assets/b90c2f42-6f81-40ec-9e0b-a42a6cbf56b6" />
   - 수정 후
      <img width="317" height="199" alt="image" src="https://github.com/user-attachments/assets/da09346f-4242-44ed-b4a6-e84c741a472a" />

- 체크박스 css 
   - 수정 전
      <img width="292" height="145" alt="image" src="https://github.com/user-attachments/assets/445cad38-bde8-48af-93e6-7b5ca3e3819a" />
   - 수정 후
      <img width="313" height="162" alt="image" src="https://github.com/user-attachments/assets/13a800a0-7802-45df-a4a2-a7bb7ee3cf80" />
