### PR TITLE
Fix(RT-57): 프로필 이미지 등록시 1MB 이하로 이미지 용량 압축 및 뮤테이션 상태에 따라 보여지는 토스트 메시지 구현

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@stylexjs/stylex": "^0.4.1",
         "@tanstack/react-query": "^5.59.15",
         "axios": "^1.7.2",
+        "browser-image-compression": "^2.0.2",
         "dayjs": "^1.11.10",
         "jwt-decode": "^4.0.0",
         "next": "^14.0.4",
@@ -3098,6 +3099,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -7314,6 +7323,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/warning": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@stylexjs/stylex": "^0.4.1",
     "@tanstack/react-query": "^5.59.15",
     "axios": "^1.7.2",
+    "browser-image-compression": "^2.0.2",
     "dayjs": "^1.11.10",
     "jwt-decode": "^4.0.0",
     "next": "^14.0.4",

--- a/src/components/icons/CircleFailFilled.tsx
+++ b/src/components/icons/CircleFailFilled.tsx
@@ -1,0 +1,17 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+
+const CircleFailFilled: FC<IconProps> = (props) => {
+  const { width, height } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <path
+        fill="#D14444"
+        d="M12 2C6.429 2 2 6.429 2 12s4.429 10 10 10 10-4.429 10-10S17.571 2 12 2m3.857 15L12 13.143 8.143 17 7 15.857 10.857 12 7 8.143 8.143 7 12 10.857 15.857 7 17 8.143 13.143 12 17 15.857z"
+      />
+    </svg>
+  );
+};
+
+export default CircleFailFilled;

--- a/src/components/icons/Spinner.tsx
+++ b/src/components/icons/Spinner.tsx
@@ -1,0 +1,38 @@
+import React, { FC } from 'react';
+import { IconProps } from './types';
+import stylex from '@stylexjs/stylex';
+
+interface SpinnerProps {
+  spin?: boolean;
+}
+
+const Spinner: FC<IconProps & SpinnerProps> = (props) => {
+  const { width, height, spin } = props;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} fill="none" {...props}>
+      <path
+        {...stylex.props(spin && Styles.SpinnerIcon)}
+        fill="#E3E3E3"
+        d="M19.333 11.997A7.333 7.333 0 1 1 12 4.664v1.333a6 6 0 1 0 6 6z"
+      />
+    </svg>
+  );
+};
+
+export default Spinner;
+
+const spinning = stylex.keyframes({
+  '0%': { transform: 'rotate(0deg)' },
+  '100%': { transform: 'rotate(360deg)' },
+});
+
+const Styles = stylex.create({
+  SpinnerIcon: {
+    animationName: spinning,
+    animationDuration: '1s',
+    animationTimingFunction: 'linear',
+    animationIterationCount: 'infinite',
+    transformOrigin: '50% 50%',
+  },
+});

--- a/src/components/ui/Toast/index.tsx
+++ b/src/components/ui/Toast/index.tsx
@@ -4,28 +4,34 @@ import styles from './styles/styles.module.css';
 import { Typography } from '../../../../public/styles/vars.stylex';
 import stylex from '@stylexjs/stylex';
 import CircleCheckmarkFilled from '@src/components/icons/CircleCheckmarkFilled';
+import CircleFailFilled from '@src/components/icons/CircleFailFilled';
+import Spinner from '@src/components/icons/Spinner';
 
 interface ToastProps {
   message: string;
+  type?: 'success' | 'pending' | 'error';
 }
 
