### PR TITLE
Fix(RT-51): 헤더의 뒤로가기 버튼 클릭시 이전 경로로 이동하지 않고 홈으로 이동하는 문제 해결

### DIFF
--- a/src/hooks/useBackNavigation.tsx
+++ b/src/hooks/useBackNavigation.tsx
@@ -1,29 +1,27 @@
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-
 /**
  * 직전 페이지로 이동하거나 홈 페이지로 이동하는 함수를 반환하는 커스텀 훅
  */
 const useBackNavigation = () => {
   const router = useRouter();
 
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      sessionStorage.setItem('previousPath', url);
+    };
+
+    router.events.on('routeChangeStart', handleRouteChange);
+    return () => router.events.off('routeChangeStart', handleRouteChange);
+  }, [router]);
+
   const goBackOrHome = () => {
-    const referer = sessionStorage.getItem('referer');
-
-    const allowedDomains = [
-      process.env.NEXT_PUBLIC_FRONTEND_URL, // 환경변수로 관리
-    ].filter(Boolean);
-
-    const isInternalReferrer = referer && allowedDomains.some((domain) => referer.includes(domain));
-
-    const hasHistory = window.history.length > 1;
-
-    const canGoBack = router.asPath !== router.pathname || hasHistory;
-
-    if (isInternalReferrer && canGoBack) {
-      router.back();
-    } else {
-      router.push('/home');
+    const previousPath = sessionStorage.getItem('previousPath');
+    if (!previousPath) {
+      return router.push('/home');
     }
+
+    return router.back();
   };
 
   return { goBackOrHome };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,20 +7,10 @@ export async function middleware(request: NextRequest) {
   let refreshToken = request.cookies.get('refresh_token');
   let isRefreshToken = request.cookies.has('refresh_token');
   let isAccessToken = request.cookies.has('access_token');
-  const referer = request.headers.get('referer');
   const response = NextResponse.next();
 
   const path = request.nextUrl.pathname;
   const prevUrl = `${process.env.NEXT_PUBLIC_FRONTEND_URL}${request.nextUrl.pathname}${request.nextUrl.search}`; // 로그인 페이지 이전에 있었던 url
-
-  if (referer) {
-    response.cookies.set('page_referer', referer, {
-      httpOnly: false, // 클라이언트에서 접근 가능하게 함.
-      sameSite: 'lax',
-    });
-  } else {
-    response.cookies.delete('page_referer');
-  }
 
   if (isRefreshToken) {
     if (['/login', '/'].includes(path)) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -47,24 +47,6 @@ export default function App({ Component, pageProps }: AppProps) {
   // 로케일 설정
   dayjs.locale('ko');
 
-  // sessionStorage에 referer 저장
-  useEffect(() => {
-    const tempReferer = document.cookie
-      .split('; ')
-      .find((row) => row.startsWith('page_referer='))
-      ?.split('=')[1];
-
-    if (tempReferer) {
-      sessionStorage.setItem('referer', decodeURIComponent(tempReferer));
-
-      // 쿠키 삭제
-      document.cookie = 'page_referer=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-    } else {
-      // 외부 페이지로 부터 온 경우, 세션 스토리지에 저장되어 있던 기존 referer 삭제
-      sessionStorage.removeItem('referer');
-    }
-  }, [router.asPath]);
-
   return (
     <QueryClientProvider client={queryClient}>
       <HydrationBoundary state={pageProps.dehydratedState}>


### PR DESCRIPTION
# 발생한 문제 및 해결 내용
- 페이지를 이동하면서 쿠키에 저장했던 page_referer가 사라지면서 sessionStorage에도 경로가 제대로 저장되지 않는 문제가 발생했음. 이에 따라 '마이페이지 > 워크스페이스 정보 > 멤버'순으로 거쳐왔을 때 뒤로가기를 누르면 거꾸로 이동하지 않고 홈으로 바로 이동해버리는 문제가 발생함.

- 기존에는 구체적인 referrer 값을 구해서 홈 이동 혹은 router.back() 이동을 처리하려고 했음. 
   그러나 referrer 값이 꼭 필요한 것이 아니라 내부 사이트 이동인지, 외부에서 직접 접근해서 온 것인지 구별만 하면 되었기 때문에 이 부분에 대해 초점을 맞추고 문제를 해결하려고 했음.

- 그래서 routeChangeStart 이벤트로 현재 경로를 sessionStorage에 저장되게 수정함.

- useEffect안에 routeChangeStart를 추가하고 dependency 안에 router 를 넣은 코드를 작성했을 때, 외부 사이트에서 오렌지보드로 접근하면 routeChangeStart에 등록한 코드가 실행되지 않고 직접적으로 router 이동이 발생했을 때만 코드가 실행하게 됨.

- 그러면 외부에서 룸렛에 접근했을 때만 세션스토리지의previousPath값이 null이기 때문에, 내부 사이트 이동과 구별할 수 있게 되어 외부에서 접근한 경우에는 뒤로가기 클릭시 홈으로 이동시킬 수 있게 됨.

# 추가 고려 사항
- 외부 페이지에서 룸렛으로 이동해온 상태에서 헤더의 뒤로가기를 누르면 다시 외부 페이지로 이동시키는 게 맞는지, 아니면 룸렛으로 이동시키는 게 맞는지 잘 모르겠음. 
   seo 환경에서는 따로 홈으로 이동하는 버튼을 헤더에 추가해주고, 뒤로가기 버튼을 클릭하면 브라우저 히스토리에 쌓인대로 이동시키는 게 맞는 것 같은데 우리 사이트는 로그인한 사람만 이용할 수 있고, 헤더에 홈으로 이동하는 아이콘을 넣는 것도 마땅치 않다고 생각함. 
   그래서 이런 경우에는 뒤로가기를 누르면 홈으로 이동시키는 게 맞다고 생각했는데 기획자님과 추가 논의가 필요한 것 같음.