### PR TITLE
Fix(RT-55

### DIFF
--- a/src/components/ui/BottomSheet/index.tsx
+++ b/src/components/ui/BottomSheet/index.tsx
@@ -10,19 +10,7 @@ interface BottomSheetProps extends React.HTMLAttributes<HTMLDivElement> {
  * Bottom Sheet 공통 컴포넌트
  */
 const BottomSheet: FC<BottomSheetProps> = (props) => {
-  const { children, id, onClick, ...anotherProps } = props;
-
-  const handleClickMask = (func) => async (e) => {
-    const mainLayoutElement = document.getElementById('main-layout');
-
-    /* onClick 함수가 실행된 후에 main-layout의 overflow를 auto로 변경 */
-    const isClick = await new Promise((resolve) => {
-      onClick(e);
-      resolve(true);
-    });
-
-    if (isClick) mainLayoutElement.style.overflow = 'auto';
-  };
+  const { children, id, ...anotherProps } = props;
 
   useEffect(() => {
     const mainLayoutElement = document.getElementById('main-layout');
@@ -30,11 +18,17 @@ const BottomSheet: FC<BottomSheetProps> = (props) => {
     if (mainLayoutElement) {
       mainLayoutElement.style.overflow = 'hidden';
     }
+
+    return () => {
+      if (mainLayoutElement) {
+        mainLayoutElement.style.overflow = 'auto';
+      }
+    };
   }, []);
 
   return (
     <div id={id}>
-      <div {...anotherProps} {...stylex.props(Styles.MaskWrapper)} onClick={handleClickMask(onClick)} />
+      <div {...anotherProps} {...stylex.props(Styles.MaskWrapper)} />
       <div {...stylex.props(Styles.ContentWrapper)}>{children}</div>
     </div>
   );

--- a/src/components/ui/BottomSheet/index.tsx
+++ b/src/components/ui/BottomSheet/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import stylex from '@stylexjs/stylex';
 import { colors } from '../../../../public/styles/vars.stylex';
 
@@ -10,11 +10,31 @@ interface BottomSheetProps extends React.HTMLAttributes<HTMLDivElement> {
  * Bottom Sheet 공통 컴포넌트
  */
 const BottomSheet: FC<BottomSheetProps> = (props) => {
-  const { children, id, ...anotherProps } = props;
+  const { children, id, onClick, ...anotherProps } = props;
+
+  const handleClickMask = (func) => async (e) => {
+    const mainLayoutElement = document.getElementById('main-layout');
+
+    /* onClick 함수가 실행된 후에 main-layout의 overflow를 auto로 변경 */
+    const isClick = await new Promise((resolve) => {
+      onClick(e);
+      resolve(true);
+    });
+
+    if (isClick) mainLayoutElement.style.overflow = 'auto';
+  };
+
+  useEffect(() => {
+    const mainLayoutElement = document.getElementById('main-layout');
+    // BottomSheet 오픈 시 main-layout의 overflow를 hidden으로 변경
+    if (mainLayoutElement) {
+      mainLayoutElement.style.overflow = 'hidden';
+    }
+  }, []);
 
   return (
     <div id={id}>
-      <div {...anotherProps} {...stylex.props(Styles.MaskWrapper)} />
+      <div {...anotherProps} {...stylex.props(Styles.MaskWrapper)} onClick={handleClickMask(onClick)} />
       <div {...stylex.props(Styles.ContentWrapper)}>{children}</div>
     </div>
   );
@@ -27,6 +47,7 @@ const Styles = stylex.create({
     width: '100%',
     height: '100dvh',
     position: 'sticky',
+    overflow: 'hidden',
     bottom: 0,
     background: 'rgba(0, 0, 0, 0.5)',
     zIndex: 10,

--- a/src/features/booking/components/BookingDatePicker/MiniCalendar/index.tsx
+++ b/src/features/booking/components/BookingDatePicker/MiniCalendar/index.tsx
@@ -8,7 +8,7 @@ import { Shadows, Typography, colors } from '../../../../../../public/styles/var
 import ArrowHeadOutlinedV2 from '@src/components/icons/ArrowHeadOutlinedV2';
 import TriangleFilled from '@src/components/icons/TriangleFilled';
 import { useDispatch, useSelector } from 'react-redux';
-import { saveSelectBookingDate } from '@src/features/booking/slices/booking';
+import { saveSelectBookingDate, setIsUpdatedBookingDate } from '@src/features/booking/slices/booking';
 import { RootState } from '@src/store';
 import DateWheelPicker from '@src/features/calendar/components/DateWheelPicker';
 import { BookingForm } from '@src/pages/booking';
@@ -87,6 +87,7 @@ const MiniCalendar: FC<MiniCalendarProps> = (props) => {
     setValue('startDt', null);
     setValue('endDt', null);
     dispatch(saveSelectBookingDate(dayjs(`${year}-${month}-${day}`).format('YYYY-MM-DD')));
+    dispatch(setIsUpdatedBookingDate());
   };
 
   useEffect(() => {

--- a/src/features/booking/components/BookingTimePicker/TimeOptionList/index.tsx
+++ b/src/features/booking/components/BookingTimePicker/TimeOptionList/index.tsx
@@ -49,7 +49,9 @@ const TimeOptionList: FC<TimeOptionListProps> = (props) => {
         ) : (
           <li {...stylex.props(Styles.TimeItem, Styles.NoTime, Typography.SubTextLargeMedium)}>
             {!isDate && `날짜를\n선택해주세요.`}
-            {!optionList && isDate && `예약 가능한\n시간이 없어요. \n(장소, 카테고리, 날짜를 다시 확인해주세요.)`}
+            {!optionList?.length &&
+              isDate &&
+              `예약 가능한\n시간이 없어요. \n(장소, 카테고리, 날짜를 다시 확인해주세요.)`}
           </li>
         )}
       </ul>

--- a/src/features/booking/components/BookingTimePicker/index.tsx
+++ b/src/features/booking/components/BookingTimePicker/index.tsx
@@ -6,8 +6,9 @@ import TimeOptionList from './TimeOptionList';
 import type { TimeItemType } from '../../types';
 import useGetWorkspaceCongressRoomTimQuery from '../../queries/useGetMemberListQuery copy';
 import dayjs from 'dayjs';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@src/store';
+import { resetIsUpdatedBookingDate } from '../../slices/booking';
 
 type BookingTimePickerProps = {
   placeholder: string;
@@ -15,11 +16,14 @@ type BookingTimePickerProps = {
   startDt?: TimeItemType;
   onSelect: (value: TimeItemType) => void;
   defaultValue: TimeItemType | null;
+  isUpdatedRoomId: boolean;
+  setIsUpdatedRoomId: (value: boolean) => void;
 };
 
 const BookingTimePicker: FC<BookingTimePickerProps> = (props) => {
-  const { selectBookingDate } = useSelector((state: RootState) => state.booking);
-  const { placeholder, onSelect, roomId, startDt, defaultValue } = props;
+  const { selectBookingDate, isUpdatedBookingDate } = useSelector((state: RootState) => state.booking);
+  const dispatch = useDispatch();
+  const { placeholder, onSelect, roomId, startDt, defaultValue, isUpdatedRoomId, setIsUpdatedRoomId } = props;
   const [isTimeOptionOpen, setIsTimeOptionOpen] = useState<boolean>(false);
   const [selectTime, setSelectTime] = useState<TimeItemType>(null);
   const timeRef = useRef<HTMLDivElement>(null);
@@ -60,10 +64,18 @@ const BookingTimePicker: FC<BookingTimePickerProps> = (props) => {
 
   // 예약 날짜가 변경되면 선택된 시간 초기화
   useEffect(() => {
-    if (selectBookingDate) {
+    if (isUpdatedBookingDate) {
       setSelectTime(null);
+      dispatch(resetIsUpdatedBookingDate());
     }
-  }, [selectBookingDate]);
+  }, [isUpdatedBookingDate]);
+
+  useEffect(() => {
+    if (isUpdatedRoomId) {
+      setSelectTime(null);
+      setIsUpdatedRoomId(false);
+    }
+  }, [isUpdatedRoomId]);
 
   return (
     <div {...stylex.props(BookingStyles.formItemInputWrapper, Styles.Wrapper)} ref={timeRef}>

--- a/src/features/booking/queries/usePatchWorkspaceCongressQuery.tsx
+++ b/src/features/booking/queries/usePatchWorkspaceCongressQuery.tsx
@@ -1,0 +1,83 @@
+import { useDispatch } from 'react-redux';
+import { confirm } from '@src/components/ui/Modal/confirm';
+import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
+import clientInstance from '@src/utils/api/clientInstance';
+import { useRouter } from 'next/router';
+import { saveSelectBookingDate } from '../slices/booking';
+import { saveSelectBookingMemberObj } from '../slices/booking';
+
+interface RequestBody {
+  cgsid: number;
+  RoomId: number;
+  CongressCategoryId: number;
+  congressTitle: string;
+  congressDescription: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  attendMemberList: {
+    MemberId: number;
+  }[];
+  allTeam: boolean;
+}
+
+interface CongressInfo {
+  success: boolean;
+  code: number;
+  CongressId: number;
+}
+
+const patchCongressApi = async (
+  WorkspaceId: number | undefined,
+  cgsid: number,
+  data: RequestBody
+): Promise<CongressInfo> => {
+  const response = await clientInstance.patch(`/v1/workspace/@${WorkspaceId}/congress`, data, {
+    params: { cgsid },
+  });
+
+  return response.data;
+};
+
+/**
+ * React-query를 사용하여 회의를 수정하는 커스텀 훅
+ * @returns
+ * - 다음 객체를 반환합니다:
+ *   - `data`: 반환하는 데이터 없음 (아직 가져오지 않았다면 `undefined`)
+ *   - `error`: 에러 발생 시 에러 객체
+ *   - `isLoading`: 데이터 로딩 여부
+ *   - `refetch`: 데이터를 수동으로 다시 가져오는 함수
+ */
+const usePatchWorkspaceCongressQuery = () => {
+  const { data } = useGetWorkspaceListQuery();
+  const router = useRouter();
+  const dispatch = useDispatch();
+  const workspaceId = data?.workspaceList[0]?.WorkspaceId;
+
+  const result = useCustomMutation({
+    mutationFn: (data: RequestBody) => {
+      const cgsid = data?.cgsid;
+      return patchCongressApi(workspaceId, cgsid, data);
+    },
+    onSuccess: (data: CongressInfo, variables, context) => {
+      // [ ] 초기화 코드가 여기에 있으면, 유지보수할 때 코드 찾기가 어려울 것. 추후 수정 필요
+      // 예약 날짜 초기화
+      dispatch(saveSelectBookingDate(''));
+      // 예약 참석자 초기화
+      dispatch(saveSelectBookingMemberObj({}));
+
+      router.push(`/reservations/${data.CongressId}`);
+    },
+    onError: (error, variables, context) => {
+      if (error.response.data.code === 452) {
+        // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
+        confirm({ content: error?.response.data.message.errMsg });
+      }
+    },
+  });
+
+  return result;
+};
+
+export default usePatchWorkspaceCongressQuery;

--- a/src/features/booking/slices/booking.ts
+++ b/src/features/booking/slices/booking.ts
@@ -2,11 +2,13 @@ import { createSlice } from '@reduxjs/toolkit';
 import { MemberInfoItem } from '@src/queries/team/useGetTeamListQuery';
 
 export interface BookingState {
+  isUpdatedBookingDate: boolean;
   selectBookingDate: string;
   selectBookingMemberObj: { [teamName in string]: MemberInfoItem[] };
 }
 
 const initialState: BookingState = {
+  isUpdatedBookingDate: false,
   selectBookingDate: '',
   selectBookingMemberObj: {},
 };
@@ -15,6 +17,12 @@ export const BookingSlice = createSlice({
   name: 'booking',
   initialState,
   reducers: {
+    resetIsUpdatedBookingDate: (state) => {
+      state.isUpdatedBookingDate = false;
+    },
+    setIsUpdatedBookingDate: (state) => {
+      state.isUpdatedBookingDate = true;
+    },
     // 선택한 회의 예약 날짜
     saveSelectBookingDate: (state, action) => {
       state.selectBookingDate = action.payload;
@@ -27,6 +35,7 @@ export const BookingSlice = createSlice({
 });
 
 // Action creators are generated for each case reducer function
-export const { saveSelectBookingDate, saveSelectBookingMemberObj } = BookingSlice.actions;
+export const { saveSelectBookingDate, saveSelectBookingMemberObj, resetIsUpdatedBookingDate, setIsUpdatedBookingDate } =
+  BookingSlice.actions;
 
 export default BookingSlice.reducer;

--- a/src/pages/booking.tsx
+++ b/src/pages/booking.tsx
@@ -87,6 +87,7 @@ const Booking = ({ updateData }: BookingProps) => {
   const RoomId = useWatch({ control, name: 'RoomId' });
   const startDt = useWatch({ control, name: 'startDt' });
   const endDt = useWatch({ control, name: 'endDt' });
+  const [isUpdatedRoomId, setIsUpdatedRoomId] = useState<boolean>(false);
 
   // 모든 필드의 값을 감시
   const values = watch();
@@ -202,7 +203,12 @@ const Booking = ({ updateData }: BookingProps) => {
                         id={item.roomName}
                         label={item.roomName}
                         value={item.RoomId}
-                        onChange={field.onChange}
+                        onChange={(e) => {
+                          setIsUpdatedRoomId(true);
+                          setValue('startDt', null);
+                          setValue('endDt', null);
+                          field.onChange(e);
+                        }}
                         {...(mode === 'edit' && {
                           defaultChecked: item.RoomId === updateData?.congressRoom.RoomId,
                         })}
@@ -277,6 +283,8 @@ const Booking = ({ updateData }: BookingProps) => {
                     onSelect={field.onChange}
                     roomId={RoomId}
                     defaultValue={startDt}
+                    isUpdatedRoomId={isUpdatedRoomId}
+                    setIsUpdatedRoomId={setIsUpdatedRoomId}
                   />
                 )}
               />
@@ -293,6 +301,8 @@ const Booking = ({ updateData }: BookingProps) => {
                     roomId={RoomId}
                     startDt={startDt}
                     defaultValue={endDt}
+                    isUpdatedRoomId={isUpdatedRoomId}
+                    setIsUpdatedRoomId={setIsUpdatedRoomId}
                   />
                 )}
               />

--- a/src/pages/booking.tsx
+++ b/src/pages/booking.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { Controller, useForm, useWatch } from 'react-hook-form';
 import stylex from '@stylexjs/stylex';
@@ -18,7 +18,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@src/store';
 import usePostWorkspaceCongressQuery from '@src/features/booking/queries/usePostWorkspaceCongressQuery';
 import { TimeItemType } from '@src/features/booking/types';
-import useGetWorkspaceCongressQuery from '@src/features/reservation/queries/useGetWorkspaceCongressQuery';
+import { CongressInfo } from '@src/features/reservation/queries/useGetWorkspaceCongressQuery';
 import { useRouter } from 'next/router';
 import { saveSelectBookingDate, saveSelectBookingMemberObj } from '@src/features/booking/slices/booking';
 import dayjs from 'dayjs';
@@ -26,6 +26,10 @@ import AddCongressRoomBottomSheet from '@src/features/mypage/workspace/congress-
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import AddCategoryBottomSheet from '@src/features/mypage/workspace/category/components/AddCategoryBottomSheet';
 import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
+import usePatchWorkspaceCongressQuery from '@src/features/booking/queries/usePatchWorkspaceCongressQuery';
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import clientInstance from '@src/utils/api/clientInstance';
+import axios from 'axios';
 
 const BookingMemberSelect = dynamic(() => import('@src/features/booking/components/BookingMemberSelect'), {
   ssr: false,
@@ -44,6 +48,7 @@ const BookingDatePicker = dynamic(() => import('@src/features/booking/components
 });
 
 export type BookingForm = {
+  cgsid: number;
   date: string;
   RoomId: number | null;
   startDt: TimeItemType;
@@ -54,7 +59,11 @@ export type BookingForm = {
   congressDescription: string;
 };
 
-const Booking = () => {
+interface BookingProps {
+  updateData: CongressInfo | null;
+}
+
+const Booking = ({ updateData }: BookingProps) => {
   const { selectBookingDate } = useSelector((state: RootState) => state.booking);
   const {
     watch,
@@ -71,13 +80,12 @@ const Booking = () => {
   const { data: myInfoData } = useGetMypageInfoQuery();
   const { data: congressRoomData } = useGetCongressRoomListQuery();
   const { data: categoryData } = useGetCategoryListQuery();
-  const { data: congressData } = useGetWorkspaceCongressQuery({ cgsid: Number(id) || null });
   const isEditable = ['owner', 'admin'].includes(myInfoData?.myInfo.role);
-  const mutation = usePostWorkspaceCongressQuery();
+  const createMutation = usePostWorkspaceCongressQuery();
+  const updateMutation = usePatchWorkspaceCongressQuery();
   // 시간 선택시 roomId, date, startDt 값이 필요해서 해당 값들은 실시간 추적이 가능하도록 함.
   const RoomId = useWatch({ control, name: 'RoomId' });
   const startDt = useWatch({ control, name: 'startDt' });
-  // selectBookingDate 설정시 값이 초기화 되는 문제가 있어서 제목, 카테고리, 종료 시간, 참석자, 상세 내용도 추적이 가능하게 함
   const endDt = useWatch({ control, name: 'endDt' });
 
   // 모든 필드의 값을 감시
@@ -95,14 +103,26 @@ const Booking = () => {
   const onSubmit = (data) => {
     const mappedAttendMemberList = data.attendMemberList.map((memberId) => ({ MemberId: memberId }));
 
-    mutation.mutate({
-      ...data,
-      attendMemberList: mappedAttendMemberList,
-      CongressCategoryId: Number(data.CongressCategoryId),
-      RoomId: Number(data.RoomId),
-      startDt: data.startDt.value,
-      endDt: data.endDt.value,
-    });
+    if (mode === 'edit') {
+      updateMutation.mutate({
+        cgsid: Number(id),
+        ...data,
+        attendMemberList: mappedAttendMemberList,
+        CongressCategoryId: Number(data.CongressCategoryId),
+        RoomId: Number(data.RoomId),
+        startDt: data.startDt.value,
+        endDt: data.endDt.value,
+      });
+    } else {
+      createMutation.mutate({
+        ...data,
+        attendMemberList: mappedAttendMemberList,
+        CongressCategoryId: Number(data.CongressCategoryId),
+        RoomId: Number(data.RoomId),
+        startDt: data.startDt.value,
+        endDt: data.endDt.value,
+      });
+    }
   };
 
   const handleClickAddMeetingRoom = () => {
@@ -115,32 +135,32 @@ const Booking = () => {
 
   useEffect(() => {
     // 회의 수정하는 경우, 기존 회의 정보를 가져와서 저장
-    if (congressData?.congress && mode === 'edit') {
-      const mappedAttendMemberObj = congressData?.congress?.attendTeamList.reduce((acc, val) => {
+    if (updateData && mode === 'edit') {
+      const mappedAttendMemberObj = updateData?.attendTeamList.reduce((acc, val) => {
         acc[val.teamName] = val.memberList;
         return acc;
       }, {});
 
       reset({
-        congressTitle: congressData?.congress?.congressTitle,
-        CongressCategoryId: congressData?.congress?.congressCategory.CongressCategoryId,
-        RoomId: congressData?.congress?.congressRoom.RoomId,
-        date: congressData?.congress?.date,
+        congressTitle: updateData?.congressTitle,
+        CongressCategoryId: updateData?.congressCategory.CongressCategoryId,
+        RoomId: updateData?.congressRoom.RoomId,
+        date: updateData?.date,
         startDt: {
-          name: dayjs(congressData.congress.startDt).format('A HH:mm'),
-          value: congressData.congress.startDt,
+          name: dayjs(updateData.startDt).format('A HH:mm'),
+          value: updateData.startDt,
         },
         endDt: {
-          name: dayjs(congressData.congress.endDt).format('A HH:mm'),
-          value: congressData.congress.endDt,
+          name: dayjs(updateData.endDt).format('A HH:mm'),
+          value: updateData.endDt,
         },
-        congressDescription: congressData?.congress?.congressDescription,
+        congressDescription: updateData?.congressDescription,
       });
 
       dispatch(saveSelectBookingMemberObj(mappedAttendMemberObj));
-      dispatch(saveSelectBookingDate(congressData?.congress?.date));
+      dispatch(saveSelectBookingDate(updateData?.date));
     }
-  }, [congressRoomData?.congressRoomList, categoryData?.congressCategoryList, congressData?.congress]);
+  }, [updateData]);
 
   return (
     <MainLayout isScroll>
@@ -184,7 +204,7 @@ const Booking = () => {
                         value={item.RoomId}
                         onChange={field.onChange}
                         {...(mode === 'edit' && {
-                          checked: field.value === congressData?.congress.congressRoom.RoomId,
+                          defaultChecked: item.RoomId === updateData?.congressRoom.RoomId,
                         })}
                       />
                     )}
@@ -217,7 +237,7 @@ const Booking = () => {
                         value={item.CongressCategoryId}
                         onChange={field.onChange}
                         {...(mode === 'edit' && {
-                          checked: field.value === congressData?.congress.congressCategory.CongressCategoryId,
+                          defaultChecked: item.CongressCategoryId === updateData?.congressCategory.CongressCategoryId,
                         })}
                       />
                     )}
@@ -320,6 +340,36 @@ const Booking = () => {
 };
 
 export default Booking;
+
+export const getServerSideProps = (async (context: GetServerSidePropsContext) => {
+  // Fetch data from external API
+  const { id, mode } = context.query;
+  const cookie = context.req ? context.req.headers.cookie : '';
+
+  axios.defaults.headers.common.cookie = '';
+  if (context.req && cookie) {
+    axios.defaults.headers.common.cookie = cookie;
+  }
+
+  if (mode === 'edit') {
+    try {
+      const workspaceListResponse = await clientInstance.get(`/v1/workspace/list`);
+      const workspaceId = workspaceListResponse?.data.workspaceList[0]?.WorkspaceId;
+      const workspaceCongressResponse = await clientInstance.get(`/v1/workspace/@${workspaceId}/congress`, {
+        params: {
+          cgsid: id,
+        },
+      });
+
+      return { props: { updateData: workspaceCongressResponse.data.congress } };
+    } catch (error) {
+      console.error(error);
+      return { props: { updateData: null } };
+    }
+  }
+
+  return { props: { updateData: null } };
+}) satisfies GetServerSideProps<{ updateData: CongressInfo | null }>;
 
 const Styles = stylex.create({
   container: {


### PR DESCRIPTION
# 발생한 문제 및 해결 내용
## 문제1. 시간 혹은 날짜를 변경할 때, 기존에 선택했던 장소와 카테고리가 수정 전 값으로 초기화되는 문제
- 카테고리 및 장소에 불러온 데이터를 적용할 때, checked가 onChange 함수로 변경된 값을 계속 반영해서 발생한 문제였음.
- defaultCheck를 사용해서 맨 처음 렌더링 때만 이전에 선택했었던 데이터를 유지하고, 그 외에는 사용자가 선택한 데이터가 계속 유지되게 하고 싶었음.
- 그러나 클라이언트 사이드로 요청한 회의 데이터가 처음에 undefined로 들어오는 문제때문에 defulatCheck가 제대로 동작하지 못했음.
- 그래서 getServerSideProps에서 회의 데이터를 요청해서 보여주는 방식으로 수정함. 이후에는 defaultCheck를 정상적으로 사용할 수 있었음.

## 문제2. 회의실 변경 후 시간이 유지되는 문제
- 회의실을 변경하면 시간이 초기화되게 수정함.
- 시간 선택이 불가능한 경우에는 다음과 같은 문구가 보여지도록 함. 이미 구현했던 기능인데 시간을 전달하는 배열 데이터 길이를 체크하지 않고, 배열 존재 여부를 체크하고 있어서 해당 문구가 보여지지 않았음.
   <img width="774" height="518" alt="image" src="https://github.com/user-attachments/assets/bbd8bd88-3703-4c64-b937-e083468abb9b" />

## 문제3. 시간대 변경하여 수정하였는데 기존 회의가 남아있고, 수정된 회의 클릭 시 시간만 변경되고 회의실 변경은 반영이 안되는 문제
- 회의 수정 데이터를 제출하는 부분을 구현하지 않아서 발생한 문제였음. 수정 상태에 대해 분기처리 하지 않고 모두 post로 요청하고 있었음.
- React-query를 사용하여 회의를 수정하는 커스텀 훅을 구현하여 수정 요청을 정상적으로 전달할 수 있게 구현함.

## 문제4. BottomSheet가 열렸을 떄, MainLayout 부분의 스크롤이 계속 유지되는 문제
- BottomSheet가 열렸을 때는 MainLayout 부분의 세로 스크롤이 사라져야하는데 계속 유지되어서 아래 이미지와 같이 동작하는 문제가 있었음.
    <img width="784" height="819" alt="image" src="https://github.com/user-attachments/assets/71ce9a1d-2b2b-4ab9-9c4e-04b2cd15095a" />

- 그래서 BottonSheet가 열렸을 때 MainLayout 스크롤이 hidden 상태로 되게 하고, 닫혔을 때는 auto상태로 변경되게 함.