-const MessageContent: FC<ToastProps> = (props) => {
-  const { message } = props;
+export const ToastContent: FC<ToastProps> = (props) => {
+  const { message, type } = props;
+  const typeIcon = {
+    success: <CircleCheckmarkFilled width={24} height={24} />,
+    pending: <Spinner width={24} height={24} spin />,
+    error: <CircleFailFilled width={24} height={24} />,
+  };
 
   return (
     <div {...stylex.props(Styles.Message, Typography.TextSmallMedium)}>
-      <div {...stylex.props(Styles.IconWrapper)}>
-        <CircleCheckmarkFilled width={24} height={24} />
-      </div>
+      <div {...stylex.props(Styles.IconWrapper)}>{typeIcon[type]}</div>
       <span>{message}</span>
     </div>
   );
 };
 
 const Toast: FC<ToastProps> = (props) => {
-  const { message } = props;
+  const { message, type = 'success' } = props;
 
-  return toast(<MessageContent message={message} />, {
+  return toast(<ToastContent message={message} type={type} />, {
     position: 'bottom-center',
     autoClose: 1500,
     closeButton: false,

--- a/src/components/ui/Toast/styles/styles.module.css
+++ b/src/components/ui/Toast/styles/styles.module.css
@@ -1,5 +1,6 @@
 .toast-container {
-  width: fit-content;
+  width: 100%;
+  max-width: 328px;
   margin: 16px;
   padding: 1.6rem;
   border-radius: 1.2rem;

--- a/src/components/ui/Toast/styles/styles.module.css
+++ b/src/components/ui/Toast/styles/styles.module.css
@@ -1,6 +1,6 @@
 .toast-container {
-  width: 100%;
-  max-width: 328px;
+  width: 328px;
+  max-width: calc(100% - 32px);
   margin: 16px;
   padding: 1.6rem;
   border-radius: 1.2rem;

--- a/src/features/mypage/compontents/MyPageImgUpload/index.tsx
+++ b/src/features/mypage/compontents/MyPageImgUpload/index.tsx
@@ -2,6 +2,7 @@ import React, { FC, useRef, useState } from 'react';
 import stylex from '@stylexjs/stylex';
 import ProfileImg from '@src/components/ui/ProfileImg';
 import PhotoFilled from '@src/components/icons/PhotoFilled';
+import imageCompression from 'browser-image-compression';
 
 type MyPageImgUploadProps = {
   onSelect: (file: Blob) => void;
@@ -15,7 +16,6 @@ type MyPageImgUploadProps = {
 const MyPageImgUpload: FC<MyPageImgUploadProps> = (props) => {
   const { onSelect, initialImgUrl } = props;
 
-  const [profileImg, setProfileImg] = useState<string>('');
   const [imgUrl, setImgUrl] = useState<string | null>(null);
   const imageUploadRef = useRef(null);
 
@@ -23,11 +23,16 @@ const MyPageImgUpload: FC<MyPageImgUploadProps> = (props) => {
     imageUploadRef.current.click();
   };
 
-  const handleLoadFile = (e) => {
+  const handleLoadFile = async (e) => {
+    let compressionFile = null;
     const file = e.target.files;
     const fileType = file['0']?.type;
     const fileSize = file['0']?.size && file['0'].size;
     const limitSize = 5 * 1024 ** 2; // 파일 용량 제한은 5MB
+    const options = {
+      maxSizeMB: 1, // 서버에서 이미지 업로드시 최대 용량으로 1MB 제한
+      initialQuality: 0.7,
+    };
 
     if (!file['0']) {
       return false;
@@ -40,8 +45,8 @@ const MyPageImgUpload: FC<MyPageImgUploadProps> = (props) => {
 
         reader.onload = () => setImgUrl(reader.result as string); // string 타입의 base64 형식
         reader.readAsDataURL(file['0']);
-        setProfileImg(file);
-        onSelect(file['0']);
+        compressionFile = await imageCompression(file['0'], options);
+        onSelect(compressionFile);
       }
     } else {
       alert('이미지 파일만 등록이 가능합니다.');

--- a/src/features/mypage/profile/queries/usePatchMypageInfoQuery.tsx
+++ b/src/features/mypage/profile/queries/usePatchMypageInfoQuery.tsx
@@ -1,6 +1,7 @@
 import { confirm } from '@src/components/ui/Modal/confirm';
 import Toast from '@src/components/ui/Toast';
 import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useMutationWithToast from '@src/hooks/react-query/useMutationWithToast';
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 import clientInstance from '@src/utils/api/clientInstance';
 
@@ -28,21 +29,18 @@ const usePatchMypageInfoQuery = () => {
 
   const mutation = useCustomMutation({
     mutationFn: (data: FormData) => patchMypageInfoApi(workspaceId, data),
-    onSuccess: () => {
-      Toast({ message: '프로필 수정이 완료되었습니다.' });
-    },
-    onError: (error, variables, context) => {
-      const errorCode = error?.status;
+  });
 
-      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
-      confirm({
-        content:
-          error?.response.data.message.errMsg || `프로필 수정에 실패했습니다.\n(server error code: ${errorCode})`,
-      });
+  const { mutateWithToast } = useMutationWithToast({
+    mutation,
+    message: {
+      pending: '프로필 수정중입니다',
+      success: '프로필 수정이 완료되었습니다.',
+      error: '프로필 수정에 실패했습니다.',
     },
   });
 
-  return mutation;
+  return { ...mutation, mutateWithToast };
 };
 
 export default usePatchMypageInfoQuery;

--- a/src/features/mypage/profile/queries/usePatchMypageProfileQuery.tsx
+++ b/src/features/mypage/profile/queries/usePatchMypageProfileQuery.tsx
@@ -1,5 +1,6 @@
 import { confirm } from '@src/components/ui/Modal/confirm';
 import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useMutationWithToast from '@src/hooks/react-query/useMutationWithToast';
 import clientInstance from '@src/utils/api/clientInstance';
 
 interface WorkspaceInfo {
@@ -32,13 +33,17 @@ const patchMypageProfileApi = async (data: FormData): Promise<WorkspaceInfo> => 
 const usePatchMypageProfileQuery = () => {
   const mutation = useCustomMutation({
     mutationFn: (data: FormData) => patchMypageProfileApi(data),
-    onError: (error, variables, context) => {
-      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
-      confirm({ content: error?.response.data.message.errMsg });
-    },
   });
 
-  return mutation;
+  const { mutateWithToast } = useMutationWithToast({
+    mutation,
+    message: {
+      pending: '프로필 수정중입니다',
+      success: '프로필 수정이 완료되었습니다.',
+      error: '프로필 수정에 실패했습니다.',
+    },
+  });
+  return { ...mutation, mutateWithToast };
 };
 
 export default usePatchMypageProfileQuery;

--- a/src/features/workspace/queries/usePatchWorkspaceInfoQuery.tsx
+++ b/src/features/workspace/queries/usePatchWorkspaceInfoQuery.tsx
@@ -1,6 +1,7 @@
 import { confirm } from '@src/components/ui/Modal/confirm';
 import Toast from '@src/components/ui/Toast';
 import useCustomMutation from '@src/hooks/react-query/useCustomMutation';
+import useMutationWithToast from '@src/hooks/react-query/useMutationWithToast';
 import useGetWorkspaceListQuery from '@src/queries/workspace/useGetWorkspaceListQuery';
 import clientInstance from '@src/utils/api/clientInstance';
 
@@ -38,21 +39,17 @@ const usePatchWorkspaceInfoQuery = () => {
 
   const mutation = useCustomMutation({
     mutationFn: (data: FormData) => patchWorkspaceInfoApi(workspaceId, data),
-    onSuccess: () => {
-      Toast({ message: '워크스페이스 정보 수정이 완료되었습니다.' });
-    },
-    onError: (error, variables, context) => {
-      const errorCode = error?.status;
-      // 에러가 발생한 경우, 에러 내용이 담긴 confirm 모달 띄우기
-      confirm({
-        content:
-          error?.response.data.message.errMsg ||
-          `워크스페이스 정보 수정에 실패했습니다.\n(server error code: ${errorCode})`,
-      });
-    },
   });
 
-  return mutation;
+  const { mutateWithToast } = useMutationWithToast({
+    mutation,
+    message: {
+      pending: '워크스페이스 정보 수정중입니다',
+      success: '워크스페이스 정보 수정이 완료되었습니다.',
+      error: '워크스페이스 정보 수정에 실패했습니다.',
+    },
+  });
+  return { ...mutation, mutateWithToast };
 };
 
 export default usePatchWorkspaceInfoQuery;

--- a/src/hooks/react-query/useMutationWithToast.tsx
+++ b/src/hooks/react-query/useMutationWithToast.tsx
@@ -1,0 +1,65 @@
+import { CustomAxiosError } from '@src/types/axios/error';
+import { UseMutationResult } from '@tanstack/react-query';
+import styles from '@src/components/ui/Toast/styles/styles.module.css';
+import { Slide, toast } from 'react-toastify';
+import { ToastContent } from '@src/components/ui/Toast';
+
+interface MutationWithToastProps<TData, TError, TVariables> {
+  mutation: UseMutationResult<TData, TError, TVariables>;
+  message: {
+    pending: string;
+    success: string;
+    error: string;
+  };
+}
+
+/**
+ * 뮤테이션 상태에 따라 토스트 메시지를 표시하는 커스텀 훅
+ * @param mutation - 뮤테이션 객체
+ * @param message - 토스트 메시지 객체
+ * @returns - 뮤테이션 상태에 따라 토스트 메시지를 표시하는 함수
+ */
+const useMutationWithToast = <TData, TError, TVariables>({
+  mutation,
+  message,
+}: MutationWithToastProps<TData, TError, TVariables>) => {
+  const mutateWithToast = (data: TVariables) => {
+    toast.promise(
+      mutation.mutateAsync(data),
+      {
+        pending: {
+          render: () => <ToastContent message={message.pending} type="pending" />,
+          icon: false,
+        },
+        success: {
+          render: () => <ToastContent message={message.success} type="success" />,
+          icon: false,
+        },
+        error: {
+          render: ({ data: error }: { data: CustomAxiosError }) => {
+            const errorCode = error?.status;
+            const errorMessage = error?.response?.data?.message?.errMsg || `${message.error} (code: ${errorCode})`;
+            return <ToastContent message={errorMessage} type="error" />;
+          },
+          icon: false,
+        },
+      },
+      {
+        position: 'bottom-center',
+        autoClose: 1500,
+        closeButton: false,
+        hideProgressBar: true,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        progress: undefined,
+        className: styles['toast-container'],
+        transition: Slide, // Bounce, Slide, Zoom, Flip, Fade
+      }
+    );
+  };
+
+  return { mutateWithToast };
+};
+
+export default useMutationWithToast;

--- a/src/pages/mypage/profile.tsx
+++ b/src/pages/mypage/profile.tsx
@@ -52,7 +52,7 @@ const MyPageProfile = () => {
         formData.append('image', imageFile);
       }
 
-      myPageInfoMutation.mutate(formData);
+      myPageInfoMutation.mutateWithToast(formData);
     },
   };
   const profileCompleteBtnProps = {
@@ -62,9 +62,12 @@ const MyPageProfile = () => {
       const formData = new FormData();
 
       formData.append('displayName', displayName);
-      formData.append('image', imageFile);
 
-      myPageProfileMutation.mutate(formData);
+      if (imageFile) {
+        formData.append('image', imageFile);
+      }
+
+      myPageProfileMutation.mutateWithToast(formData);
     },
   };
 

--- a/src/pages/mypage/profile.tsx
+++ b/src/pages/mypage/profile.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import Header from '@src/components/ui/Header';
-import GnbNavLayout from '@src/layouts/GnbNavLayout';
 import stylex from '@stylexjs/stylex';
 import { colors } from '../../../public/styles/vars.stylex';
 import BoundaryArea from '@src/components/ui/BoundaryArea';
@@ -16,6 +15,7 @@ import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfo
 import { RootState } from '@src/store';
 import useGetMyPageProfileQuery from '@src/features/mypage/profile/queries/useGetMyPageProfileQuery';
 import usePatchMypageProfileQuery from '@src/features/mypage/profile/queries/usePatchMypageProfileQuery';
+import MainLayout from '@src/layouts/MainLayout';
 
 const MyPageProfile = () => {
   const { isWorkspace } = useSelector((state: RootState) => state.workspace);
@@ -72,7 +72,7 @@ const MyPageProfile = () => {
   };
 
   return (
-    <GnbNavLayout backgroundColor={colors.white500}>
+    <MainLayout backgroundColor={colors.white500}>
       <Header title="프로필 수정" rightBtnInfo={isWorkspace ? myInfoCompleteBtnProps : profileCompleteBtnProps} />
 
       {/* 이미지 업로드 및 이름 입력 */}
@@ -89,7 +89,7 @@ const MyPageProfile = () => {
 
       {/* 개인 정보 리스트 */}
       <ProfilePersonalDataList dataList={dataList} title="기타 설정" />
-    </GnbNavLayout>
+    </MainLayout>
   );
 };
 

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -67,7 +67,7 @@ const WorkspaceHome = () => {
                           formData.append('image', workspaceImgFile);
                         }
 
-                        mutation.mutate(formData);
+                        mutation.mutateWithToast(formData);
                       },
                     }
                   : { isActive: false, onClick: null }),


### PR DESCRIPTION
# 문제 상황
- 배포 환경에서 프로필 or 워크스페이스 정보에서 이미지 변경 시도시 413 Request Entity Too large 에러가 발생함. 
   <img width="881" height="334" alt="image" src="https://github.com/user-attachments/assets/e64589ca-5fab-42bd-b2e1-4f501869609f" />

# 문제가 발생한 이유
- 서버에서 1MB 미만의 사이즈를 가진 이미지만 등록이 가능하도록 해서 발생한 문제였음.

# 문제 해결 방법
- browser-image-compression 라이브러리를 사용하여 1MB 로 이미지 용량을 압축하여 서버로 데이터를 전송하니 문제가 해결됨.
- 그러나 이미지 변경이 완료되기 까지 로딩시간이 조금 걸려서 사용자가 이미지 완료를 미처 확인하지 못하고 화면을 벗어나거나 이미지가 제대로 등록이 되지 않는다는 오류로 인지할 가능성이 높았음. 
- 그래서 react-toastify의 toast.promise를 사용하여 react-query의 mutation 상태에 따라 로딩중, 완료, 에러 상태를 표현할 수 있게 함.
   ![프로필 수정](https://github.com/user-attachments/assets/f9039796-57dd-4b7e-af85-4ab88fe421c4)
   - 이 기능을 구현하기 위해 useMutationWithToast라는 커스텀 훅을 만듦.

# 기타 작업
- 기존 프로필 페이지 디자인 시안에 GNB가 존재하지 않았는데, 착각하여 GNB 레이아웃으로 구성했었음. MainLayout 컴포넌트를 사용하여 GNB 메뉴를 없애줌.
- 토스트 메시지 박스가 고정값으로 328px로 표현되어야 하는데, 메시지 길이에 맞게 메시지 박스 크기가 정해지게 했었음. 그래서 고정 너비로 328px을 하되, 화면 너비가 360px 미만이 되면 calc(100% - 32px)로 반응형으로 너비가 적용되게 함. 
   - 참고로 화면 너비 기준이 360px 인 이유는 디자인상에서 최소 화면 너비 360px 기준으로 토스트 메시지 박스가 만들어졌기 때문임.
   