### PR TITLE
Feat(RT-12): 모든 페이지에 SEOHead 컴포넌트 추가

### DIFF
--- a/src/features/reservation/components/ReservationInfo/index.tsx
+++ b/src/features/reservation/components/ReservationInfo/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import stylex from '@stylexjs/stylex';
 import { colors, Typography } from '../../../../../public/styles/vars.stylex';
 import ProfileImg from '@src/components/ui/ProfileImg';
-import useGetWorkspaceCongressQuery from '../../queries/useGetWorkspaceCongressQuery';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
@@ -11,11 +10,11 @@ import PencilOutlined from '@src/components/icons/PencilOutlined';
 import TrashcanOutlined from '@src/components/icons/TrashcanOutlined';
 import { confirm } from '@src/components/ui/Modal/confirm';
 import useDeleteCongressQuery from '../../queries/useDeleteCongressQuery';
+import { CongressInfo } from '../../queries/useGetWorkspaceCongressQuery';
 
-const ReservationInfo = () => {
+const ReservationInfo = ({ data }: { data: { congress: CongressInfo } }) => {
   const router = useRouter();
   const { id } = router.query;
-  const { data } = useGetWorkspaceCongressQuery({ cgsid: Number(id) });
   const mutation = useDeleteCongressQuery();
 
   const dropdownMenuList = [

--- a/src/pages/alarm.tsx
+++ b/src/pages/alarm.tsx
@@ -1,4 +1,5 @@
 import Header from '@src/components/ui/Header';
+import SEOHead from '@src/components/ui/SEOHead';
 import AlarmCategoryList from '@src/features/alarm/components/AlarmCategoryList';
 import AlarmList from '@src/features/alarm/components/AlarmList';
 import { AlarmCategoryProvider } from '@src/features/alarm/contexts/AlarmCategoryContext';
@@ -17,16 +18,20 @@ const Alarm = () => {
 
   // 컨텍스트로 알림 카테고리 관리하기
   return (
-    <MainLayout isScroll>
-      <Header title="알림" rightBtnInfo={readAllBtnProps} />
-      <AlarmCategoryProvider>
-        {/* 알림 카테고리 */}
-        <AlarmCategoryList />
+    <>
+      <SEOHead title="알림 | 룸렛" description="룸렛의 알림 페이지입니다." url={{ pathname: '/alarm' }} />
 
-        {/* 알림 리스트 */}
-        <AlarmList />
-      </AlarmCategoryProvider>
-    </MainLayout>
+      <MainLayout isScroll>
+        <Header title="알림" rightBtnInfo={readAllBtnProps} />
+        <AlarmCategoryProvider>
+          {/* 알림 카테고리 */}
+          <AlarmCategoryList />
+
+          {/* 알림 리스트 */}
+          <AlarmList />
+        </AlarmCategoryProvider>
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/booking.tsx
+++ b/src/pages/booking.tsx
@@ -30,6 +30,7 @@ import usePatchWorkspaceCongressQuery from '@src/features/booking/queries/usePat
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import clientInstance from '@src/utils/api/clientInstance';
 import axios from 'axios';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const BookingMemberSelect = dynamic(() => import('@src/features/booking/components/BookingMemberSelect'), {
   ssr: false,
@@ -164,188 +165,192 @@ const Booking = ({ updateData }: BookingProps) => {
   }, [updateData]);
 
   return (
-    <MainLayout isScroll>
-      <Header title="예약하기" />
+    <>
+      <SEOHead title="예약하기 | 룸렛" description="룸렛의 예약하기 페이지입니다." url={{ pathname: '/booking' }} />
 
-      {/* 예약하기 폼 */}
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <div {...stylex.props(Styles.container)}>
-          {/* 회의 타이틀 */}
-          <BookingFormItem label="회의 타이틀" required>
-            <Controller
-              name="congressTitle"
-              control={control}
-              defaultValue=""
-              rules={{ required: '회의 타이틀을 입력해주세요' }}
-              render={({ field }) => (
-                <BookingTextInput
-                  placeholder="회의 타이틀을 입력해주세요."
-                  value={field.value}
-                  onChange={field.onChange}
-                />
-              )}
-            />
-          </BookingFormItem>
+      <MainLayout isScroll>
+        <Header title="예약하기" />
 
-          {/* 카테고리 */}
-          <BookingFormItem label="카테고리" required>
-            <div {...stylex.props(Styles.RadioBtnContainer)}>
-              {React.Children.toArray(
-                categoryData?.congressCategoryList.map((item) => (
-                  <Controller
-                    name="CongressCategoryId"
-                    control={control}
-                    defaultValue={null}
-                    rules={{ required: '카테고리를 선택해주세요' }}
-                    render={({ field }) => (
-                      <Radio
-                        name="CongressCategoryId"
-                        id={item.categoryName}
-                        label={item.categoryName}
-                        value={item.CongressCategoryId}
-                        onChange={field.onChange}
-                        {...(mode === 'edit' && {
-                          defaultChecked: item.CongressCategoryId === updateData?.congressCategory.CongressCategoryId,
-                        })}
-                      />
-                    )}
-                  />
-                ))
-              )}
-              {isEditable && (
-                <button type="button" {...stylex.props(Styles.addBtn)} onClick={handleClickAddCategory}>
-                  + 추가하기
-                </button>
-              )}
-            </div>
-          </BookingFormItem>
-
-          {/* 장소 */}
-          <BookingFormItem label="장소" required>
-            <div {...stylex.props(Styles.RadioBtnContainer)}>
-              {React.Children.toArray(
-                congressRoomData?.congressRoomList.map((item) => (
-                  <Controller
-                    name="RoomId"
-                    control={control}
-                    defaultValue={null}
-                    rules={{ required: '장소를 선택해주세요' }}
-                    render={({ field }) => (
-                      <Radio
-                        name="RoomId"
-                        id={item.roomName}
-                        label={item.roomName}
-                        value={item.RoomId}
-                        onChange={(e) => {
-                          setIsUpdatedRoomId(true);
-                          setValue('startDt', null);
-                          setValue('endDt', null);
-                          field.onChange(e);
-                        }}
-                        {...(mode === 'edit' && {
-                          defaultChecked: item.RoomId === updateData?.congressRoom.RoomId,
-                        })}
-                      />
-                    )}
-                  />
-                ))
-              )}
-              {isEditable && (
-                <button type="button" {...stylex.props(Styles.addBtn)} onClick={handleClickAddMeetingRoom}>
-                  + 추가하기
-                </button>
-              )}
-            </div>
-          </BookingFormItem>
-
-          {/* 날짜 선택 */}
-          <BookingFormItem label="날짜 선택" required>
-            <Controller
-              name="date"
-              control={control}
-              defaultValue={selectBookingDate}
-              render={({ field }) => <BookingDatePicker setValue={setValue} />}
-              rules={{ required: '날짜를 선택해주세요' }}
-            />
-          </BookingFormItem>
-
-          {/* 시간 선택 */}
-          <BookingFormItem label="시간 선택" required>
-            <div {...stylex.props(Styles.TimePickerContainer)}>
+        {/* 예약하기 폼 */}
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div {...stylex.props(Styles.container)}>
+            {/* 회의 타이틀 */}
+            <BookingFormItem label="회의 타이틀" required>
               <Controller
-                name="startDt"
+                name="congressTitle"
                 control={control}
-                defaultValue={null}
-                rules={{ required: '시작 시간을 선택해주세요' }}
+                defaultValue=""
+                rules={{ required: '회의 타이틀을 입력해주세요' }}
                 render={({ field }) => (
-                  <BookingTimePicker
-                    placeholder="시작 시간"
-                    onSelect={field.onChange}
-                    roomId={RoomId}
-                    defaultValue={startDt}
-                    isUpdatedRoomId={isUpdatedRoomId}
-                    setIsUpdatedRoomId={setIsUpdatedRoomId}
+                  <BookingTextInput
+                    placeholder="회의 타이틀을 입력해주세요."
+                    value={field.value}
+                    onChange={field.onChange}
                   />
                 )}
               />
-              <span {...stylex.props(Styles.Hyphen)} />
+            </BookingFormItem>
+
+            {/* 카테고리 */}
+            <BookingFormItem label="카테고리" required>
+              <div {...stylex.props(Styles.RadioBtnContainer)}>
+                {React.Children.toArray(
+                  categoryData?.congressCategoryList.map((item) => (
+                    <Controller
+                      name="CongressCategoryId"
+                      control={control}
+                      defaultValue={null}
+                      rules={{ required: '카테고리를 선택해주세요' }}
+                      render={({ field }) => (
+                        <Radio
+                          name="CongressCategoryId"
+                          id={item.categoryName}
+                          label={item.categoryName}
+                          value={item.CongressCategoryId}
+                          onChange={field.onChange}
+                          {...(mode === 'edit' && {
+                            defaultChecked: item.CongressCategoryId === updateData?.congressCategory.CongressCategoryId,
+                          })}
+                        />
+                      )}
+                    />
+                  ))
+                )}
+                {isEditable && (
+                  <button type="button" {...stylex.props(Styles.addBtn)} onClick={handleClickAddCategory}>
+                    + 추가하기
+                  </button>
+                )}
+              </div>
+            </BookingFormItem>
+
+            {/* 장소 */}
+            <BookingFormItem label="장소" required>
+              <div {...stylex.props(Styles.RadioBtnContainer)}>
+                {React.Children.toArray(
+                  congressRoomData?.congressRoomList.map((item) => (
+                    <Controller
+                      name="RoomId"
+                      control={control}
+                      defaultValue={null}
+                      rules={{ required: '장소를 선택해주세요' }}
+                      render={({ field }) => (
+                        <Radio
+                          name="RoomId"
+                          id={item.roomName}
+                          label={item.roomName}
+                          value={item.RoomId}
+                          onChange={(e) => {
+                            setIsUpdatedRoomId(true);
+                            setValue('startDt', null);
+                            setValue('endDt', null);
+                            field.onChange(e);
+                          }}
+                          {...(mode === 'edit' && {
+                            defaultChecked: item.RoomId === updateData?.congressRoom.RoomId,
+                          })}
+                        />
+                      )}
+                    />
+                  ))
+                )}
+                {isEditable && (
+                  <button type="button" {...stylex.props(Styles.addBtn)} onClick={handleClickAddMeetingRoom}>
+                    + 추가하기
+                  </button>
+                )}
+              </div>
+            </BookingFormItem>
+
+            {/* 날짜 선택 */}
+            <BookingFormItem label="날짜 선택" required>
               <Controller
-                name="endDt"
+                name="date"
+                control={control}
+                defaultValue={selectBookingDate}
+                render={({ field }) => <BookingDatePicker setValue={setValue} />}
+                rules={{ required: '날짜를 선택해주세요' }}
+              />
+            </BookingFormItem>
+
+            {/* 시간 선택 */}
+            <BookingFormItem label="시간 선택" required>
+              <div {...stylex.props(Styles.TimePickerContainer)}>
+                <Controller
+                  name="startDt"
+                  control={control}
+                  defaultValue={null}
+                  rules={{ required: '시작 시간을 선택해주세요' }}
+                  render={({ field }) => (
+                    <BookingTimePicker
+                      placeholder="시작 시간"
+                      onSelect={field.onChange}
+                      roomId={RoomId}
+                      defaultValue={startDt}
+                      isUpdatedRoomId={isUpdatedRoomId}
+                      setIsUpdatedRoomId={setIsUpdatedRoomId}
+                    />
+                  )}
+                />
+                <span {...stylex.props(Styles.Hyphen)} />
+                <Controller
+                  name="endDt"
+                  control={control}
+                  defaultValue={null}
+                  rules={{ required: '종료 시간을 선택해주세요' }}
+                  render={({ field }) => (
+                    <BookingTimePicker
+                      placeholder="종료 시간"
+                      onSelect={field.onChange}
+                      roomId={RoomId}
+                      startDt={startDt}
+                      defaultValue={endDt}
+                      isUpdatedRoomId={isUpdatedRoomId}
+                      setIsUpdatedRoomId={setIsUpdatedRoomId}
+                    />
+                  )}
+                />
+              </div>
+            </BookingFormItem>
+
+            {/* 참석자 */}
+            <BookingFormItem label="참석자" required>
+              <Controller
+                name="attendMemberList"
                 control={control}
                 defaultValue={null}
-                rules={{ required: '종료 시간을 선택해주세요' }}
+                rules={{ required: '참석자를 선택해주세요' }}
+                render={({ field }) => <BookingMemberSelect onSelect={field.onChange} />}
+              />
+            </BookingFormItem>
+
+            {/* 상세 내용 */}
+            <BookingFormItem label="상세 내용" required>
+              <Controller
+                name="congressDescription"
+                control={control}
+                defaultValue=""
+                rules={{ required: '상세 내용을 입력해주세요' }}
                 render={({ field }) => (
-                  <BookingTimePicker
-                    placeholder="종료 시간"
-                    onSelect={field.onChange}
-                    roomId={RoomId}
-                    startDt={startDt}
-                    defaultValue={endDt}
-                    isUpdatedRoomId={isUpdatedRoomId}
-                    setIsUpdatedRoomId={setIsUpdatedRoomId}
+                  <BookingTextarea
+                    placeholder="업무에 필요한 정보를 작성해주세요"
+                    value={field.value}
+                    onChange={field.onChange}
                   />
                 )}
               />
-            </div>
-          </BookingFormItem>
+            </BookingFormItem>
+          </div>
 
-          {/* 참석자 */}
-          <BookingFormItem label="참석자" required>
-            <Controller
-              name="attendMemberList"
-              control={control}
-              defaultValue={null}
-              rules={{ required: '참석자를 선택해주세요' }}
-              render={({ field }) => <BookingMemberSelect onSelect={field.onChange} />}
-            />
-          </BookingFormItem>
-
-          {/* 상세 내용 */}
-          <BookingFormItem label="상세 내용" required>
-            <Controller
-              name="congressDescription"
-              control={control}
-              defaultValue=""
-              rules={{ required: '상세 내용을 입력해주세요' }}
-              render={({ field }) => (
-                <BookingTextarea
-                  placeholder="업무에 필요한 정보를 작성해주세요"
-                  value={field.value}
-                  onChange={field.onChange}
-                />
-              )}
-            />
-          </BookingFormItem>
-        </div>
-
-        {/* 작성 완료 버튼 */}
-        <div {...stylex.props(Styles.submitBtnWrapper)}>
-          <button type="submit" {...stylex.props(Styles.submitBtn(isAllFieldsFilled), Typography.TextSmallMedium)}>
-            작성 완료
-          </button>
-        </div>
-      </form>
-    </MainLayout>
+          {/* 작성 완료 버튼 */}
+          <div {...stylex.props(Styles.submitBtnWrapper)}>
+            <button type="submit" {...stylex.props(Styles.submitBtn(isAllFieldsFilled), Typography.TextSmallMedium)}>
+              작성 완료
+            </button>
+          </div>
+        </form>
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import dayjs from 'dayjs';
 import { useSelector } from 'react-redux';
 import { RootState } from '@src/store';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const MonthlyCalendar = dynamic(() => import('@src/features/calendar/components/MonthlyCalendar'), {
   ssr: false,
@@ -26,21 +27,25 @@ const Calendar = () => {
   };
 
   return (
-    <GnbNavLayout>
-      {/* 월간 캘린더 */}
-      <MonthlyCalendar onSelectDate={handleSelectDate} />
-      {/* 캘린더에서 선택한 날짜에 대한 회의 리스트 보는 영역 */}
-      <MeetingSchedule selectDate={selectDate} />
+    <>
+      <SEOHead title="캘린더 | 룸렛" description="룸렛의 캘린더 페이지입니다." url={{ pathname: '/calendar' }} />
 
-      {/* 예약하기 링크 (플로팅) */}
-      {isWorkspace && (
-        <div {...stylex.props(Styles.CreateReservationWrapper)}>
-          <a href="/booking">
-            <CirclePlusFilled width={56} height={56} />
-          </a>
-        </div>
-      )}
-    </GnbNavLayout>
+      <GnbNavLayout>
+        {/* 월간 캘린더 */}
+        <MonthlyCalendar onSelectDate={handleSelectDate} />
+        {/* 캘린더에서 선택한 날짜에 대한 회의 리스트 보는 영역 */}
+        <MeetingSchedule selectDate={selectDate} />
+
+        {/* 예약하기 링크 (플로팅) */}
+        {isWorkspace && (
+          <div {...stylex.props(Styles.CreateReservationWrapper)}>
+            <a href="/booking">
+              <CirclePlusFilled width={56} height={56} />
+            </a>
+          </div>
+        )}
+      </GnbNavLayout>
+    </>
   );
 };
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -10,40 +10,45 @@ import PlusOutlined from '@src/components/icons/PlusOutlined';
 import Link from 'next/link';
 import { useSelector } from 'react-redux';
 import { RootState } from '@src/store';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const Home = () => {
   const { isWorkspace } = useSelector((state: RootState) => state.workspace);
 
   return (
-    <GnbNavLayout backgroundColor="#FAFAFA">
-      {/* 프로필 섹션 */}
-      <section {...stylex.props(Styles.userGreetingSection)}>
-        {isWorkspace ? <WorkspaceUserGreeting /> : <NonWorkspaceUserGreeting />}
-      </section>
-      {/* 회의 현황 섹션 */}
-      <section {...stylex.props(Styles.meetingStatusSection)}>
-        <h2 {...stylex.props(Styles.sectionTitle)}>회의 현황</h2>
-        <MeetingStatus />
-      </section>
-      {/* 타임 라인 섹션 */}
-      <section {...stylex.props(Styles.timeLineSection)}>
-        <TimeLine />
-      </section>
+    <>
+      <SEOHead title="홈 | 룸렛" description="룸렛의 홈 페이지입니다." url={{ pathname: '/home' }} />
 
-      {/* 워크스페이스가 없는 경우 */}
-      {!isWorkspace && (
-        <div {...stylex.props(Styles.CreateWorkspaceBtnWrapper)}>
-          {/* 워크스페이스 등록하기 버튼 */}
-          <Link
-            href="/mypage/create-workspace"
-            {...stylex.props(Typography.SubtitleSmallBold, Styles.CreateWorkspaceBtn)}
-          >
-            <PlusOutlined width={24} height={24} />
-            워크스페이스 등록하기
-          </Link>
-        </div>
-      )}
-    </GnbNavLayout>
+      <GnbNavLayout backgroundColor="#FAFAFA">
+        {/* 프로필 섹션 */}
+        <section {...stylex.props(Styles.userGreetingSection)}>
+          {isWorkspace ? <WorkspaceUserGreeting /> : <NonWorkspaceUserGreeting />}
+        </section>
+        {/* 회의 현황 섹션 */}
+        <section {...stylex.props(Styles.meetingStatusSection)}>
+          <h2 {...stylex.props(Styles.sectionTitle)}>회의 현황</h2>
+          <MeetingStatus />
+        </section>
+        {/* 타임 라인 섹션 */}
+        <section {...stylex.props(Styles.timeLineSection)}>
+          <TimeLine />
+        </section>
+
+        {/* 워크스페이스가 없는 경우 */}
+        {!isWorkspace && (
+          <div {...stylex.props(Styles.CreateWorkspaceBtnWrapper)}>
+            {/* 워크스페이스 등록하기 버튼 */}
+            <Link
+              href="/mypage/create-workspace"
+              {...stylex.props(Typography.SubtitleSmallBold, Styles.CreateWorkspaceBtn)}
+            >
+              <PlusOutlined width={24} height={24} />
+              워크스페이스 등록하기
+            </Link>
+          </div>
+        )}
+      </GnbNavLayout>
+    </>
   );
 };
 

--- a/src/pages/mypage/alarm.tsx
+++ b/src/pages/mypage/alarm.tsx
@@ -4,6 +4,7 @@ import Toggle from '@src/components/ui/Toggle';
 import useGetWorkspaceMypageSettingsAlarmsQuery from '@src/features/alarm/queries/useGetWorkspaceMypageSettingsAlarmsQuery';
 import MyPageAlarmToggle from '@src/features/mypage/compontents/MyPageAlarmToggle';
 import MainLayout from '@src/layouts/MainLayout';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const MyPageAlarmSetting = () => {
   const { data } = useGetWorkspaceMypageSettingsAlarmsQuery();
@@ -17,15 +18,23 @@ const MyPageAlarmSetting = () => {
   ];
 
   return (
-    <MainLayout>
-      <Header title="알림 수신 설정" />
+    <>
+      <SEOHead
+        title="알림 설정 | 룸렛"
+        description="룸렛의 알림 설정 페이지입니다."
+        url={{ pathname: '/mypage/alarm' }}
+      />
 
-      <section>
-        {toggleList.map((item) => (
-          <MyPageAlarmToggle key={item.id} label={item.label} caption={item.caption} value={item.value} />
-        ))}
-      </section>
-    </MainLayout>
+      <MainLayout>
+        <Header title="알림 수신 설정" />
+
+        <section>
+          {toggleList.map((item) => (
+            <MyPageAlarmToggle key={item.id} label={item.label} caption={item.caption} value={item.value} />
+          ))}
+        </section>
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/mypage/create-workspace.tsx
+++ b/src/pages/mypage/create-workspace.tsx
@@ -8,6 +8,7 @@ import Input from '@src/components/ui/Input';
 import useInput from '@src/hooks/useInput';
 import Button from '@src/components/ui/Button';
 import usePostWorkspaceQuery from '@src/features/workspace/queries/usePostWorkspaceQuery copy';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const CreateWorkspace = () => {
   const [workspaceName, handleChangeWorkspaceName] = useInput('');
@@ -26,48 +27,56 @@ const CreateWorkspace = () => {
   };
 
   return (
-    <MainLayout isScroll>
-      <div {...stylex.props(Styles.Container)}>
-        <div {...stylex.props(Styles.logoAndInfoWrapper)}>
-          <div {...stylex.props(Styles.logoAndInfoContainer)}>
-            {/* 룸렛 텍스트 로고 */}
-            <div className="logo-wrapper" {...stylex.props(Styles.logoWrapper)}>
-              <RoomletTextLogo width={164} height={24} />
-            </div>
+    <>
+      <SEOHead
+        title="워크스페이스 생성 | 룸렛"
+        description="룸렛의 워크스페이스 생성 페이지입니다."
+        url={{ pathname: '/mypage/create-workspace' }}
+      />
 
-            {/* 초대 내용 */}
-            <div {...stylex.props(Typography.M3BodyLarge)}>
-              <img src={letterImgUrl} alt="메세지 이미지" {...stylex.props(Styles.letterImg)} />
-              <div {...stylex.props(Styles.contentWrapper, Typography.M3BodyLarge)}>
-                룸렛에서 워크스페이스를 만들어 <br />
-                함께 회의를 준비해보세요.
+      <MainLayout isScroll>
+        <div {...stylex.props(Styles.Container)}>
+          <div {...stylex.props(Styles.logoAndInfoWrapper)}>
+            <div {...stylex.props(Styles.logoAndInfoContainer)}>
+              {/* 룸렛 텍스트 로고 */}
+              <div className="logo-wrapper" {...stylex.props(Styles.logoWrapper)}>
+                <RoomletTextLogo width={164} height={24} />
+              </div>
+
+              {/* 초대 내용 */}
+              <div {...stylex.props(Typography.M3BodyLarge)}>
+                <img src={letterImgUrl} alt="메세지 이미지" {...stylex.props(Styles.letterImg)} />
+                <div {...stylex.props(Styles.contentWrapper, Typography.M3BodyLarge)}>
+                  룸렛에서 워크스페이스를 만들어 <br />
+                  함께 회의를 준비해보세요.
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <div className="" {...stylex.props(Styles.formContainer)}>
-          {/* 닉네임 */}
-          <Input
-            onChange={handleChangeWorkspaceName}
-            value={workspaceName}
-            placeholder="사용하실 워크스페이스 명을 입력 해 주세요."
-          />
+          <div className="" {...stylex.props(Styles.formContainer)}>
+            {/* 닉네임 */}
+            <Input
+              onChange={handleChangeWorkspaceName}
+              value={workspaceName}
+              placeholder="사용하실 워크스페이스 명을 입력 해 주세요."
+            />
 
-          {/* 생성하기 및 생성하지 않기 버튼 */}
-          <Button type="button" onClick={handleClickCreate}>
-            생성하기
-          </Button>
-          <button
-            type="button"
-            onClick={handleClickDenyCreate}
-            {...stylex.props(Styles.dontParticipateButton, Typography.M3BodyLarge)}
-          >
-            생성하지 않기
-          </button>
+            {/* 생성하기 및 생성하지 않기 버튼 */}
+            <Button type="button" onClick={handleClickCreate}>
+              생성하기
+            </Button>
+            <button
+              type="button"
+              onClick={handleClickDenyCreate}
+              {...stylex.props(Styles.dontParticipateButton, Typography.M3BodyLarge)}
+            >
+              생성하지 않기
+            </button>
+          </div>
         </div>
-      </div>
-    </MainLayout>
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -28,6 +28,7 @@ import { hideModal } from '@src/slices/modal';
 import useRenderModal from '@src/hooks/ui/useRenderModal';
 import LockOutlined from '@src/components/icons/LockOutlined';
 import { TERMS } from '@src/constant/terms';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const MyPageInviteModal = dynamic(() => import('@src/features/mypage/compontents/MyPageInviteModal'), {
   ssr: false,
@@ -137,6 +138,8 @@ const MyPageHome = () => {
 
   return (
     <>
+      <SEOHead title="마이페이지 | 룸렛" description="룸렛의 마이페이지입니다." url={{ pathname: '/mypage' }} />
+
       <GnbNavLayout backgroundColor={colors.white500}>
         <Header title="마이페이지" />
         {/* 프로필 페이지로 이동 */}

--- a/src/pages/mypage/profile.tsx
+++ b/src/pages/mypage/profile.tsx
@@ -16,6 +16,7 @@ import { RootState } from '@src/store';
 import useGetMyPageProfileQuery from '@src/features/mypage/profile/queries/useGetMyPageProfileQuery';
 import usePatchMypageProfileQuery from '@src/features/mypage/profile/queries/usePatchMypageProfileQuery';
 import MainLayout from '@src/layouts/MainLayout';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const MyPageProfile = () => {
   const { isWorkspace } = useSelector((state: RootState) => state.workspace);
@@ -72,24 +73,32 @@ const MyPageProfile = () => {
   };
 
   return (
-    <MainLayout backgroundColor={colors.white500}>
-      <Header title="프로필 수정" rightBtnInfo={isWorkspace ? myInfoCompleteBtnProps : profileCompleteBtnProps} />
+    <>
+      <SEOHead
+        title="프로필 수정 | 룸렛"
+        description="룸렛의 프로필 수정 페이지입니다."
+        url={{ pathname: '/mypage/profile' }}
+      />
 
-      {/* 이미지 업로드 및 이름 입력 */}
-      <div {...stylex.props(Styles.SettingContainer)}>
-        <MyPageImgUpload
-          onSelect={handleSelectImg}
-          initialImgUrl={isWorkspace ? `${data?.myInfo?.profileImgKey}` : `${profileData?.profile.profileImgKey}`}
-        />
-        <MyPageInput label="닉네임" value={displayName} onChange={handleChangeDisplayName} />
-      </div>
+      <MainLayout backgroundColor={colors.white500}>
+        <Header title="프로필 수정" rightBtnInfo={isWorkspace ? myInfoCompleteBtnProps : profileCompleteBtnProps} />
 
-      {/* 경계선 */}
-      <BoundaryArea />
+        {/* 이미지 업로드 및 이름 입력 */}
+        <div {...stylex.props(Styles.SettingContainer)}>
+          <MyPageImgUpload
+            onSelect={handleSelectImg}
+            initialImgUrl={isWorkspace ? `${data?.myInfo?.profileImgKey}` : `${profileData?.profile.profileImgKey}`}
+          />
+          <MyPageInput label="닉네임" value={displayName} onChange={handleChangeDisplayName} />
+        </div>
 
-      {/* 개인 정보 리스트 */}
-      <ProfilePersonalDataList dataList={dataList} title="기타 설정" />
-    </MainLayout>
+        {/* 경계선 */}
+        <BoundaryArea />
+
+        {/* 개인 정보 리스트 */}
+        <ProfilePersonalDataList dataList={dataList} title="기타 설정" />
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/mypage/workspace/category.tsx
+++ b/src/pages/mypage/workspace/category.tsx
@@ -13,6 +13,7 @@ import useRenderModal from '@src/hooks/ui/useRenderModal';
 import AddCategoryBottomSheet from '@src/features/mypage/workspace/category/components/AddCategoryBottomSheet';
 import usePutCongressCategory from '@src/features/mypage/workspace/category/queries/usePutCongressCategory';
 import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const Category = () => {
   const { data: myInfoData } = useGetMypageInfoQuery();
@@ -57,36 +58,44 @@ const Category = () => {
   }, [isEdit]);
 
   return (
-    <MainLayout>
-      <Header title={isEdit ? '수정하기' : '카테고리'} {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})} />
-      {/* 검색 */}
+    <>
+      <SEOHead
+        title="워크스페이스 카테고리 정보 | 룸렛"
+        description="룸렛의 워크스페이스 카테고리 정보 페이지입니다."
+        url={{ pathname: '/mypage/workspace/category' }}
+      />
 
-      <div {...{ ...stylex.props(Styles.Container) }}>
-        {/* 전체 카테고리 수 */}
-        <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
-          전체 카테고리 ({data?.congressCategoryCount})
+      <MainLayout>
+        <Header title={isEdit ? '수정하기' : '카테고리'} {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})} />
+        {/* 검색 */}
+
+        <div {...{ ...stylex.props(Styles.Container) }}>
+          {/* 전체 카테고리 수 */}
+          <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
+            전체 카테고리 ({data?.congressCategoryCount})
+          </div>
+
+          {/* 카테고리 목록 */}
+          <div {...stylex.props(Styles.CategoryListContainer)}>
+            {isEdit
+              ? editCongressCategoryList?.map((item, idx) => <CategoryItem data={item} isEdit />)
+              : data?.congressCategoryList?.map((item, idx) => <CategoryItem data={item} />)}
+          </div>
+
+          {/* 카테고리 추가 */}
+          {isEdit && (
+            <button
+              type="button"
+              {...stylex.props(Styles.AddCategoryBtn, Typography.TextSmallMedium)}
+              onClick={handleClickAddCategory}
+            >
+              <PlusOutlined width={24} height={24} />
+              <span>카테고리 추가</span>
+            </button>
+          )}
         </div>
-
-        {/* 카테고리 목록 */}
-        <div {...stylex.props(Styles.CategoryListContainer)}>
-          {isEdit
-            ? editCongressCategoryList?.map((item, idx) => <CategoryItem data={item} isEdit />)
-            : data?.congressCategoryList?.map((item, idx) => <CategoryItem data={item} />)}
-        </div>
-
-        {/* 카테고리 추가 */}
-        {isEdit && (
-          <button
-            type="button"
-            {...stylex.props(Styles.AddCategoryBtn, Typography.TextSmallMedium)}
-            onClick={handleClickAddCategory}
-          >
-            <PlusOutlined width={24} height={24} />
-            <span>카테고리 추가</span>
-          </button>
-        )}
-      </div>
-    </MainLayout>
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/mypage/workspace/congress-room.tsx
+++ b/src/pages/mypage/workspace/congress-room.tsx
@@ -14,6 +14,7 @@ import useRenderModal from '@src/hooks/ui/useRenderModal';
 import AddCongressRoomBottomSheet from '@src/features/mypage/workspace/congress-room/components/AddCongressRoomBottomSheet';
 import usePutCongressRoomQuery from '@src/features/mypage/workspace/congress-room/queries/usePutCongressRoomQuery';
 import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfoQuery';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const MeetingRoom = () => {
   const { data: myInfoData } = useGetMypageInfoQuery();
@@ -56,38 +57,48 @@ const MeetingRoom = () => {
   }, [isEdit]);
 
   return (
-    <MainLayout backgroundColor="#FAFAFA">
-      <Header title="회의실" {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})} />
+    <>
+      <SEOHead
+        title="워크스페이스 회의실 정보 | 룸렛"
+        description="룸렛의 워크스페이스 회의실 정보 페이지입니다."
+        url={{ pathname: '/mypage/workspace/congress-room' }}
+      />
 
-      <div {...stylex.props(Styles.Container)}>
-        {/* 회의실 개수 */}
-        <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
-          전체 회의실{' '}
-          <span {...stylex.props(Styles.Count)}>{isEdit ? editCongressRoomList?.length : data?.congressRoomCount}</span>
+      <MainLayout backgroundColor="#FAFAFA">
+        <Header title="회의실" {...(isEditable ? { rightBtnInfo: completeBtnProps } : {})} />
+
+        <div {...stylex.props(Styles.Container)}>
+          {/* 회의실 개수 */}
+          <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
+            전체 회의실{' '}
+            <span {...stylex.props(Styles.Count)}>
+              {isEdit ? editCongressRoomList?.length : data?.congressRoomCount}
+            </span>
+          </div>
+
+          {/* 회의실 목록 */}
+          <div {...stylex.props(Styles.RoomListWrapper)}>
+            {isEdit
+              ? // 수정 상태 일 때
+                editCongressRoomList?.map((item) => <CongressRoomCard data={item} isEdit={isEdit} />)
+              : // 수정 상태가 아닐 때
+                data?.congressRoomList?.map((item) => <CongressRoomCard data={item} />)}
+          </div>
+
+          {/* 회의실 추가 */}
+          {isEdit && (
+            <button
+              type="button"
+              {...stylex.props(Styles.AddCongressRoomBtn, Typography.TextSmallMedium)}
+              onClick={handleClickAddCongressRoom}
+            >
+              <PlusOutlined width={24} height={24} />
+              <span>회의실 추가</span>
+            </button>
+          )}
         </div>
-
-        {/* 회의실 목록 */}
-        <div {...stylex.props(Styles.RoomListWrapper)}>
-          {isEdit
-            ? // 수정 상태 일 때
-              editCongressRoomList?.map((item) => <CongressRoomCard data={item} isEdit={isEdit} />)
-            : // 수정 상태가 아닐 때
-              data?.congressRoomList?.map((item) => <CongressRoomCard data={item} />)}
-        </div>
-
-        {/* 회의실 추가 */}
-        {isEdit && (
-          <button
-            type="button"
-            {...stylex.props(Styles.AddCongressRoomBtn, Typography.TextSmallMedium)}
-            onClick={handleClickAddCongressRoom}
-          >
-            <PlusOutlined width={24} height={24} />
-            <span>회의실 추가</span>
-          </button>
-        )}
-      </div>
-    </MainLayout>
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/mypage/workspace/index.tsx
+++ b/src/pages/mypage/workspace/index.tsx
@@ -16,6 +16,7 @@ import ProfileImg from '@src/components/ui/ProfileImg';
 import { Typography } from '../../../../public/styles/vars.stylex';
 import usePatchWorkspaceInfoQuery from '@src/features/workspace/queries/usePatchWorkspaceInfoQuery';
 import Toast from '@src/components/ui/Toast';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const WorkspaceHome = () => {
   const { data: myInfoData } = useGetMypageInfoQuery();
@@ -47,54 +48,62 @@ const WorkspaceHome = () => {
   };
 
   return (
-    <MainLayout>
-      <Header
-        title="워크스페이스 정보"
-        {...(isEditable
-          ? {
-              rightBtnInfo: {
-                name: '완료',
-                // 이미지 파일이 있거나 워크스페이스 이름이 변경되었을 때 버튼 활성화
-                ...(!!workspaceImgFile || data?.workspace?.workspaceName !== workspaceName
-                  ? {
-                      isActive: true,
-                      onClick: () => {
-                        const formData = new FormData();
-
-                        formData.append('workspaceName', workspaceName);
-
-                        if (workspaceImgFile) {
-                          formData.append('image', workspaceImgFile);
-                        }
-
-                        mutation.mutateWithToast(formData);
-                      },
-                    }
-                  : { isActive: false, onClick: null }),
-              },
-            }
-          : {})}
+    <>
+      <SEOHead
+        title="워크스페이스 정보 | 룸렛"
+        description="룸렛의 워크스페이스 정보 페이지입니다."
+        url={{ pathname: '/mypage/workspace' }}
       />
 
-      {/* 이미지 업로드 및 이름 입력 */}
-      {isEditable ? (
-        <div {...stylex.props(Styles.ProfileContainer)}>
-          <MyPageImgUpload onSelect={handleSelectWorkspaceImg} initialImgUrl={workspaceImgUrl} />
-          <MyPageInput label="워크스페이스 이름" value={workspaceName} onChange={handleChangeWorkspaceName} />
-        </div>
-      ) : (
-        <div {...stylex.props(Styles.ProfileContainer)}>
-          <ProfileImg imgKey={workspaceImgUrl} size={68} />
-          <p {...stylex.props(Typography.TitleRegularBold)}>{data.workspace.workspaceName}</p>
-        </div>
-      )}
+      <MainLayout>
+        <Header
+          title="워크스페이스 정보"
+          {...(isEditable
+            ? {
+                rightBtnInfo: {
+                  name: '완료',
+                  // 이미지 파일이 있거나 워크스페이스 이름이 변경되었을 때 버튼 활성화
+                  ...(!!workspaceImgFile || data?.workspace?.workspaceName !== workspaceName
+                    ? {
+                        isActive: true,
+                        onClick: () => {
+                          const formData = new FormData();
 
-      {/* 경계선 */}
-      <BoundaryArea />
+                          formData.append('workspaceName', workspaceName);
 
-      {/* 메뉴 리스트 */}
-      <MypageMenu menuList={menuList} title="기타 설정" />
-    </MainLayout>
+                          if (workspaceImgFile) {
+                            formData.append('image', workspaceImgFile);
+                          }
+
+                          mutation.mutateWithToast(formData);
+                        },
+                      }
+                    : { isActive: false, onClick: null }),
+                },
+              }
+            : {})}
+        />
+
+        {/* 이미지 업로드 및 이름 입력 */}
+        {isEditable ? (
+          <div {...stylex.props(Styles.ProfileContainer)}>
+            <MyPageImgUpload onSelect={handleSelectWorkspaceImg} initialImgUrl={workspaceImgUrl} />
+            <MyPageInput label="워크스페이스 이름" value={workspaceName} onChange={handleChangeWorkspaceName} />
+          </div>
+        ) : (
+          <div {...stylex.props(Styles.ProfileContainer)}>
+            <ProfileImg imgKey={workspaceImgUrl} size={68} />
+            <p {...stylex.props(Typography.TitleRegularBold)}>{data.workspace.workspaceName}</p>
+          </div>
+        )}
+
+        {/* 경계선 */}
+        <BoundaryArea />
+
+        {/* 메뉴 리스트 */}
+        <MypageMenu menuList={menuList} title="기타 설정" />
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/mypage/workspace/member.tsx
+++ b/src/pages/mypage/workspace/member.tsx
@@ -12,6 +12,7 @@ import useGetMypageInfoQuery from '@src/features/mypage/queries/useGetMypageInfo
 import useInput from '@src/hooks/useInput';
 import SearchOutlinedV2 from '@src/components/icons/SearchOutlinedV2';
 import useDebounce from '@src/hooks/useDebounce';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const Member = () => {
   const { data: myInfoData } = useGetMypageInfoQuery();
@@ -31,46 +32,54 @@ const Member = () => {
   };
 
   return (
-    <MainLayout>
-      <Header title="멤버" />
-      <div {...{ ...stylex.props(Styles.Container) }}>
-        {/* 검색 */}
-        <div {...stylex.props(Styles.SearchContainer)}>
-          <SearchOutlinedV2 width={24} height={24} />
-          <input
-            type="text"
-            placeholder="검색어를 입력해주세요"
-            value={searchKeyword}
-            onChange={handleChangeSearchKeyword}
-            {...stylex.props(Typography.SubTextLargeRegular, Styles.SearchInput)}
-          />
-        </div>
+    <>
+      <SEOHead
+        title="워크스페이스 멤버 정보 | 룸렛"
+        description="룸렛의 워크스페이스 멤버 정보 페이지입니다."
+        url={{ pathname: '/mypage/workspace/member' }}
+      />
 
-        {/* 전체 멤버수 */}
-        <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
-          전체 멤버 ({totalMemberCount})
-        </div>
-
-        {/* 팀 목록 */}
-        <div {...stylex.props(Styles.TeamListContainer)}>
-          {data?.teamList?.map((item, idx) => <TeamToggle key={item.TeamId} data={item} teamIdx={idx} />)}
-        </div>
-
-        {/* 팀 추가 */}
-        {isEditable && (
-          <div {...stylex.props(Styles.AddTeamBtnContainer)}>
-            <button
-              type="button"
-              {...stylex.props(Styles.AddTeamBtn, Typography.TextSmallMedium)}
-              onClick={handleClickAddTeam}
-            >
-              <PlusOutlined width={24} height={24} />
-              <span>팀 추가</span>
-            </button>
+      <MainLayout>
+        <Header title="멤버" />
+        <div {...{ ...stylex.props(Styles.Container) }}>
+          {/* 검색 */}
+          <div {...stylex.props(Styles.SearchContainer)}>
+            <SearchOutlinedV2 width={24} height={24} />
+            <input
+              type="text"
+              placeholder="검색어를 입력해주세요"
+              value={searchKeyword}
+              onChange={handleChangeSearchKeyword}
+              {...stylex.props(Typography.SubTextLargeRegular, Styles.SearchInput)}
+            />
           </div>
-        )}
-      </div>
-    </MainLayout>
+
+          {/* 전체 멤버수 */}
+          <div {...stylex.props(Styles.TotalCountWrapper, Typography.TextSmallMedium)}>
+            전체 멤버 ({totalMemberCount})
+          </div>
+
+          {/* 팀 목록 */}
+          <div {...stylex.props(Styles.TeamListContainer)}>
+            {data?.teamList?.map((item, idx) => <TeamToggle key={item.TeamId} data={item} teamIdx={idx} />)}
+          </div>
+
+          {/* 팀 추가 */}
+          {isEditable && (
+            <div {...stylex.props(Styles.AddTeamBtnContainer)}>
+              <button
+                type="button"
+                {...stylex.props(Styles.AddTeamBtn, Typography.TextSmallMedium)}
+                onClick={handleClickAddTeam}
+              >
+                <PlusOutlined width={24} height={24} />
+                <span>팀 추가</span>
+              </button>
+            </div>
+          )}
+        </div>
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -11,6 +11,7 @@ import useGetWorkspaceMemberQuery from '@src/features/profile/queries/useGetWork
 import MainLayout from '@src/layouts/MainLayout';
 import { Typography } from '../../../public/styles/vars.stylex';
 import { MEMBER_ROLE_KOREAN_LABELS } from '@src/constants/member';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const UserProfile = () => {
   const router = useRouter();
@@ -23,31 +24,39 @@ const UserProfile = () => {
   ];
 
   return (
-    <MainLayout>
-      <Header />
-
-      {/* 프로필 이미지 */}
-      <div {...stylex.props(Styles.ProfileContainer)}>
-        <ProfileImg size={68} imgKey={data?.member?.profileImgKey} role={data?.member?.role} />
-
-        <div {...stylex.props(Styles.nameContainer)}>
-          <p {...stylex.props(Typography.TitleRegularBold)}>{data?.member?.displayName}</p>
-          <p {...stylex.props(Typography.SubTextLargeRegular)}>{MEMBER_ROLE_KOREAN_LABELS[data?.member?.role]}</p>
-        </div>
-      </div>
-
-      {/* 경계선 */}
-      <BoundaryArea />
-
-      {/* 개인 정보 */}
-      <ProfilePersonalDataList
-        isPublicProfile
-        title="개인 정보"
-        dataList={dataList}
-        memberId={data?.member?.MemberId}
-        isMyProfile={data?.member.ourself}
+    <>
+      <SEOHead
+        title={`${data?.member?.displayName}의 프로필 | 룸렛`}
+        description={`${data?.member?.displayName}의 프로필 페이지입니다.`}
+        url={{ pathname: `/profile/${id}` }}
       />
-    </MainLayout>
+
+      <MainLayout>
+        <Header />
+
+        {/* 프로필 이미지 */}
+        <div {...stylex.props(Styles.ProfileContainer)}>
+          <ProfileImg size={68} imgKey={data?.member?.profileImgKey} role={data?.member?.role} />
+
+          <div {...stylex.props(Styles.nameContainer)}>
+            <p {...stylex.props(Typography.TitleRegularBold)}>{data?.member?.displayName}</p>
+            <p {...stylex.props(Typography.SubTextLargeRegular)}>{MEMBER_ROLE_KOREAN_LABELS[data?.member?.role]}</p>
+          </div>
+        </div>
+
+        {/* 경계선 */}
+        <BoundaryArea />
+
+        {/* 개인 정보 */}
+        <ProfilePersonalDataList
+          isPublicProfile
+          title="개인 정보"
+          dataList={dataList}
+          memberId={data?.member?.MemberId}
+          isMyProfile={data?.member.ourself}
+        />
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/reservations/[id].tsx
+++ b/src/pages/reservations/[id].tsx
@@ -7,6 +7,8 @@ import MainLayout from '@src/layouts/MainLayout';
 // import ReservationInfo from '@src/features/reservation/components/ReservationInfo';
 import Header from '@src/components/ui/Header';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
+import useGetWorkspaceCongressQuery from '@src/features/reservation/queries/useGetWorkspaceCongressQuery';
 
 const CommentList = dynamic(() => import('@src/features/comment/components/CommentList'), {
   ssr: false,
@@ -19,11 +21,15 @@ const ReservationInfo = dynamic(() => import('@src/features/reservation/componen
 });
 
 const MeetingDetails = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const { data } = useGetWorkspaceCongressQuery({ cgsid: Number(id) });
+
   return (
     <MainLayout isScroll>
       <Header />
 
-      <ReservationInfo />
+      <ReservationInfo data={data} />
 
       {/* 경계선 */}
       <div {...stylex.props(Styles.borderLine)} />

--- a/src/pages/reservations/[id].tsx
+++ b/src/pages/reservations/[id].tsx
@@ -9,6 +9,7 @@ import Header from '@src/components/ui/Header';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import useGetWorkspaceCongressQuery from '@src/features/reservation/queries/useGetWorkspaceCongressQuery';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const CommentList = dynamic(() => import('@src/features/comment/components/CommentList'), {
   ssr: false,
@@ -26,23 +27,31 @@ const MeetingDetails = () => {
   const { data } = useGetWorkspaceCongressQuery({ cgsid: Number(id) });
 
   return (
-    <MainLayout isScroll>
-      <Header />
+    <>
+      <SEOHead
+        title={`${data?.congress.congressTitle} | 룸렛`}
+        description={`${data?.congress.congressTitle}의 회의 상세 페이지입니다.`}
+        url={{ pathname: `/reservations/${id}` }}
+      />
 
-      <ReservationInfo data={data} />
+      <MainLayout isScroll>
+        <Header />
 
-      {/* 경계선 */}
-      <div {...stylex.props(Styles.borderLine)} />
+        <ReservationInfo data={data} />
 
-      {/* 댓글 */}
-      <div>
-        {/* 댓글 리스트 */}
-        <CommentList />
-      </div>
+        {/* 경계선 */}
+        <div {...stylex.props(Styles.borderLine)} />
 
-      {/* 댓글 작성 */}
-      <CommentTextarea />
-    </MainLayout>
+        {/* 댓글 */}
+        <div>
+          {/* 댓글 리스트 */}
+          <CommentList />
+        </div>
+
+        {/* 댓글 작성 */}
+        <CommentTextarea />
+      </MainLayout>
+    </>
   );
 };
 

--- a/src/pages/reservations/index.tsx
+++ b/src/pages/reservations/index.tsx
@@ -8,6 +8,7 @@ import ArrowHeadOutlinedV2 from '@src/components/icons/ArrowHeadOutlinedV2';
 import dayjs from 'dayjs';
 import useGetWorkspaceCongressListQuery from '@src/queries/workspace/useGetWorkspaceCongressListQuery';
 import { useRouter } from 'next/router';
+import SEOHead from '@src/components/ui/SEOHead';
 
 const Reservations = () => {
   const router = useRouter();
@@ -35,6 +36,12 @@ const Reservations = () => {
 
   return (
     <>
+      <SEOHead
+        title="예약리스트 | 룸렛"
+        description="룸렛의 예약리스트 페이지입니다."
+        url={{ pathname: '/reservations' }}
+      />
+
       <GnbNavLayout backgroundColor="#FAFAFA">
         {/*  날짜 선택 버튼 */}
         <h1 {...stylex.props(Styles.dateTitle)} onClick={handleClickDateWheel}>


### PR DESCRIPTION
# 작업 내용
- 모든 페이지에 SEOHead 컴포넌트 추가
   - 검색 엔진에 노출되는 페이지들은 이미 SEOHead 컴포넌트가 추가되어있었지만, 로그인한 사용자가 보는 모든 페이지에는 추가하지 않았었음.
   - 추가하지 않아도 상관은 없으나, 사용자 경험 개선과 추후에 추가한 GA를 고려해서 추가해줌.
      - 기존에 모든 페이지에 title을 표현하지 않아서 브라우저 탭에 아래와 같이 주소가 보여지는 문제가 있었음. 그래서 title을 추가하여 문제를 해결함.
         - 적용 전
            <img width="247" height="50" alt="image" src="https://github.com/user-attachments/assets/daa3f687-51d1-4373-a554-b3673cb77b24" />
         - 적용 후
            <img width="248" height="45" alt="image" src="https://github.com/user-attachments/assets/6d3e8a05-fad2-4e75-adfd-f5877ca0f5b1" />

